### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/info2

### DIFF
--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -1,18 +1,22 @@
 <?php
 
-function Update($id) {
-  global $db, $cfg, $row, $func;
+function Update($id)
+{
+    global $db, $cfg, $row, $func;
 
-	if ($id != '') {
-		$menu_intem = $db->qry_first('SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %int%', $id);
+    if ($id != '') {
+        $menu_intem = $db->qry_first('SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %int%', $id);
 
-		if ($menu_intem['active']) {
-      ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+        if ($menu_intem['active']) {
+            ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
 
-        if ($_POST['link']) $link = $_POST['link'] .'" target="_blank';
-        else $link = 'index.php?mod=info2&action=show_info2&id='. $id;
+            if ($_POST['link']) {
+                $link = $_POST['link'] .'" target="_blank';
+            } else {
+                $link = 'index.php?mod=info2&action=show_info2&id='. $id;
+            }
 
-			$db->qry("UPDATE %prefix%menu
+            $db->qry("UPDATE %prefix%menu
         SET module = 'info2',
 				caption = %string%,
 				hint = %string%,
@@ -20,39 +24,44 @@ function Update($id) {
 				link = %string%
 				WHERE link = %string%",
         $_POST["caption"], $_POST["shorttext"], $level, $link, $link);
-		}
-	}
-	
-	return true;
+        }
+    }
+    
+    return true;
 }
 
-function ShowActiveState($val){
-  global $dsp, $templ, $lang, $line;
+function ShowActiveState($val)
+{
+    global $dsp, $templ, $lang, $line;
 
-  if ($val) return $dsp->FetchIcon('', 'yes', t('Ja'));
-  else return $dsp->FetchIcon('', 'no', t('Nein'));
+    if ($val) {
+        return $dsp->FetchIcon('', 'yes', t('Ja'));
+    } else {
+        return $dsp->FetchIcon('', 'no', t('Nein'));
+    }
 }
 
 if ($auth['type'] <= 1) {
-  include_once('modules/mastersearch2/class_mastersearch2.php');
-  $ms2 = new MasterSearch2();
+    include_once('modules/mastersearch2/class_mastersearch2.php');
+    $ms2 = new MasterSearch2();
 
-  $ms2->query['from'] = "%prefix%info AS i";
-  $ms2->query['where'] = "i.active";
+    $ms2->query['from'] = "%prefix%info AS i";
+    $ms2->query['where'] = "i.active";
 
-  $ms2->config['EntriesPerPage'] = 50;
+    $ms2->config['EntriesPerPage'] = 50;
 
-  $ms2->AddResultField(t('Seitentitel'), 'i.caption');
-  $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
+    $ms2->AddResultField(t('Seitentitel'), 'i.caption');
+    $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
 
-  $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
-  $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
-
+    $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
+    $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
 } else {
-  if ($_POST['content'] == '') $_POST['content'] = $_POST['FCKeditor1'];
+    if ($_POST['content'] == '') {
+        $_POST['content'] = $_POST['FCKeditor1'];
+    }
 
-  switch($_GET["step"]){
-  	default:
+    switch ($_GET["step"]) {
+    default:
       $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Info-Seiten editieren.'));
       $dsp->AddSingleRow($dsp->FetchSpanButton('Neuen Infotext hinzufügen', 'index.php?mod=info2&action=change&step=2'));
 
@@ -68,13 +77,25 @@ if ($auth['type'] <= 1) {
       $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
       $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
-	    $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
-      if ($auth['type'] >= 2) $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
-      if ($auth['type'] >= 3) $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+        $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
+      if ($auth['type'] >= 2) {
+          $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
+      }
+      if ($auth['type'] >= 3) {
+          $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+      }
 
       $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
 
@@ -93,29 +114,43 @@ if ($auth['type'] <= 1) {
       $ms2->AddResultField(t('Link'), 'i.link', '', 140);
       $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
-      if ($auth['type'] >= 2) $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-      if ($auth['type'] >= 2) $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
-      if ($auth['type'] >= 3) $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+      if ($auth['type'] >= 2) {
+          $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
+      }
+      if ($auth['type'] >= 2) {
+          $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
+      }
+      if ($auth['type'] >= 3) {
+          $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+      }
 
       $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
-  	break;
-	
-	// Generate Editform
-  	case 2:
-			if ($_GET['infoID'] != '') $row = $db->qry_first("SELECT m.id FROM %prefix%info AS i
+    break;
+    
+    // Generate Editform
+    case 2:
+            if ($_GET['infoID'] != '') {
+                $row = $db->qry_first("SELECT m.id FROM %prefix%info AS i
         LEFT JOIN %prefix%menu AS m ON i.caption = m.caption AND m.action = 'show_info2'
         WHERE i.infoID = %int%", $_GET["infoID"]);
+            }
 
-  		$dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Seite editieren.'));
+        $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Seite editieren.'));
 
       include_once('inc/classes/class_masterform.php');
       $mf = new masterform();
 
       foreach ($translation->valid_lang as $val) {
-        $_POST[$language] = 1;
+          $_POST[$language] = 1;
         #$mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 3);
         if ($val == 'de') {
             $valkey = '';
@@ -124,65 +159,77 @@ if ($auth['type'] <= 1) {
             $valkey = '_'. $val;
             $optional = FIELD_OPTIONAL;
         }
-        $mf->AddField(t('Seitentitel'), 'caption'. $valkey, '', '', $optional);
-        $mf->AddField(t('Untertitel'), 'shorttext'. $valkey, '', '', $optional);
-        if ($cfg['info2_use_fckedit']) $mf->AddField(t('Text'), 'text'. $valkey, '', HTML_WYSIWYG, $optional);
-        else $mf->AddField(t('Text'), 'text'. $valkey, '', '', $optional);
-        $mf->AddPage($translation->lang_names[$val]);
+          $mf->AddField(t('Seitentitel'), 'caption'. $valkey, '', '', $optional);
+          $mf->AddField(t('Untertitel'), 'shorttext'. $valkey, '', '', $optional);
+          if ($cfg['info2_use_fckedit']) {
+              $mf->AddField(t('Text'), 'text'. $valkey, '', HTML_WYSIWYG, $optional);
+          } else {
+              $mf->AddField(t('Text'), 'text'. $valkey, '', '', $optional);
+          }
+          $mf->AddPage($translation->lang_names[$val]);
       }
       $mf->AdditionalDBUpdateFunction = 'Update';
       $mf->SendForm('index.php?mod=info2&action=change&step=2', 'info', 'infoID', $_GET['infoID']);
       
-  		$dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
-  	break;
+        $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
+    break;
 
-  	// Delete entry
-  	case 10:
-  		foreach($_POST["action"] AS $item => $val) {
-  			$menu_intem = $db->qry_first("SELECT caption FROM %prefix%info WHERE infoID = %string%", $item);
-  			$db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-  			$db->qry("DELETE FROM %prefix%info WHERE infoID = %string%", $item);
-  		}
+    // Delete entry
+    case 10:
+        foreach ($_POST["action"] as $item => $val) {
+            $menu_intem = $db->qry_first("SELECT caption FROM %prefix%info WHERE infoID = %string%", $item);
+            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+            $db->qry("DELETE FROM %prefix%info WHERE infoID = %string%", $item);
+        }
 
-  		$func->confirmation(t('Der Eintrag wurde gelöscht.'), "index.php?mod=info2&action=change");
-  	break;
+        $func->confirmation(t('Der Eintrag wurde gelöscht.'), "index.php?mod=info2&action=change");
+    break;
 
-  	// Deactivate
-  	case 20:
-  		if ($_GET['infoID']) $_POST["action"][$_GET['infoID']] = '1';
-  		foreach($_POST["action"] AS $item => $val) {
-				$db->qry("UPDATE %prefix%info SET active = 0 WHERE infoID = %string%", $item);
-  			$menu_intem = $db->qry_first("SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%", $item);
-				$db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-      }
+    // Deactivate
+    case 20:
+        if ($_GET['infoID']) {
+            $_POST["action"][$_GET['infoID']] = '1';
+        }
+        foreach ($_POST["action"] as $item => $val) {
+            $db->qry("UPDATE %prefix%info SET active = 0 WHERE infoID = %string%", $item);
+            $menu_intem = $db->qry_first("SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%", $item);
+            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+        }
       $func->confirmation(t('Eintrag deaktiviert'), "index.php?mod=info2&action=change");
-  	break;
+    break;
     
     // Activate
     case 21:
-  		if ($_GET['infoID']) $_POST["action"][$_GET['infoID']] = '1';
-  		foreach($_POST["action"] AS $item => $val) {
-				$db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-      }
+        if ($_GET['infoID']) {
+            $_POST["action"][$_GET['infoID']] = '1';
+        }
+        foreach ($_POST["action"] as $item => $val) {
+            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+        }
       $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-  	break;
+    break;
     
     // Activate and link
     case 22:
-  		if ($_GET['infoID']) $_POST["action"][$_GET['infoID']] = '1';
-  		foreach($_POST["action"] AS $item => $val) {
-  			$menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
-  			$info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
+        if ($_GET['infoID']) {
+            $_POST["action"][$_GET['infoID']] = '1';
+        }
+        foreach ($_POST["action"] as $item => $val) {
+            $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+            $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
 
-				$db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
 
-        ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+            ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
 
-        if ($menu_intem['link']) $link = $menu_intem['link'] .'" target="_blank';
-        else $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+            if ($menu_intem['link']) {
+                $link = $menu_intem['link'] .'" target="_blank';
+            } else {
+                $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+            }
 
-				$db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-				$db->qry("INSERT INTO %prefix%menu
+            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+            $db->qry("INSERT INTO %prefix%menu
 					SET module = 'info2',
 					caption = %string%,
 					hint = %string%,
@@ -193,26 +240,31 @@ if ($auth['type'] <= 1) {
 					action = 'show_info2',
 					file = 'show'
 					", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
-      }
+        }
       $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-  	break;
+    break;
     
     // Activate and link (admin only)
     case 23:
-  		if ($_GET['id']) $_POST["action"][$_GET['id']] = '1';
-  		foreach($_POST["action"] AS $item => $val) {
-  			$menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
-  			$info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
+        if ($_GET['id']) {
+            $_POST["action"][$_GET['id']] = '1';
+        }
+        foreach ($_POST["action"] as $item => $val) {
+            $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+            $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
 
-				$db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
 
-        ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+            ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
 
-        if ($menu_intem['link']) $link = $menu_intem['link'] .'" target="_blank';
-        else $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+            if ($menu_intem['link']) {
+                $link = $menu_intem['link'] .'" target="_blank';
+            } else {
+                $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+            }
 
-				$db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-				$db->qry("INSERT INTO %prefix%menu
+            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+            $db->qry("INSERT INTO %prefix%menu
 					SET module = 'info2',
 					caption = %string%,
 					hint = %string%,
@@ -223,9 +275,9 @@ if ($auth['type'] <= 1) {
 					action = 'show_info2',
 					file = 'show'
 					", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
-      }
+        }
       $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-  	break;
+    break;
 
     // Define external link
     case 30:
@@ -236,12 +288,15 @@ if ($auth['type'] <= 1) {
 
       $mf->AddField(t('Link'), 'link');
       foreach ($translation->valid_lang as $val) {
-        $_POST[$language] = 1;
-        $mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 2);
-        if ($val == 'de') $val = '';
-        else $val = '_'. $val;
-        $mf->AddField(t('Seitentitel'), 'caption'. $val);
-        $mf->AddField(t('Popup-Infotext'), 'shorttext'. $val);
+          $_POST[$language] = 1;
+          $mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 2);
+          if ($val == 'de') {
+              $val = '';
+          } else {
+              $val = '_'. $val;
+          }
+          $mf->AddField(t('Seitentitel'), 'caption'. $val);
+          $mf->AddField(t('Popup-Infotext'), 'shorttext'. $val);
       }
       $mf->AdditionalDBUpdateFunction = 'Update';
       $mf->SendForm('index.php?mod=info2&action=change&step=30', 'info', 'infoID', $_GET['infoID']);
@@ -250,4 +305,3 @@ if ($auth['type'] <= 1) {
     break;
   }
 }
-?>

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -16,14 +16,20 @@ function Update($id)
                 $link = 'index.php?mod=info2&action=show_info2&id='. $id;
             }
 
-            $db->qry("UPDATE %prefix%menu
+            $db->qry(
+                "UPDATE %prefix%menu
         SET module = 'info2',
 				caption = %string%,
 				hint = %string%,
 				level = %int%,
 				link = %string%
 				WHERE link = %string%",
-        $_POST["caption"], $_POST["shorttext"], $level, $link, $link);
+                $_POST["caption"],
+                $_POST["shorttext"],
+                $level,
+                $link,
+                $link
+            );
         }
     }
     
@@ -61,175 +67,175 @@ if ($auth['type'] <= 1) {
     }
 
     switch ($_GET["step"]) {
-    default:
-      $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Info-Seiten editieren.'));
-      $dsp->AddSingleRow($dsp->FetchSpanButton('Neuen Infotext hinzufügen', 'index.php?mod=info2&action=change&step=2'));
+        default:
+              $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Info-Seiten editieren.'));
+              $dsp->AddSingleRow($dsp->FetchSpanButton('Neuen Infotext hinzufügen', 'index.php?mod=info2&action=change&step=2'));
 
-      include_once('modules/mastersearch2/class_mastersearch2.php');
-      $ms2 = new MasterSearch2();
+              include_once('modules/mastersearch2/class_mastersearch2.php');
+              $ms2 = new MasterSearch2();
 
-      $ms2->query['from'] = "%prefix%info AS i";
-      $ms2->query['where'] = "i.link = ''";
+              $ms2->query['from'] = "%prefix%info AS i";
+              $ms2->query['where'] = "i.link = ''";
 
-      $ms2->config['EntriesPerPage'] = 50;
+              $ms2->config['EntriesPerPage'] = 50;
 
-      $ms2->AddResultField(t('Seitentitel'), 'i.caption');
-      $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
-      $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
+              $ms2->AddResultField(t('Seitentitel'), 'i.caption');
+              $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
+              $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
-        $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
-      if ($auth['type'] >= 2) {
-          $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
-      }
-      if ($auth['type'] >= 3) {
-          $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
-      }
+            $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
+            if ($auth['type'] >= 2) {
+                $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
+            }
+            if ($auth['type'] >= 3) {
+                  $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+            }
 
-      $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
+              $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
 
 
-      $dsp->AddSingleRow($dsp->FetchSpanButton('Externen Link erstellen', 'index.php?mod=info2&action=change&step=30'));
+              $dsp->AddSingleRow($dsp->FetchSpanButton('Externen Link erstellen', 'index.php?mod=info2&action=change&step=30'));
 
-      $ms2 = new MasterSearch2();
+              $ms2 = new MasterSearch2();
 
-      $ms2->query['from'] = "%prefix%info AS i";
-      $ms2->query['where'] = "i.link != ''";
+              $ms2->query['from'] = "%prefix%info AS i";
+              $ms2->query['where'] = "i.link != ''";
 
-      $ms2->config['EntriesPerPage'] = 50;
+              $ms2->config['EntriesPerPage'] = 50;
 
-      $ms2->AddResultField(t('Seitentitel'), 'i.caption');
-      $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
-      $ms2->AddResultField(t('Link'), 'i.link', '', 140);
-      $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
+              $ms2->AddResultField(t('Seitentitel'), 'i.caption');
+              $ms2->AddResultField(t('Untertitel'), 'i.shorttext', '', 140);
+              $ms2->AddResultField(t('Link'), 'i.link', '', 140);
+              $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
-      if ($auth['type'] >= 2) {
-          $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-      }
-      if ($auth['type'] >= 2) {
-          $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
-      }
-      if ($auth['type'] >= 3) {
-          $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
-      }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
+            }
+            if ($auth['type'] >= 2) {
+                  $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
+            }
+            if ($auth['type'] >= 3) {
+                  $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+            }
 
-      $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
-    break;
+              $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
+            break;
     
     // Generate Editform
-    case 2:
+        case 2:
             if ($_GET['infoID'] != '') {
                 $row = $db->qry_first("SELECT m.id FROM %prefix%info AS i
         LEFT JOIN %prefix%menu AS m ON i.caption = m.caption AND m.action = 'show_info2'
         WHERE i.infoID = %int%", $_GET["infoID"]);
             }
 
-        $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Seite editieren.'));
+            $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Seite editieren.'));
 
-      include_once('inc/classes/class_masterform.php');
-      $mf = new masterform();
+              include_once('inc/classes/class_masterform.php');
+              $mf = new masterform();
 
-      foreach ($translation->valid_lang as $val) {
-          $_POST[$language] = 1;
-        #$mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 3);
-        if ($val == 'de') {
-            $valkey = '';
-            $optional = 0;
-        } else {
-            $valkey = '_'. $val;
-            $optional = FIELD_OPTIONAL;
-        }
-          $mf->AddField(t('Seitentitel'), 'caption'. $valkey, '', '', $optional);
-          $mf->AddField(t('Untertitel'), 'shorttext'. $valkey, '', '', $optional);
-          if ($cfg['info2_use_fckedit']) {
-              $mf->AddField(t('Text'), 'text'. $valkey, '', HTML_WYSIWYG, $optional);
-          } else {
-              $mf->AddField(t('Text'), 'text'. $valkey, '', '', $optional);
-          }
-          $mf->AddPage($translation->lang_names[$val]);
-      }
-      $mf->AdditionalDBUpdateFunction = 'Update';
-      $mf->SendForm('index.php?mod=info2&action=change&step=2', 'info', 'infoID', $_GET['infoID']);
+            foreach ($translation->valid_lang as $val) {
+                $_POST[$language] = 1;
+                #$mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 3);
+                if ($val == 'de') {
+                    $valkey = '';
+                    $optional = 0;
+                } else {
+                      $valkey = '_'. $val;
+                      $optional = FIELD_OPTIONAL;
+                }
+                  $mf->AddField(t('Seitentitel'), 'caption'. $valkey, '', '', $optional);
+                  $mf->AddField(t('Untertitel'), 'shorttext'. $valkey, '', '', $optional);
+                if ($cfg['info2_use_fckedit']) {
+                    $mf->AddField(t('Text'), 'text'. $valkey, '', HTML_WYSIWYG, $optional);
+                } else {
+                    $mf->AddField(t('Text'), 'text'. $valkey, '', '', $optional);
+                }
+                    $mf->AddPage($translation->lang_names[$val]);
+            }
+              $mf->AdditionalDBUpdateFunction = 'Update';
+              $mf->SendForm('index.php?mod=info2&action=change&step=2', 'info', 'infoID', $_GET['infoID']);
       
-        $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
-    break;
+                $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
+            break;
 
     // Delete entry
-    case 10:
-        foreach ($_POST["action"] as $item => $val) {
-            $menu_intem = $db->qry_first("SELECT caption FROM %prefix%info WHERE infoID = %string%", $item);
-            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-            $db->qry("DELETE FROM %prefix%info WHERE infoID = %string%", $item);
-        }
-
-        $func->confirmation(t('Der Eintrag wurde gelöscht.'), "index.php?mod=info2&action=change");
-    break;
-
-    // Deactivate
-    case 20:
-        if ($_GET['infoID']) {
-            $_POST["action"][$_GET['infoID']] = '1';
-        }
-        foreach ($_POST["action"] as $item => $val) {
-            $db->qry("UPDATE %prefix%info SET active = 0 WHERE infoID = %string%", $item);
-            $menu_intem = $db->qry_first("SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%", $item);
-            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-        }
-      $func->confirmation(t('Eintrag deaktiviert'), "index.php?mod=info2&action=change");
-    break;
-    
-    // Activate
-    case 21:
-        if ($_GET['infoID']) {
-            $_POST["action"][$_GET['infoID']] = '1';
-        }
-        foreach ($_POST["action"] as $item => $val) {
-            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-        }
-      $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-    break;
-    
-    // Activate and link
-    case 22:
-        if ($_GET['infoID']) {
-            $_POST["action"][$_GET['infoID']] = '1';
-        }
-        foreach ($_POST["action"] as $item => $val) {
-            $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
-            $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
-
-            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-
-            ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
-
-            if ($menu_intem['link']) {
-                $link = $menu_intem['link'] .'" target="_blank';
-            } else {
-                $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+        case 10:
+            foreach ($_POST["action"] as $item => $val) {
+                $menu_intem = $db->qry_first("SELECT caption FROM %prefix%info WHERE infoID = %string%", $item);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+                $db->qry("DELETE FROM %prefix%info WHERE infoID = %string%", $item);
             }
 
-            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-            $db->qry("INSERT INTO %prefix%menu
+            $func->confirmation(t('Der Eintrag wurde gelöscht.'), "index.php?mod=info2&action=change");
+            break;
+
+    // Deactivate
+        case 20:
+            if ($_GET['infoID']) {
+                $_POST["action"][$_GET['infoID']] = '1';
+            }
+            foreach ($_POST["action"] as $item => $val) {
+                $db->qry("UPDATE %prefix%info SET active = 0 WHERE infoID = %string%", $item);
+                $menu_intem = $db->qry_first("SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%", $item);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+            }
+              $func->confirmation(t('Eintrag deaktiviert'), "index.php?mod=info2&action=change");
+            break;
+    
+    // Activate
+        case 21:
+            if ($_GET['infoID']) {
+                $_POST["action"][$_GET['infoID']] = '1';
+            }
+            foreach ($_POST["action"] as $item => $val) {
+                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+            }
+              $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            break;
+    
+    // Activate and link
+        case 22:
+            if ($_GET['infoID']) {
+                $_POST["action"][$_GET['infoID']] = '1';
+            }
+            foreach ($_POST["action"] as $item => $val) {
+                $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+                $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
+
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+
+                ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+
+                if ($menu_intem['link']) {
+                    $link = $menu_intem['link'] .'" target="_blank';
+                } else {
+                    $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+                }
+
+                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+                $db->qry("INSERT INTO %prefix%menu
 					SET module = 'info2',
 					caption = %string%,
 					hint = %string%,
@@ -240,31 +246,31 @@ if ($auth['type'] <= 1) {
 					action = 'show_info2',
 					file = 'show'
 					", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
-        }
-      $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-    break;
+            }
+              $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            break;
     
     // Activate and link (admin only)
-    case 23:
-        if ($_GET['id']) {
-            $_POST["action"][$_GET['id']] = '1';
-        }
-        foreach ($_POST["action"] as $item => $val) {
-            $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
-            $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
-
-            $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-
-            ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
-
-            if ($menu_intem['link']) {
-                $link = $menu_intem['link'] .'" target="_blank';
-            } else {
-                $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+        case 23:
+            if ($_GET['id']) {
+                $_POST["action"][$_GET['id']] = '1';
             }
+            foreach ($_POST["action"] as $item => $val) {
+                $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+                $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
 
-            $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
-            $db->qry("INSERT INTO %prefix%menu
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+
+                ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+
+                if ($menu_intem['link']) {
+                    $link = $menu_intem['link'] .'" target="_blank';
+                } else {
+                    $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+                }
+
+                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+                $db->qry("INSERT INTO %prefix%menu
 					SET module = 'info2',
 					caption = %string%,
 					hint = %string%,
@@ -275,33 +281,33 @@ if ($auth['type'] <= 1) {
 					action = 'show_info2',
 					file = 'show'
 					", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
-        }
-      $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
-    break;
+            }
+              $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            break;
 
     // Define external link
-    case 30:
-      $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du einen externen Link definieren.'));
+        case 30:
+              $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du einen externen Link definieren.'));
 
-      include_once('inc/classes/class_masterform.php');
-      $mf = new masterform();
+              include_once('inc/classes/class_masterform.php');
+              $mf = new masterform();
 
-      $mf->AddField(t('Link'), 'link');
-      foreach ($translation->valid_lang as $val) {
-          $_POST[$language] = 1;
-          $mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 2);
-          if ($val == 'de') {
-              $val = '';
-          } else {
-              $val = '_'. $val;
-          }
-          $mf->AddField(t('Seitentitel'), 'caption'. $val);
-          $mf->AddField(t('Popup-Infotext'), 'shorttext'. $val);
-      }
-      $mf->AdditionalDBUpdateFunction = 'Update';
-      $mf->SendForm('index.php?mod=info2&action=change&step=30', 'info', 'infoID', $_GET['infoID']);
+              $mf->AddField(t('Link'), 'link');
+            foreach ($translation->valid_lang as $val) {
+                $_POST[$language] = 1;
+                $mf->AddField(t($translation->lang_names[$val]).'|'.t('Einen Text für die Sprache "%1" definieren', t($translation->lang_names[$val])), $val, 'tinyint(1)', '', FIELD_OPTIONAL, '', 2);
+                if ($val == 'de') {
+                    $val = '';
+                } else {
+                    $val = '_'. $val;
+                }
+                  $mf->AddField(t('Seitentitel'), 'caption'. $val);
+                  $mf->AddField(t('Popup-Infotext'), 'shorttext'. $val);
+            }
+              $mf->AdditionalDBUpdateFunction = 'Update';
+              $mf->SendForm('index.php?mod=info2&action=change&step=30', 'info', 'infoID', $_GET['infoID']);
 
-      $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
-    break;
-  }
+              $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
+            break;
+    }
 }

--- a/modules/info2/show.php
+++ b/modules/info2/show.php
@@ -1,40 +1,46 @@
 <?php
 
-if ($language == 'de') $val = '';
-else $val = '_'. $language;
+if ($language == 'de') {
+    $val = '';
+} else {
+    $val = '_'. $language;
+}
 
 if (($_GET["submod"] != "")||($_GET["id"]>=1)) {
-	
-	if ($_GET["submod"]) { 
-		// FIX : Remove on next Version, SUBMOD is only for compartiblity
-		$info = $db->qry_first("SELECT active, text%plain%, shorttext%plain%, caption%plain% FROM %prefix%info WHERE caption = %string%", $val, $val, $val, $_GET["submod"]);
-	} else {
-		$info = $db->qry_first("SELECT active, text%plain%, shorttext%plain%, caption%plain% FROM %prefix%info WHERE infoID = %int%", $val, $val, $val, $_GET["id"]);
-	}
-
-	$dsp->NewContent("{$info["caption$val"]}", $info["shorttext$val"]);
-	$framework->AddToPageTitle($info["caption$val"]);
-
-  if ($info['active'] == 1) {
-  	if($info["text$val"] == null)
-  		$func->information(t("Es liegen Informationen zu der ausgewählten Seite vor, jedoch nicht in deiner aktuell gewählten Sprache: <b>%1</b>",$language));
-	else
-	 	$dsp->AddSingleRow($func->AllowHTML($info["text$val"]), '', 'textContent');
-	} else $func->error(t('Diese Info-Seite ist nicht aktiviert. Ein Admin muss sie zuerst im Info-Modul aktivieren'));
-	
-	// Show edit/aktivate Buttons
-	// FIX : add delete
-	if ($auth["type"] > 1) {
-		//$dsp->AddSingleRow(" <font color=\"#ff0000\">".t('Diese Seite enthält selbst definierten Text. Du kannst ihn ändern, indem du den Informationen-Link in der Navigations-Box auswählen.')."</font>");
-		$buttons .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=info2&action=change&step=2&infoID={$_GET["id"]}"). " ";
-		if ($info['active'] == 1) {
-    		$buttons .= $dsp->FetchSpanButton(t('Deaktivieren'), "index.php?mod=info2&action=change&step=20&infoID={$_GET["id"]}"). " ";
-		} else {
-    		$buttons .= $dsp->FetchSpanButton(t('Aktivieren'), "index.php?mod=info2&action=change&step=21&infoID={$_GET["id"]}"). " ";
-		}
-		$dsp->AddSingleRow($buttons);
+    if ($_GET["submod"]) {
+        // FIX : Remove on next Version, SUBMOD is only for compartiblity
+        $info = $db->qry_first("SELECT active, text%plain%, shorttext%plain%, caption%plain% FROM %prefix%info WHERE caption = %string%", $val, $val, $val, $_GET["submod"]);
+    } else {
+        $info = $db->qry_first("SELECT active, text%plain%, shorttext%plain%, caption%plain% FROM %prefix%info WHERE infoID = %int%", $val, $val, $val, $_GET["id"]);
     }
 
-	$dsp->AddContent();
-} else $func->error(t('Du hast keine Seite ausgewählt'));
-?>
+    $dsp->NewContent("{$info["caption$val"]}", $info["shorttext$val"]);
+    $framework->AddToPageTitle($info["caption$val"]);
+
+    if ($info['active'] == 1) {
+        if ($info["text$val"] == null) {
+            $func->information(t("Es liegen Informationen zu der ausgewählten Seite vor, jedoch nicht in deiner aktuell gewählten Sprache: <b>%1</b>", $language));
+        } else {
+            $dsp->AddSingleRow($func->AllowHTML($info["text$val"]), '', 'textContent');
+        }
+    } else {
+        $func->error(t('Diese Info-Seite ist nicht aktiviert. Ein Admin muss sie zuerst im Info-Modul aktivieren'));
+    }
+    
+    // Show edit/aktivate Buttons
+    // FIX : add delete
+    if ($auth["type"] > 1) {
+        //$dsp->AddSingleRow(" <font color=\"#ff0000\">".t('Diese Seite enthält selbst definierten Text. Du kannst ihn ändern, indem du den Informationen-Link in der Navigations-Box auswählen.')."</font>");
+        $buttons .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=info2&action=change&step=2&infoID={$_GET["id"]}"). " ";
+        if ($info['active'] == 1) {
+            $buttons .= $dsp->FetchSpanButton(t('Deaktivieren'), "index.php?mod=info2&action=change&step=20&infoID={$_GET["id"]}"). " ";
+        } else {
+            $buttons .= $dsp->FetchSpanButton(t('Aktivieren'), "index.php?mod=info2&action=change&step=21&infoID={$_GET["id"]}"). " ";
+        }
+        $dsp->AddSingleRow($buttons);
+    }
+
+    $dsp->AddContent();
+} else {
+    $func->error(t('Du hast keine Seite ausgewählt'));
+}


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.