### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/about

### DIFF
--- a/modules/about/credits.php
+++ b/modules/about/credits.php
@@ -68,4 +68,3 @@ HTML: <!--HTML-LINES-START-->12156<!--HTML-LINES-STOP--> html-code lines and <!-
 
 $dsp->AddBackButton("index.php?mod=about", "about/credits");
 $dsp->AddContent();
-?>

--- a/modules/about/design_info.php
+++ b/modules/about/design_info.php
@@ -2,20 +2,18 @@
 include_once("inc/classes/class_xml.php");
 $xml = new xml;
 
-$xml_file = @fopen("design/" . $auth["design"] . "/design.xml","r");
-$xml_content = @fread($xml_file,filesize("design/".$auth["design"]."/design.xml"));
+$xml_file = @fopen("design/" . $auth["design"] . "/design.xml", "r");
+$xml_content = @fread($xml_file, filesize("design/".$auth["design"]."/design.xml"));
 
 $design_name = $xml->get_tag_content("name", $xml_content);
 
 $dsp->NewContent("Designinfo zu '<b>$design_name</b>'", "Auf dieser Seite erhälst du Informationen &uuml;ber das derzeitige Lansuite-Erscheinungsbild");
 $dsp->AddDoubleRow("Name", $design_name);
-$dsp->AddDoubleRow("Version", $xml->get_tag_content("version",$xml_content));
-$dsp->AddDoubleRow("Beschreibung", $xml->get_tag_content("description",$xml_content));
-$dsp->AddDoubleRow("Autor", $xml->get_tag_content("author",$xml_content));
-$dsp->AddDoubleRow("Kontakt", $xml->get_tag_content("contact",$xml_content));
-$dsp->AddDoubleRow("Website", $xml->get_tag_content("website",$xml_content));
-$dsp->AddDoubleRow("Kommentar", $xml->get_tag_content("comments",$xml_content));
+$dsp->AddDoubleRow("Version", $xml->get_tag_content("version", $xml_content));
+$dsp->AddDoubleRow("Beschreibung", $xml->get_tag_content("description", $xml_content));
+$dsp->AddDoubleRow("Autor", $xml->get_tag_content("author", $xml_content));
+$dsp->AddDoubleRow("Kontakt", $xml->get_tag_content("contact", $xml_content));
+$dsp->AddDoubleRow("Website", $xml->get_tag_content("website", $xml_content));
+$dsp->AddDoubleRow("Kommentar", $xml->get_tag_content("comments", $xml_content));
 $dsp->AddBackButton("index.php?mod=about", "about/design");
 $dsp->AddContent();
-
-?>

--- a/modules/about/generate_file_stats.php
+++ b/modules/about/generate_file_stats.php
@@ -1,59 +1,58 @@
 <?php
 
-	$dir = ".";
+    $dir = ".";
 
-	function lets_open_the_dir( $dir ) {
-		global $files;
-		
-		// Open the design-dir
-		$thedir = opendir( $dir );
-		
-		// Reading all subdirs from design and fill them into an array
-		while( false !== ( $content = readdir($thedir) ) ) {
-			if( $content != "." AND $content != ".." ) {
-				if( is_dir( $dir."/".$content ) ) {
-					lets_open_the_dir( $dir."/".$content );
-				}
-				if( file_exists($dir."/".$content) ) {
-					$files[] = $dir."/".$content;
-				}
-			}
-		}
-	}
-	function get_the_lines_and_chars( $file ) {
-		$file_content = file( $file );
-		$data[0] = count($file_content);
-		for( $i=0; $i < count($file_content); $i++ ) {
-			$data[1] += strlen( $file_content[$i] );
-		}
-		return $data;
-	}
-	
-	lets_open_the_dir( $dir );
-	
-	foreach ( $files as $file ) {
-		if( eregi( ".php", $file ) ) {
-			$data = get_the_lines_and_chars( $file );
-			$php_lines += $data[0];
-			$php_chars += $data[1];
-		}
-		if( eregi( ".htm", $file ) ) {
-			$data = get_the_lines_and_chars( $file );
-			$html_lines += $data[0];
-			$html_chars += $data[1];
-		}
-	}
-	
-	$filecontents = file( "modules/about/credits.php" );
-	$fo = fopen( "modules/about/credits.php", "w" );
-	foreach ( $filecontents as $filecontent ) {
-		$filecontent = eregi_replace( "<!--PHP-LINES-START-->(.*)<!--PHP-LINES-STOP-->", "<!--PHP-LINES-START-->$php_lines<!--PHP-LINES-STOP-->", $filecontent );
-		$filecontent = eregi_replace( "<!--PHP-CHARS-START-->(.*)<!--PHP-CHARS-STOP-->", "<!--PHP-CHARS-START-->$php_chars<!--PHP-CHARS-STOP-->", $filecontent );
-		$filecontent = eregi_replace( "<!--HTML-LINES-START-->(.*)<!--HTML-LINES-STOP-->", "<!--HTML-LINES-START-->$html_lines<!--HTML-LINES-STOP-->", $filecontent );
-		$filecontent = eregi_replace( "<!--HTML-CHARS-START-->(.*)<!--HTML-CHARS-STOP-->", "<!--HTML-CHARS-START-->$html_chars<!--HTML-CHARS-STOP-->", $filecontent );
-		fwrite( $fo, $filecontent );
-	}
-	fclose( $fo );
-	
-
-?>
+    function lets_open_the_dir($dir)
+    {
+        global $files;
+        
+        // Open the design-dir
+        $thedir = opendir($dir);
+        
+        // Reading all subdirs from design and fill them into an array
+        while (false !== ($content = readdir($thedir))) {
+            if ($content != "." and $content != "..") {
+                if (is_dir($dir."/".$content)) {
+                    lets_open_the_dir($dir."/".$content);
+                }
+                if (file_exists($dir."/".$content)) {
+                    $files[] = $dir."/".$content;
+                }
+            }
+        }
+    }
+    function get_the_lines_and_chars($file)
+    {
+        $file_content = file($file);
+        $data[0] = count($file_content);
+        for ($i=0; $i < count($file_content); $i++) {
+            $data[1] += strlen($file_content[$i]);
+        }
+        return $data;
+    }
+    
+    lets_open_the_dir($dir);
+    
+    foreach ($files as $file) {
+        if (eregi(".php", $file)) {
+            $data = get_the_lines_and_chars($file);
+            $php_lines += $data[0];
+            $php_chars += $data[1];
+        }
+        if (eregi(".htm", $file)) {
+            $data = get_the_lines_and_chars($file);
+            $html_lines += $data[0];
+            $html_chars += $data[1];
+        }
+    }
+    
+    $filecontents = file("modules/about/credits.php");
+    $fo = fopen("modules/about/credits.php", "w");
+    foreach ($filecontents as $filecontent) {
+        $filecontent = eregi_replace("<!--PHP-LINES-START-->(.*)<!--PHP-LINES-STOP-->", "<!--PHP-LINES-START-->$php_lines<!--PHP-LINES-STOP-->", $filecontent);
+        $filecontent = eregi_replace("<!--PHP-CHARS-START-->(.*)<!--PHP-CHARS-STOP-->", "<!--PHP-CHARS-START-->$php_chars<!--PHP-CHARS-STOP-->", $filecontent);
+        $filecontent = eregi_replace("<!--HTML-LINES-START-->(.*)<!--HTML-LINES-STOP-->", "<!--HTML-LINES-START-->$html_lines<!--HTML-LINES-STOP-->", $filecontent);
+        $filecontent = eregi_replace("<!--HTML-CHARS-START-->(.*)<!--HTML-CHARS-STOP-->", "<!--HTML-CHARS-START-->$html_chars<!--HTML-CHARS-STOP-->", $filecontent);
+        fwrite($fo, $filecontent);
+    }
+    fclose($fo);

--- a/modules/about/generate_file_stats.php
+++ b/modules/about/generate_file_stats.php
@@ -2,57 +2,57 @@
 
     $dir = ".";
 
-    function lets_open_the_dir($dir)
-    {
-        global $files;
+function lets_open_the_dir($dir)
+{
+    global $files;
         
-        // Open the design-dir
-        $thedir = opendir($dir);
+    // Open the design-dir
+    $thedir = opendir($dir);
         
-        // Reading all subdirs from design and fill them into an array
-        while (false !== ($content = readdir($thedir))) {
-            if ($content != "." and $content != "..") {
-                if (is_dir($dir."/".$content)) {
-                    lets_open_the_dir($dir."/".$content);
-                }
-                if (file_exists($dir."/".$content)) {
-                    $files[] = $dir."/".$content;
-                }
+    // Reading all subdirs from design and fill them into an array
+    while (false !== ($content = readdir($thedir))) {
+        if ($content != "." and $content != "..") {
+            if (is_dir($dir."/".$content)) {
+                lets_open_the_dir($dir."/".$content);
+            }
+            if (file_exists($dir."/".$content)) {
+                $files[] = $dir."/".$content;
             }
         }
     }
-    function get_the_lines_and_chars($file)
-    {
-        $file_content = file($file);
-        $data[0] = count($file_content);
-        for ($i=0; $i < count($file_content); $i++) {
-            $data[1] += strlen($file_content[$i]);
-        }
-        return $data;
+}
+function get_the_lines_and_chars($file)
+{
+    $file_content = file($file);
+    $data[0] = count($file_content);
+    for ($i=0; $i < count($file_content); $i++) {
+        $data[1] += strlen($file_content[$i]);
     }
+    return $data;
+}
     
     lets_open_the_dir($dir);
     
-    foreach ($files as $file) {
-        if (eregi(".php", $file)) {
-            $data = get_the_lines_and_chars($file);
-            $php_lines += $data[0];
-            $php_chars += $data[1];
-        }
-        if (eregi(".htm", $file)) {
-            $data = get_the_lines_and_chars($file);
-            $html_lines += $data[0];
-            $html_chars += $data[1];
-        }
+foreach ($files as $file) {
+    if (eregi(".php", $file)) {
+        $data = get_the_lines_and_chars($file);
+        $php_lines += $data[0];
+        $php_chars += $data[1];
     }
+    if (eregi(".htm", $file)) {
+        $data = get_the_lines_and_chars($file);
+        $html_lines += $data[0];
+        $html_chars += $data[1];
+    }
+}
     
     $filecontents = file("modules/about/credits.php");
     $fo = fopen("modules/about/credits.php", "w");
-    foreach ($filecontents as $filecontent) {
-        $filecontent = eregi_replace("<!--PHP-LINES-START-->(.*)<!--PHP-LINES-STOP-->", "<!--PHP-LINES-START-->$php_lines<!--PHP-LINES-STOP-->", $filecontent);
-        $filecontent = eregi_replace("<!--PHP-CHARS-START-->(.*)<!--PHP-CHARS-STOP-->", "<!--PHP-CHARS-START-->$php_chars<!--PHP-CHARS-STOP-->", $filecontent);
-        $filecontent = eregi_replace("<!--HTML-LINES-START-->(.*)<!--HTML-LINES-STOP-->", "<!--HTML-LINES-START-->$html_lines<!--HTML-LINES-STOP-->", $filecontent);
-        $filecontent = eregi_replace("<!--HTML-CHARS-START-->(.*)<!--HTML-CHARS-STOP-->", "<!--HTML-CHARS-START-->$html_chars<!--HTML-CHARS-STOP-->", $filecontent);
-        fwrite($fo, $filecontent);
-    }
+foreach ($filecontents as $filecontent) {
+    $filecontent = eregi_replace("<!--PHP-LINES-START-->(.*)<!--PHP-LINES-STOP-->", "<!--PHP-LINES-START-->$php_lines<!--PHP-LINES-STOP-->", $filecontent);
+    $filecontent = eregi_replace("<!--PHP-CHARS-START-->(.*)<!--PHP-CHARS-STOP-->", "<!--PHP-CHARS-START-->$php_chars<!--PHP-CHARS-STOP-->", $filecontent);
+    $filecontent = eregi_replace("<!--HTML-LINES-START-->(.*)<!--HTML-LINES-STOP-->", "<!--HTML-LINES-START-->$html_lines<!--HTML-LINES-STOP-->", $filecontent);
+    $filecontent = eregi_replace("<!--HTML-CHARS-START-->(.*)<!--HTML-CHARS-STOP-->", "<!--HTML-CHARS-START-->$html_chars<!--HTML-CHARS-STOP-->", $filecontent);
+    fwrite($fo, $filecontent);
+}
     fclose($fo);

--- a/modules/about/license.php
+++ b/modules/about/license.php
@@ -3,4 +3,3 @@ $dsp->NewContent($config['lansuite']['version'], 'A web based lanparty administr
 $dsp->AddSmartyTpl('license', 'about');
 $dsp->AddBackButton("index.php?mod=about", "about/license");
 $dsp->AddContent();
-?>

--- a/modules/about/overview.php
+++ b/modules/about/overview.php
@@ -6,4 +6,3 @@ $dsp->AddDoubleRow('', '<a href="index.php?mod=about&action=credits">credits</a>
 $dsp->AddDoubleRow('', '<a href="index.php?mod=about&action=design_info">design</a>');
 $dsp->AddDoubleRow('', '<a href="index.php?mod=about&action=license">license</a>');
 $dsp->AddFieldsetEnd();
-?>


### PR DESCRIPTION
This is the first try for #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.