### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/bugtracker

### DIFF
--- a/modules/bugtracker/add.php
+++ b/modules/bugtracker/add.php
@@ -38,11 +38,11 @@ if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']
     $mf->AddField(t('Priorität'), 'priority', IS_SELECTION, $selections, FIELD_OPTIONAL);
 
   // Assign bug
-  if ($auth['type'] >= 2) {
-      $mf->AddDropDownFromTable(t('Bearbeiter'), 'agent', 'userid', 'username', 'user', t('Keinem zugeordnet'), 'type >= 2');
-      $mf->AddField(t('Preis'), 'price', '', '', FIELD_OPTIONAL);
-      $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', FIELD_OPTIONAL);
-  }
+    if ($auth['type'] >= 2) {
+        $mf->AddDropDownFromTable(t('Bearbeiter'), 'agent', 'userid', 'username', 'user', t('Keinem zugeordnet'), 'type >= 2');
+        $mf->AddField(t('Preis'), 'price', '', '', FIELD_OPTIONAL);
+        $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', FIELD_OPTIONAL);
+    }
 
     if (!$_GET['bugid']) {
         $mf->AddFix('date', 'NOW()');

--- a/modules/bugtracker/add.php
+++ b/modules/bugtracker/add.php
@@ -2,65 +2,75 @@
 $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der Verwendung dieses Systems auftreten, sowie Feature Wünsche äußern. Können die Admins dieser Webseite sie nicht selbst beheben, haben diese die Möglichkeit sie an das Lansuite-Team weiterzureichen.'));
 
 $row = $db->qry_first('SELECT reporter FROM %prefix%bugtracker WHERE bugid = %int%', $_GET['bugid']);
-if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']) $func->error(t('Nur Admins und der Reporter dürfen Bug-Einträge im Nachhinein editieren'), 'index.php?mod=bugtracker');
-else {
-  include_once('inc/classes/class_masterform.php');
-  $mf = new masterform();
+if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']) {
+    $func->error(t('Nur Admins und der Reporter dürfen Bug-Einträge im Nachhinein editieren'), 'index.php?mod=bugtracker');
+} else {
+    include_once('inc/classes/class_masterform.php');
+    $mf = new masterform();
 
-  $mf->AddField(t('Überschrift'), 'caption');
+    $mf->AddField(t('Überschrift'), 'caption');
 
-  $selections = array();
-  $selections[''] = t('Bitte auswählen');
-  $selections['1'] = t('Feature Wunsch');
-  $selections['2'] = t('Schreibfehler');
-  $selections['3'] = t('Kleiner Fehler');
-  $selections['4'] = t('Schwerer Fehler');
-  $selections['5'] = t('Absturz');
-  $mf->AddField(t('Typ'), 'type', IS_SELECTION, $selections);
+    $selections = array();
+    $selections[''] = t('Bitte auswählen');
+    $selections['1'] = t('Feature Wunsch');
+    $selections['2'] = t('Schreibfehler');
+    $selections['3'] = t('Kleiner Fehler');
+    $selections['4'] = t('Schwerer Fehler');
+    $selections['5'] = t('Absturz');
+    $mf->AddField(t('Typ'), 'type', IS_SELECTION, $selections);
 
-  $mf->AddDropDownFromTable(t('Betrifft Modul'), 'module', 'name', 'name', 'modules', t('Nicht Modul-spezifisch'));
+    $mf->AddDropDownFromTable(t('Betrifft Modul'), 'module', 'name', 'name', 'modules', t('Nicht Modul-spezifisch'));
 
-  if ($_SERVER['SERVER_NAME'] == 'lansuite.orgapage.de') $mf->AddField(t('Betrifft Version'), 'version');
+    if ($_SERVER['SERVER_NAME'] == 'lansuite.orgapage.de') {
+        $mf->AddField(t('Betrifft Version'), 'version');
+    }
 
-  $selections = array();
-  for ($z = 5; $z >= -5; $z--) {
-    $selections[$z] = $z;
-    if ($z == 5) $selections[$z] .= ' ('. t('Sehr hoch') .')';
-    if ($z == -5) $selections[$z] .= ' ('. t('Sehr gering') .')';
-  }
-  $mf->AddField(t('Priorität'), 'priority', IS_SELECTION, $selections, FIELD_OPTIONAL);
+    $selections = array();
+    for ($z = 5; $z >= -5; $z--) {
+        $selections[$z] = $z;
+        if ($z == 5) {
+            $selections[$z] .= ' ('. t('Sehr hoch') .')';
+        }
+        if ($z == -5) {
+            $selections[$z] .= ' ('. t('Sehr gering') .')';
+        }
+    }
+    $mf->AddField(t('Priorität'), 'priority', IS_SELECTION, $selections, FIELD_OPTIONAL);
 
   // Assign bug
   if ($auth['type'] >= 2) {
-    $mf->AddDropDownFromTable(t('Bearbeiter'), 'agent', 'userid', 'username', 'user', t('Keinem zugeordnet'), 'type >= 2');
-    $mf->AddField(t('Preis'), 'price', '', '', FIELD_OPTIONAL);
-    $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', FIELD_OPTIONAL);
+      $mf->AddDropDownFromTable(t('Bearbeiter'), 'agent', 'userid', 'username', 'user', t('Keinem zugeordnet'), 'type >= 2');
+      $mf->AddField(t('Preis'), 'price', '', '', FIELD_OPTIONAL);
+      $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', FIELD_OPTIONAL);
   }
 
-  if (!$_GET['bugid']) {
-    $mf->AddFix('date', 'NOW()');
-    if ($_SERVER['SERVER_NAME'] != 'lansuite.orgapage.de') $mf->AddFix('version', $config['lansuite']['version']);
-    $mf->AddFix('url', $_SERVER['SERVER_NAME']);
-    $mf->AddFix('reporter', $auth['userid']);
-    $mf->AddFix('state', '0');
-  } elseif ($auth['type'] >= 2) {
-    $selections = array();
-    $selections['0'] = t('Neu');
-    $selections['1'] = t('Bestätigt');
-    $selections['2'] = t('In Bearbeitung');
-    $selections['3'] = t('Reporter-Antwort erforderlich');
-    $selections['4'] = t('Behoben');
-    $selections['5'] = t('Aufgeschoben');
-    $selections['6'] = t('Geschlossen');
-    $mf->AddField(t('Status'), 'state', IS_SELECTION, $selections);
-    $mf->AddField(t('Privat') .'|'. t('Nur Admins dürfen diesen Bugeintrag lesen.'), 'private', '', '', FIELD_OPTIONAL);
-  }
+    if (!$_GET['bugid']) {
+        $mf->AddFix('date', 'NOW()');
+        if ($_SERVER['SERVER_NAME'] != 'lansuite.orgapage.de') {
+            $mf->AddFix('version', $config['lansuite']['version']);
+        }
+        $mf->AddFix('url', $_SERVER['SERVER_NAME']);
+        $mf->AddFix('reporter', $auth['userid']);
+        $mf->AddFix('state', '0');
+    } elseif ($auth['type'] >= 2) {
+        $selections = array();
+        $selections['0'] = t('Neu');
+        $selections['1'] = t('Bestätigt');
+        $selections['2'] = t('In Bearbeitung');
+        $selections['3'] = t('Reporter-Antwort erforderlich');
+        $selections['4'] = t('Behoben');
+        $selections['5'] = t('Aufgeschoben');
+        $selections['6'] = t('Geschlossen');
+        $mf->AddField(t('Status'), 'state', IS_SELECTION, $selections);
+        $mf->AddField(t('Privat') .'|'. t('Nur Admins dürfen diesen Bugeintrag lesen.'), 'private', '', '', FIELD_OPTIONAL);
+    }
 
-  $mf->AddField(t('Text'), 'text', '', LSCODE_BIG);
-  if ($_SERVER['SERVER_NAME'] == 'lansuite.orgapage.de') $mf->AddField(t('Bild / Datei anhängen'), 'file', IS_FILE_UPLOAD, 'ext_inc/bugtracker_upload/', FIELD_OPTIONAL);
+    $mf->AddField(t('Text'), 'text', '', LSCODE_BIG);
+    if ($_SERVER['SERVER_NAME'] == 'lansuite.orgapage.de') {
+        $mf->AddField(t('Bild / Datei anhängen'), 'file', IS_FILE_UPLOAD, 'ext_inc/bugtracker_upload/', FIELD_OPTIONAL);
+    }
 
-  $mf->SendForm('index.php?mod=bugtracker&action=add', 'bugtracker', 'bugid', $_GET['bugid']);
+    $mf->SendForm('index.php?mod=bugtracker&action=add', 'bugtracker', 'bugid', $_GET['bugid']);
 
-  $dsp->AddBackButton('index.php?mod=bugtracker');
+    $dsp->AddBackButton('index.php?mod=bugtracker');
 }
-?>

--- a/modules/bugtracker/class_bugtracker.php
+++ b/modules/bugtracker/class_bugtracker.php
@@ -4,17 +4,17 @@ class Bugtracker
     public $stati = array();
 
   // Constructor
-  public function Bugtracker()
-  {
-      $this->stati[0] = t('Neu');
-      $this->stati[1] = t('Bestätigt');
-      $this->stati[2] = t('In Bearbeitung');
-      $this->stati[3] = t('Feedback benötigt');
-      $this->stati[4] = t('Behoben');
-      $this->stati[5] = t('Aufgeschoben');
-      $this->stati[6] = t('Geschlossen');
-      $this->stati[7] = t('Wiedereröffnet');
-  }
+    public function Bugtracker()
+    {
+        $this->stati[0] = t('Neu');
+        $this->stati[1] = t('Bestätigt');
+        $this->stati[2] = t('In Bearbeitung');
+        $this->stati[3] = t('Feedback benötigt');
+        $this->stati[4] = t('Behoben');
+        $this->stati[5] = t('Aufgeschoben');
+        $this->stati[6] = t('Geschlossen');
+        $this->stati[7] = t('Wiedereröffnet');
+    }
 
     public function SetBugStateInternal($bugid, $state)
     {
@@ -41,26 +41,32 @@ class Bugtracker
             $func->log_event(t('Bugreport auf Status "%1" geändert', array($this->stati[$state])), 1, '', $bugid);
 
       // Mails
-      $AddLink = '
+            $AddLink = '
 
 [url=index.php?mod=bugtracker&bugid=%2]'. t('Zum Bug-Eintrag') .'[/url]';
             if ($state == 1 or $state == 2 or $state == 3 or $state == 4 or $state == 5 or $state == 6) {
                 $row = $db->qry_first("SELECT reporter, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
                 if ($row['reporter'] != $auth['userid']) {
                     switch ($state) {
-            case 1: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde bestätigt'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Bestätigt"[/b] gesetzt. Dies bedeutet, dass der Fehler bekannt ist (bzw. der Feature-Wunsch anerkannt wurde), sich jedoch noch kein Bearbeiter gefunden hat.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 2: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wird nun bearbeitet'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Dies bedeutet, dass jemand an dem Problem arbeitet und es vorraussichtlich in Kürze behoben sein wird.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 3: $mail->create_sys_mail($row['reporter'], t('Feedback zu deinem Bugreport benötigt'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Feedback benötigt"[/b] gesetzt. Bitte schaue dir den Bugreport noch einmal an und hilf, deine Angaben zu vervollständigen.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 4: $mail->create_sys_mail($row['reporter'], t('Das Problem aus deinem Bugreport wurde behoben'), t('Gute Nachrichten: Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Behoben"[/b] gesetzt. Bitte prüfe nochmals, ob nun auch wirklich alles korrekt funktioniert und setze den Status auf "Wiedereröffnet", falls weiterhin noch Probleme bestehen.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 5: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde aufgeschoben'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Aufgeschoben"[/b] gesetzt. Dies ist in aller Regel dann der Fall, wenn der Aufwand unverhältnismäßig hoch gegenüber dem Nutzen eines Fixes sein würde, oder der Wunsch mit aktuellen Boardmitteln von Lansuite nur sehr schwer realisierbar ist. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 6: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde geschlossen'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Geschlossen"[/b] gesetzt. Dies bedeutet in den meisten Fällen, dass sich das Problem auf Grund eines Irrtums von selbst behoben hat und kein Fix für dieses Problem notwendig bzw. vorgesehen ist. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-          }
+                        case 1:
+                            $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde bestätigt'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Bestätigt"[/b] gesetzt. Dies bedeutet, dass der Fehler bekannt ist (bzw. der Feature-Wunsch anerkannt wurde), sich jedoch noch kein Bearbeiter gefunden hat.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 2:
+                            $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wird nun bearbeitet'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Dies bedeutet, dass jemand an dem Problem arbeitet und es vorraussichtlich in Kürze behoben sein wird.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 3:
+                            $mail->create_sys_mail($row['reporter'], t('Feedback zu deinem Bugreport benötigt'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Feedback benötigt"[/b] gesetzt. Bitte schaue dir den Bugreport noch einmal an und hilf, deine Angaben zu vervollständigen.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 4:
+                            $mail->create_sys_mail($row['reporter'], t('Das Problem aus deinem Bugreport wurde behoben'), t('Gute Nachrichten: Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Behoben"[/b] gesetzt. Bitte prüfe nochmals, ob nun auch wirklich alles korrekt funktioniert und setze den Status auf "Wiedereröffnet", falls weiterhin noch Probleme bestehen.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 5:
+                            $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde aufgeschoben'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Aufgeschoben"[/b] gesetzt. Dies ist in aller Regel dann der Fall, wenn der Aufwand unverhältnismäßig hoch gegenüber dem Nutzen eines Fixes sein würde, oder der Wunsch mit aktuellen Boardmitteln von Lansuite nur sehr schwer realisierbar ist. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 6:
+                            $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde geschlossen'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Geschlossen"[/b] gesetzt. Dies bedeutet in den meisten Fällen, dass sich das Problem auf Grund eines Irrtums von selbst behoben hat und kein Fix für dieses Problem notwendig bzw. vorgesehen ist. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                    }
                     $func->log_event(t('Benachrichtigungsmail an Reporter versandt'), 1, '', $bugid);
                 }
             }
@@ -68,11 +74,13 @@ class Bugtracker
                 $row = $db->qry_first("SELECT agent, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
                 if ($row['agent'] != $auth['userid']) {
                     switch ($state) {
-            case 2: $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wartet auf seine Bearbeitung'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Entweder hat ein Administrator dir den Eintrag zugewiesen oder ein Benutzer hat das von dir erwartete Feedback übermittelt und den Status anschließend geändert. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-            case 7: $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wurde wiedereröffnet'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"Wiedereröffnet"[/b] gesetzt. Bitte schaue dir den Bugreport noch einmal an und behebe nach Möglichkeit die weiteren Probleme.'. $AddLink, array($row['caption'], $bugid)));
-            break;
-          }
+                        case 2:
+                            $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wartet auf seine Bearbeitung'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Entweder hat ein Administrator dir den Eintrag zugewiesen oder ein Benutzer hat das von dir erwartete Feedback übermittelt und den Status anschließend geändert. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                        case 7:
+                            $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wurde wiedereröffnet'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"Wiedereröffnet"[/b] gesetzt. Bitte schaue dir den Bugreport noch einmal an und behebe nach Möglichkeit die weiteren Probleme.'. $AddLink, array($row['caption'], $bugid)));
+                            break;
+                    }
                     $func->log_event(t('Benachrichtigungsmail an Bearbeiter versandt'), 1, '', $bugid);
                 }
             }

--- a/modules/bugtracker/class_bugtracker.php
+++ b/modules/bugtracker/class_bugtracker.php
@@ -1,52 +1,53 @@
 <?php
-class Bugtracker {
-
-  var $stati = array();
+class Bugtracker
+{
+    public $stati = array();
 
   // Constructor
-  function Bugtracker() {
-    $this->stati[0] = t('Neu');
-    $this->stati[1] = t('Bestätigt');
-    $this->stati[2] = t('In Bearbeitung');
-    $this->stati[3] = t('Feedback benötigt');
-    $this->stati[4] = t('Behoben');
-    $this->stati[5] = t('Aufgeschoben');
-    $this->stati[6] = t('Geschlossen');
-    $this->stati[7] = t('Wiedereröffnet');
+  public function Bugtracker()
+  {
+      $this->stati[0] = t('Neu');
+      $this->stati[1] = t('Bestätigt');
+      $this->stati[2] = t('In Bearbeitung');
+      $this->stati[3] = t('Feedback benötigt');
+      $this->stati[4] = t('Behoben');
+      $this->stati[5] = t('Aufgeschoben');
+      $this->stati[6] = t('Geschlossen');
+      $this->stati[7] = t('Wiedereröffnet');
   }
 
-  function SetBugStateInternal($bugid, $state) {
-    global $db, $func, $auth;
+    public function SetBugStateInternal($bugid, $state)
+    {
+        global $db, $func, $auth;
 
-    if ($auth['type'] <= 1) {
-      $row = $db->qry_first("SELECT reporter, caption, state FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
-      if (!(($row['state'] == 0 and $state == 1) or ($row['state'] == 4 and $state == 7) or ($row['state'] == 3 and $state == 2))) {
-        $func->information(t('Der Status des Bugreports <b>"%1"</b> konnte nicht geändert werden, da du nur von <b>"Neu" auf "Bestätigt"</b>, von <b>"Feedback benötigt" auf "In Bearbeitung"</b> und von <b>"Behoben" auf "Wiedereröffnet"</b> wechseln darfst.', array($row['caption'])));
-        return;
-      }
-      if ($state == 1 and $row['reporter'] == $auth['userid']) {
-        $func->information(t('Du darfst nicht deinen eigenen Bugreport bestätigen'));
-        return;
-      }
-    }
+        if ($auth['type'] <= 1) {
+            $row = $db->qry_first("SELECT reporter, caption, state FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
+            if (!(($row['state'] == 0 and $state == 1) or ($row['state'] == 4 and $state == 7) or ($row['state'] == 3 and $state == 2))) {
+                $func->information(t('Der Status des Bugreports <b>"%1"</b> konnte nicht geändert werden, da du nur von <b>"Neu" auf "Bestätigt"</b>, von <b>"Feedback benötigt" auf "In Bearbeitung"</b> und von <b>"Behoben" auf "Wiedereröffnet"</b> wechseln darfst.', array($row['caption'])));
+                return;
+            }
+            if ($state == 1 and $row['reporter'] == $auth['userid']) {
+                $func->information(t('Du darfst nicht deinen eigenen Bugreport bestätigen'));
+                return;
+            }
+        }
 
-    $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE state = %int% AND bugid = %int%", $state, $bugid);
-    if (!$row['found']) {
+        $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE state = %int% AND bugid = %int%", $state, $bugid);
+        if (!$row['found']) {
+            include_once("modules/mail/class_mail.php");
+            $mail = new mail();
 
-      include_once("modules/mail/class_mail.php");
-      $mail = new mail();
-
-      $db->qry("UPDATE %prefix%bugtracker SET state = %int% WHERE bugid = %int%", $state, $bugid);
-      $func->log_event(t('Bugreport auf Status "%1" geändert', array($this->stati[$state])), 1, '', $bugid);
+            $db->qry("UPDATE %prefix%bugtracker SET state = %int% WHERE bugid = %int%", $state, $bugid);
+            $func->log_event(t('Bugreport auf Status "%1" geändert', array($this->stati[$state])), 1, '', $bugid);
 
       // Mails
       $AddLink = '
 
 [url=index.php?mod=bugtracker&bugid=%2]'. t('Zum Bug-Eintrag') .'[/url]';
-      if ($state == 1 or $state == 2 or $state == 3 or $state == 4 or $state == 5 or $state == 6) {
-        $row = $db->qry_first("SELECT reporter, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
-        if ($row['reporter'] != $auth['userid']) {
-          switch ($state) {
+            if ($state == 1 or $state == 2 or $state == 3 or $state == 4 or $state == 5 or $state == 6) {
+                $row = $db->qry_first("SELECT reporter, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
+                if ($row['reporter'] != $auth['userid']) {
+                    switch ($state) {
             case 1: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde bestätigt'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Bestätigt"[/b] gesetzt. Dies bedeutet, dass der Fehler bekannt ist (bzw. der Feature-Wunsch anerkannt wurde), sich jedoch noch kein Bearbeiter gefunden hat.'. $AddLink, array($row['caption'], $bugid)));
             break;
             case 2: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wird nun bearbeitet'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Dies bedeutet, dass jemand an dem Problem arbeitet und es vorraussichtlich in Kürze behoben sein wird.'. $AddLink, array($row['caption'], $bugid)));
@@ -60,57 +61,72 @@ class Bugtracker {
             case 6: $mail->create_sys_mail($row['reporter'], t('Dein Bugreport wurde geschlossen'), t('Der Status deines Bugreports [b]"%1"[/b] wurde auf [b]"Geschlossen"[/b] gesetzt. Dies bedeutet in den meisten Fällen, dass sich das Problem auf Grund eines Irrtums von selbst behoben hat und kein Fix für dieses Problem notwendig bzw. vorgesehen ist. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
             break;
           }
-          $func->log_event(t('Benachrichtigungsmail an Reporter versandt'), 1, '', $bugid);
-        }
-      }
-      if ($state == 2 or $state == 7) {
-        $row = $db->qry_first("SELECT agent, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
-        if ($row['agent'] != $auth['userid']) {
-          switch ($state) {
+                    $func->log_event(t('Benachrichtigungsmail an Reporter versandt'), 1, '', $bugid);
+                }
+            }
+            if ($state == 2 or $state == 7) {
+                $row = $db->qry_first("SELECT agent, caption FROM %prefix%bugtracker WHERE bugid = %int%", $bugid);
+                if ($row['agent'] != $auth['userid']) {
+                    switch ($state) {
             case 2: $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wartet auf seine Bearbeitung'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"In Bearbeitung"[/b] gesetzt. Entweder hat ein Administrator dir den Eintrag zugewiesen oder ein Benutzer hat das von dir erwartete Feedback übermittelt und den Status anschließend geändert. Näheres erfährst du eventuell in den Kommentaren dieses Bug-Reports.'. $AddLink, array($row['caption'], $bugid)));
             break;
             case 7: $mail->create_sys_mail($row['agent'], t('Ein dir zugewiesener Bugreport wurde wiedereröffnet'), t('Der Status des Bugreports [b]"%1"[/b] wurde auf [b]"Wiedereröffnet"[/b] gesetzt. Bitte schaue dir den Bugreport noch einmal an und behebe nach Möglichkeit die weiteren Probleme.'. $AddLink, array($row['caption'], $bugid)));
             break;
           }
-          $func->log_event(t('Benachrichtigungsmail an Bearbeiter versandt'), 1, '', $bugid);
+                    $func->log_event(t('Benachrichtigungsmail an Bearbeiter versandt'), 1, '', $bugid);
+                }
+            }
         }
-      }
     }
-  }
 
-  function AssignBugToUserInternal($bugid, $userid) {
-    global $db, $func, $auth;
+    public function AssignBugToUserInternal($bugid, $userid)
+    {
+        global $db, $func, $auth;
 
-    $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE agent = %int% AND bugid = %int%", $userid, $bugid);
-    if (!$row['found']) {
-      if ($auth['type'] > 1) $db->qry("UPDATE %prefix%bugtracker SET agent = %int% WHERE bugid = %int%", $userid, $bugid);
+        $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE agent = %int% AND bugid = %int%", $userid, $bugid);
+        if (!$row['found']) {
+            if ($auth['type'] > 1) {
+                $db->qry("UPDATE %prefix%bugtracker SET agent = %int% WHERE bugid = %int%", $userid, $bugid);
+            }
 
-      if ($userid == 0) $func->log_event(t('Benutzerzuordnung gelöscht'), 1, '', $bugid);
-      else {
-        $row = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $userid);
-        $func->log_event(t('Bugreport Benutzer "%1" zugeordnet', array($row['username'])), 1, '', $bugid);
-      }
+            if ($userid == 0) {
+                $func->log_event(t('Benutzerzuordnung gelöscht'), 1, '', $bugid);
+            } else {
+                $row = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $userid);
+                $func->log_event(t('Bugreport Benutzer "%1" zugeordnet', array($row['username'])), 1, '', $bugid);
+            }
+        }
     }
-  }
 
-  function AssignBugToUser($bugid, $userid) {
+    public function AssignBugToUser($bugid, $userid)
+    {
+        if (!$bugid) {
+            return false;
+        }
 
-    if (!$bugid) return false;
+        $this->AssignBugToUserInternal($bugid, $userid);
 
-    $this->AssignBugToUserInternal($bugid, $userid);
+        if ($userid == 0) {
+            $this->SetBugStateInternal($bugid, 0);
+        } else {
+            $this->SetBugStateInternal($bugid, 2);
+        }
+    }
 
-    if ($userid == 0) $this->SetBugStateInternal($bugid, 0);
-    else $this->SetBugStateInternal($bugid, 2);
-  }
+    public function SetBugState($bugid, $state)
+    {
+        global $auth;
 
-  function SetBugState($bugid, $state) {
-    global $auth;
+        if (!$bugid) {
+            return false;
+        }
+        if ($state == '') {
+            return false;
+        }
 
-    if (!$bugid) return false;
-    if ($state == '') return false;
-
-    $this->SetBugStateInternal($bugid, $state);
-    if ($state == 2 or $state == 4 or $state == 6) $this->AssignBugToUserInternal($bugid, $auth['userid']);
-  }
+        $this->SetBugStateInternal($bugid, $state);
+        if ($state == 2 or $state == 4 or $state == 6) {
+            $this->AssignBugToUserInternal($bugid, $auth['userid']);
+        }
+    }
 }
-?>

--- a/modules/bugtracker/export.php
+++ b/modules/bugtracker/export.php
@@ -1,5 +1,5 @@
 <?php
-switch($_GET['step']) {
+switch ($_GET['step']) {
   default:
     $dsp->NewContent(t('Bugtracker Export'), t('Nutze diese Funktion um einen Export der Bugtracker-Einträge zu erstellen, den sie auf lansuite.de importieren können'));
     $dsp->AddDoubleRow('', t('Bitte versuche Fehler zunächst selbst zu beheben und filter vor dem Export Probleme aus, die nicht von generellem Interesse für Lansuite sind. Es werden nur Probleme mit Status offen, oder bestätigt exportiert. Ergänze unvollständige Angaben, so gut du kannst. Danke, für die Hilfe!'));
@@ -19,30 +19,30 @@ switch($_GET['step']) {
     $entrys = '';
     $res = $db->qry("SELECT * FROM %prefix%bugtracker WHERE state = 0 OR state = 1");
     while ($row = $db->fetch_array($res)) {
-      $entry = '';
-      $data = '';
-      $data .= $xml->write_tag('caption', $row['caption'], 4);
-      $data .= $xml->write_tag('text', $row['text'], 4);
-      $data .= $xml->write_tag('version', $_POST['version'], 4);
-      $data .= $xml->write_tag('url', $_POST['url'], 4);
-      $data .= $xml->write_tag('priority', $row['priority'], 4);
-      $data .= $xml->write_tag('date', $row['date'], 4);
-      $data .= $xml->write_tag('type', $row['type'], 4);
-      $data .= $xml->write_tag('module', $row['module'], 4);
-      $data .= $xml->write_tag('state', $row['state'], 4);
-      $entry .= $xml->write_master_tag('main', $data, 3);
+        $entry = '';
+        $data = '';
+        $data .= $xml->write_tag('caption', $row['caption'], 4);
+        $data .= $xml->write_tag('text', $row['text'], 4);
+        $data .= $xml->write_tag('version', $_POST['version'], 4);
+        $data .= $xml->write_tag('url', $_POST['url'], 4);
+        $data .= $xml->write_tag('priority', $row['priority'], 4);
+        $data .= $xml->write_tag('date', $row['date'], 4);
+        $data .= $xml->write_tag('type', $row['type'], 4);
+        $data .= $xml->write_tag('module', $row['module'], 4);
+        $data .= $xml->write_tag('state', $row['state'], 4);
+        $entry .= $xml->write_master_tag('main', $data, 3);
 
-      $comments = '';
-      $res2 = $db->qry("SELECT date, text FROM %prefix%comments WHERE relatedto_item = 'BugEintrag' AND relatedto_id = %int%", $row['bugid']);
-      while ($row2 = $db->fetch_array($res2)) {
-        $comment = '';
-        $comment .= $xml->write_tag('text', $row2['text'], 5);
-        $comment .= $xml->write_tag('date', $row2['date'], 5);
-        $comments .= $xml->write_master_tag('comment', $comment, 4);
-      }
-      $db->free_result($res2);
-      $entry .= $xml->write_master_tag('comments', $comments, 3);
-      $entrys .= $xml->write_master_tag('entry', $entry, 2);
+        $comments = '';
+        $res2 = $db->qry("SELECT date, text FROM %prefix%comments WHERE relatedto_item = 'BugEintrag' AND relatedto_id = %int%", $row['bugid']);
+        while ($row2 = $db->fetch_array($res2)) {
+            $comment = '';
+            $comment .= $xml->write_tag('text', $row2['text'], 5);
+            $comment .= $xml->write_tag('date', $row2['date'], 5);
+            $comments .= $xml->write_master_tag('comment', $comment, 4);
+        }
+        $db->free_result($res2);
+        $entry .= $xml->write_master_tag('comments', $comments, 3);
+        $entrys .= $xml->write_master_tag('entry', $entry, 2);
     }
     $db->free_result($res);
 
@@ -50,4 +50,3 @@ switch($_GET['step']) {
     $export->LSTableFoot();
   break;
 }
-?>

--- a/modules/bugtracker/export.php
+++ b/modules/bugtracker/export.php
@@ -1,52 +1,52 @@
 <?php
 switch ($_GET['step']) {
-  default:
-    $dsp->NewContent(t('Bugtracker Export'), t('Nutze diese Funktion um einen Export der Bugtracker-Einträge zu erstellen, den sie auf lansuite.de importieren können'));
-    $dsp->AddDoubleRow('', t('Bitte versuche Fehler zunächst selbst zu beheben und filter vor dem Export Probleme aus, die nicht von generellem Interesse für Lansuite sind. Es werden nur Probleme mit Status offen, oder bestätigt exportiert. Ergänze unvollständige Angaben, so gut du kannst. Danke, für die Hilfe!'));
-    $dsp->SetForm('index.php?mod=bugtracker&action=export&step=2');
-    $dsp->AddTextFieldRow('version', t('Version'), $config['lansuite']['version'], '');
-    $dsp->AddTextFieldRow('url', t('URL'), $_SERVER['SERVER_NAME'], '');
-    $dsp->AddFormSubmitRow('next');
-    $dsp->AddContent();
-  break;
+    default:
+        $dsp->NewContent(t('Bugtracker Export'), t('Nutze diese Funktion um einen Export der Bugtracker-Einträge zu erstellen, den sie auf lansuite.de importieren können'));
+        $dsp->AddDoubleRow('', t('Bitte versuche Fehler zunächst selbst zu beheben und filter vor dem Export Probleme aus, die nicht von generellem Interesse für Lansuite sind. Es werden nur Probleme mit Status offen, oder bestätigt exportiert. Ergänze unvollständige Angaben, so gut du kannst. Danke, für die Hilfe!'));
+        $dsp->SetForm('index.php?mod=bugtracker&action=export&step=2');
+        $dsp->AddTextFieldRow('version', t('Version'), $config['lansuite']['version'], '');
+        $dsp->AddTextFieldRow('url', t('URL'), $_SERVER['SERVER_NAME'], '');
+        $dsp->AddFormSubmitRow('next');
+        $dsp->AddContent();
+        break;
 
-  case 2:
-    include_once('modules/install/class_export.php');
-    $export = new export();
+    case 2:
+        include_once('modules/install/class_export.php');
+        $export = new export();
 
-    $export->LSTableHead('bugs.xml');
+        $export->LSTableHead('bugs.xml');
 
-    $entrys = '';
-    $res = $db->qry("SELECT * FROM %prefix%bugtracker WHERE state = 0 OR state = 1");
-    while ($row = $db->fetch_array($res)) {
-        $entry = '';
-        $data = '';
-        $data .= $xml->write_tag('caption', $row['caption'], 4);
-        $data .= $xml->write_tag('text', $row['text'], 4);
-        $data .= $xml->write_tag('version', $_POST['version'], 4);
-        $data .= $xml->write_tag('url', $_POST['url'], 4);
-        $data .= $xml->write_tag('priority', $row['priority'], 4);
-        $data .= $xml->write_tag('date', $row['date'], 4);
-        $data .= $xml->write_tag('type', $row['type'], 4);
-        $data .= $xml->write_tag('module', $row['module'], 4);
-        $data .= $xml->write_tag('state', $row['state'], 4);
-        $entry .= $xml->write_master_tag('main', $data, 3);
+        $entrys = '';
+        $res = $db->qry("SELECT * FROM %prefix%bugtracker WHERE state = 0 OR state = 1");
+        while ($row = $db->fetch_array($res)) {
+            $entry = '';
+            $data = '';
+            $data .= $xml->write_tag('caption', $row['caption'], 4);
+            $data .= $xml->write_tag('text', $row['text'], 4);
+            $data .= $xml->write_tag('version', $_POST['version'], 4);
+            $data .= $xml->write_tag('url', $_POST['url'], 4);
+            $data .= $xml->write_tag('priority', $row['priority'], 4);
+            $data .= $xml->write_tag('date', $row['date'], 4);
+            $data .= $xml->write_tag('type', $row['type'], 4);
+            $data .= $xml->write_tag('module', $row['module'], 4);
+            $data .= $xml->write_tag('state', $row['state'], 4);
+            $entry .= $xml->write_master_tag('main', $data, 3);
 
-        $comments = '';
-        $res2 = $db->qry("SELECT date, text FROM %prefix%comments WHERE relatedto_item = 'BugEintrag' AND relatedto_id = %int%", $row['bugid']);
-        while ($row2 = $db->fetch_array($res2)) {
-            $comment = '';
-            $comment .= $xml->write_tag('text', $row2['text'], 5);
-            $comment .= $xml->write_tag('date', $row2['date'], 5);
-            $comments .= $xml->write_master_tag('comment', $comment, 4);
+            $comments = '';
+            $res2 = $db->qry("SELECT date, text FROM %prefix%comments WHERE relatedto_item = 'BugEintrag' AND relatedto_id = %int%", $row['bugid']);
+            while ($row2 = $db->fetch_array($res2)) {
+                $comment = '';
+                $comment .= $xml->write_tag('text', $row2['text'], 5);
+                $comment .= $xml->write_tag('date', $row2['date'], 5);
+                $comments .= $xml->write_master_tag('comment', $comment, 4);
+            }
+            $db->free_result($res2);
+            $entry .= $xml->write_master_tag('comments', $comments, 3);
+            $entrys .= $xml->write_master_tag('entry', $entry, 2);
         }
-        $db->free_result($res2);
-        $entry .= $xml->write_master_tag('comments', $comments, 3);
-        $entrys .= $xml->write_master_tag('entry', $entry, 2);
-    }
-    $db->free_result($res);
+        $db->free_result($res);
 
-    $export->lansuite .= $xml->write_master_tag('entrys', $entrys, 1);
-    $export->LSTableFoot();
-  break;
+        $export->lansuite .= $xml->write_master_tag('entrys', $entrys, 1);
+        $export->LSTableFoot();
+        break;
 }

--- a/modules/bugtracker/import.php
+++ b/modules/bugtracker/import.php
@@ -1,33 +1,33 @@
 <?php
 switch ($_GET['step']) {
-  default:
-    $dsp->NewContent(t('Bugtracker Import'), t('Hier kannst du die bugs.xml-Datei Importieren, die du auf deiner Webseite exportiert hast'));
-    $dsp->SetForm('index.php?mod=bugtracker&action=import&step=2', '', '', 'multipart/form-data');
+    default:
+        $dsp->NewContent(t('Bugtracker Import'), t('Hier kannst du die bugs.xml-Datei Importieren, die du auf deiner Webseite exportiert hast'));
+        $dsp->SetForm('index.php?mod=bugtracker&action=import&step=2', '', '', 'multipart/form-data');
         $dsp->AddFileSelectRow("importdata", t('Import (.xml, .csv, .tgz)'), "");
-    $dsp->AddFormSubmitRow('next');
-    $dsp->AddContent();
-  break;
+        $dsp->AddFormSubmitRow('next');
+        $dsp->AddContent();
+        break;
 
-  case 2:
-    include_once('modules/install/class_import.php');
-    $import = new import();
-    $import->GetImportHeader($_FILES['importdata']['tmp_name']);
+    case 2:
+        include_once('modules/install/class_import.php');
+        $import = new import();
+        $import->GetImportHeader($_FILES['importdata']['tmp_name']);
 
-    $entrys = $xml->get_tag_content_array("entrys", $import->xml_content_lansuite);
-    $entry = $xml->get_tag_content_array("entry", $entrys[0]);
-    if ($entry) {
-        foreach ($entry as $entry_val) {
-            $main = $xml->get_tag_content_array("main", $entry_val);
-            $caption = $xml->get_tag_content("caption", $main[0]);
-            $text = $xml->get_tag_content("text", $main[0]);
-            $version = $xml->get_tag_content("version", $main[0]);
-            $url = $xml->get_tag_content("url", $main[0]);
-            $priority = $xml->get_tag_content("priority", $main[0]);
-            $date = $xml->get_tag_content("date", $main[0]);
-            $type = $xml->get_tag_content("type", $main[0]);
-            $module = $xml->get_tag_content("module", $main[0]);
-            $state = $xml->get_tag_content("state", $main[0]);
-            $db->qry("INSERT INTO %prefix%bugtracker SET
+        $entrys = $xml->get_tag_content_array("entrys", $import->xml_content_lansuite);
+        $entry = $xml->get_tag_content_array("entry", $entrys[0]);
+        if ($entry) {
+            foreach ($entry as $entry_val) {
+                $main = $xml->get_tag_content_array("main", $entry_val);
+                $caption = $xml->get_tag_content("caption", $main[0]);
+                $text = $xml->get_tag_content("text", $main[0]);
+                $version = $xml->get_tag_content("version", $main[0]);
+                $url = $xml->get_tag_content("url", $main[0]);
+                $priority = $xml->get_tag_content("priority", $main[0]);
+                $date = $xml->get_tag_content("date", $main[0]);
+                $type = $xml->get_tag_content("type", $main[0]);
+                $module = $xml->get_tag_content("module", $main[0]);
+                $state = $xml->get_tag_content("state", $main[0]);
+                $db->qry("INSERT INTO %prefix%bugtracker SET
         caption = '$caption',
         text = '$text',
         version = '$version',
@@ -39,15 +39,15 @@ switch ($_GET['step']) {
         state = ". (int)$state .",
         reporter = ". (int)$auth['userid'] ."
         ");
-            $bugid = $db->insert_id();
+                $bugid = $db->insert_id();
 
-            $comments = $xml->get_tag_content_array("comments", $entry_val);
-            $comment = $xml->get_tag_content_array("comment", $comments[0]);
-            if ($comment) {
-                foreach ($comment as $comment_val) {
-                    $text = $xml->get_tag_content("text", $comment_val);
-                    $date = $xml->get_tag_content("date", $comment_val);
-                    $db->qry("INSERT INTO %prefix%comments SET
+                $comments = $xml->get_tag_content_array("comments", $entry_val);
+                $comment = $xml->get_tag_content_array("comment", $comments[0]);
+                if ($comment) {
+                    foreach ($comment as $comment_val) {
+                        $text = $xml->get_tag_content("text", $comment_val);
+                        $date = $xml->get_tag_content("date", $comment_val);
+                        $db->qry("INSERT INTO %prefix%comments SET
           caption = %string%,
           text = %string%,
           date = %string%,
@@ -55,11 +55,11 @@ switch ($_GET['step']) {
           relatedto_item = 'BugEintrag',
           creatorid = %int%
           ", $caption, $text, $date, $bugid, $auth['userid']);
+                    }
                 }
             }
         }
-    }
     
-    $func->confirmation(('Import erfolgreich'));
-  break;
+        $func->confirmation(('Import erfolgreich'));
+        break;
 }

--- a/modules/bugtracker/import.php
+++ b/modules/bugtracker/import.php
@@ -1,9 +1,9 @@
 <?php
-switch($_GET['step']) {
+switch ($_GET['step']) {
   default:
     $dsp->NewContent(t('Bugtracker Import'), t('Hier kannst du die bugs.xml-Datei Importieren, die du auf deiner Webseite exportiert hast'));
     $dsp->SetForm('index.php?mod=bugtracker&action=import&step=2', '', '', 'multipart/form-data');
-		$dsp->AddFileSelectRow("importdata", t('Import (.xml, .csv, .tgz)'), "");
+        $dsp->AddFileSelectRow("importdata", t('Import (.xml, .csv, .tgz)'), "");
     $dsp->AddFormSubmitRow('next');
     $dsp->AddContent();
   break;
@@ -15,18 +15,19 @@ switch($_GET['step']) {
 
     $entrys = $xml->get_tag_content_array("entrys", $import->xml_content_lansuite);
     $entry = $xml->get_tag_content_array("entry", $entrys[0]);
-    if ($entry) foreach ($entry as $entry_val) {
-      $main = $xml->get_tag_content_array("main", $entry_val);
-      $caption = $xml->get_tag_content("caption", $main[0]);
-      $text = $xml->get_tag_content("text", $main[0]);
-      $version = $xml->get_tag_content("version", $main[0]);
-      $url = $xml->get_tag_content("url", $main[0]);
-      $priority = $xml->get_tag_content("priority", $main[0]);
-      $date = $xml->get_tag_content("date", $main[0]);
-      $type = $xml->get_tag_content("type", $main[0]);
-      $module = $xml->get_tag_content("module", $main[0]);
-      $state = $xml->get_tag_content("state", $main[0]);
-      $db->qry("INSERT INTO %prefix%bugtracker SET
+    if ($entry) {
+        foreach ($entry as $entry_val) {
+            $main = $xml->get_tag_content_array("main", $entry_val);
+            $caption = $xml->get_tag_content("caption", $main[0]);
+            $text = $xml->get_tag_content("text", $main[0]);
+            $version = $xml->get_tag_content("version", $main[0]);
+            $url = $xml->get_tag_content("url", $main[0]);
+            $priority = $xml->get_tag_content("priority", $main[0]);
+            $date = $xml->get_tag_content("date", $main[0]);
+            $type = $xml->get_tag_content("type", $main[0]);
+            $module = $xml->get_tag_content("module", $main[0]);
+            $state = $xml->get_tag_content("state", $main[0]);
+            $db->qry("INSERT INTO %prefix%bugtracker SET
         caption = '$caption',
         text = '$text',
         version = '$version',
@@ -38,14 +39,15 @@ switch($_GET['step']) {
         state = ". (int)$state .",
         reporter = ". (int)$auth['userid'] ."
         ");
-      $bugid = $db->insert_id();
+            $bugid = $db->insert_id();
 
-      $comments = $xml->get_tag_content_array("comments", $entry_val);
-      $comment = $xml->get_tag_content_array("comment", $comments[0]);
-      if ($comment) foreach ($comment as $comment_val) {
-        $text = $xml->get_tag_content("text", $comment_val);
-        $date = $xml->get_tag_content("date", $comment_val);
-        $db->qry("INSERT INTO %prefix%comments SET
+            $comments = $xml->get_tag_content_array("comments", $entry_val);
+            $comment = $xml->get_tag_content_array("comment", $comments[0]);
+            if ($comment) {
+                foreach ($comment as $comment_val) {
+                    $text = $xml->get_tag_content("text", $comment_val);
+                    $date = $xml->get_tag_content("date", $comment_val);
+                    $db->qry("INSERT INTO %prefix%comments SET
           caption = %string%,
           text = %string%,
           date = %string%,
@@ -53,10 +55,11 @@ switch($_GET['step']) {
           relatedto_item = 'BugEintrag',
           creatorid = %int%
           ", $caption, $text, $date, $bugid, $auth['userid']);
-      }
+                }
+            }
+        }
     }
     
     $func->confirmation(('Import erfolgreich'));
   break;
 }
-?>

--- a/modules/bugtracker/plugins/home.php
+++ b/modules/bugtracker/plugins/home.php
@@ -11,11 +11,17 @@ $query = $db->qry("SELECT b.*, MAX(UNIX_TIMESTAMP(b.changedate)) AS changedate, 
   LIMIT 0, %int%
   ", $cfg['home_item_cnt_bugtracker']);
 
-if ($db->num_rows($query) > 0) while($row = $db->fetch_array($query)) {
-  $smarty->assign('link', "index.php?mod=bugtracker&bugid={$row['bugid']}");
-  $smarty->assign('text', $func->CutString($row['caption'], 40));
-  $smarty->assign('text2', ' ['. $row['comments'] .']');
-  if ($func->CheckNewPosts($row['changedate'], 'bugtracker', $row['bugid'])) $content .= $smarty->fetch('modules/home/templates/show_row_new.htm');
-  else $content .= $smarty->fetch('modules/home/templates/show_row.htm');
-} else $content = "<i>". t('Keine Einträge vorhanden') ."</i>";
-?>
+if ($db->num_rows($query) > 0) {
+    while ($row = $db->fetch_array($query)) {
+        $smarty->assign('link', "index.php?mod=bugtracker&bugid={$row['bugid']}");
+        $smarty->assign('text', $func->CutString($row['caption'], 40));
+        $smarty->assign('text2', ' ['. $row['comments'] .']');
+        if ($func->CheckNewPosts($row['changedate'], 'bugtracker', $row['bugid'])) {
+            $content .= $smarty->fetch('modules/home/templates/show_row_new.htm');
+        } else {
+            $content .= $smarty->fetch('modules/home/templates/show_row.htm');
+        }
+    }
+} else {
+    $content = "<i>". t('Keine Einträge vorhanden') ."</i>";
+}

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -23,19 +23,19 @@ if ($_POST['action']) {
     foreach ($_POST['action'] as $key => $val) {
         if ($auth['type'] >= 2) {
             // Change state
-    if ($_GET['state'] != '' and $_GET['state'] >= 2) {
-        $bugtracker->SetBugState($key, $_GET['state']);
-    }
+            if ($_GET['state'] != '' and $_GET['state'] >= 2) {
+                $bugtracker->SetBugState($key, $_GET['state']);
+            }
 
     // Assign to new user
-    if ($_GET['userid'] != '') {
-        $bugtracker->AssignBugToUser($key, $_GET['userid']);
-    }
+            if ($_GET['userid'] != '') {
+                $bugtracker->AssignBugToUser($key, $_GET['userid']);
+            }
         } elseif ($auth['login']) {
             // Change state
-    if ($_GET['state'] != '' and ($_GET['state'] == 1 or $_GET['state'] == 2 or $_GET['state'] == 7)) {
-        $bugtracker->SetBugState($key, $_GET['state']);
-    }
+            if ($_GET['state'] != '' and ($_GET['state'] == 1 or $_GET['state'] == 2 or $_GET['state'] == 7)) {
+                $bugtracker->SetBugState($key, $_GET['state']);
+            }
         }
     }
 }
@@ -90,7 +90,7 @@ if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
     ";
     $ms2->query['where'] = '(!private OR '. (int)$auth['type'] .' >= 2)';
 #  $ms2->query['default_order_by'] = 'FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
-  $ms2->query['default_order_by'] = 'changedate DESC, FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
+    $ms2->query['default_order_by'] = 'changedate DESC, FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
     $ms2->config['EntriesPerPage'] = 50;
     $ms2->AddBGColor('state', $colors);
 
@@ -138,7 +138,7 @@ if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
   $ms2->AddTextSearchDropDown('Typ', 'b.type', $list);
 */
 
-  $ms2->AddResultField(t('Titel'), 'b.caption');
+    $ms2->AddResultField(t('Titel'), 'b.caption');
     $ms2->AddSelect('r.userid');
     $ms2->AddSelect('b.price');
     $ms2->AddSelect('b.price_payed');
@@ -189,8 +189,7 @@ if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
     $row = $db->qry_first("SELECT b.*, UNIX_TIMESTAMP(b.changedate) AS changedate, UNIX_TIMESTAMP(b.date) AS date, r.username AS reporter_name, a.username AS agent_name FROM %prefix%bugtracker AS b
     LEFT JOIN %prefix%user AS r ON b.reporter = r.userid
     LEFT JOIN %prefix%user AS a ON b.agent = a.userid
-    WHERE bugid = %int% AND (!private OR ". (int)$auth['type'] ." >= 2)", $_GET['bugid']
-    );
+    WHERE bugid = %int% AND (!private OR ". (int)$auth['type'] ." >= 2)", $_GET['bugid']);
 
     $dsp->NewContent($row['caption'], $types[$row['type']] .', '. t('Priorität') .': '. $row['priority']);
     $dsp->StartTabs();

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -19,99 +19,118 @@ $colors[5] = '#aaaaaa';
 $colors[6] = '#999999';
 $colors[7] = '#bc851b';
 
-if ($_POST['action']) foreach ($_POST['action'] as $key => $val) {
-  if ($auth['type'] >= 2) {
-    // Change state
-    if ($_GET['state'] != '' and $_GET['state'] >= 2) $bugtracker->SetBugState($key, $_GET['state']);
+if ($_POST['action']) {
+    foreach ($_POST['action'] as $key => $val) {
+        if ($auth['type'] >= 2) {
+            // Change state
+    if ($_GET['state'] != '' and $_GET['state'] >= 2) {
+        $bugtracker->SetBugState($key, $_GET['state']);
+    }
 
     // Assign to new user
-    if ($_GET['userid'] != '') $bugtracker->AssignBugToUser($key, $_GET['userid']);
-
-  } elseif ($auth['login']) {
-    // Change state
-    if ($_GET['state'] != '' and ($_GET['state'] == 1 or $_GET['state'] == 2 or $_GET['state'] == 7)) $bugtracker->SetBugState($key, $_GET['state']);
-  }
+    if ($_GET['userid'] != '') {
+        $bugtracker->AssignBugToUser($key, $_GET['userid']);
+    }
+        } elseif ($auth['login']) {
+            // Change state
+    if ($_GET['state'] != '' and ($_GET['state'] == 1 or $_GET['state'] == 2 or $_GET['state'] == 7)) {
+        $bugtracker->SetBugState($key, $_GET['state']);
+    }
+        }
+    }
 }
 
 if ($_GET['action'] == 'delete' and $auth['type'] >= 2) {
-  if ($_GET['bugid'] != '') {
-    include_once('inc/classes/class_masterdelete.php');
-    $md = new masterdelete();
-    $md->Delete('bugtracker', 'bugid', $_GET['bugid']);
-  } else {
-    include_once('inc/classes/class_masterdelete.php');
-    $md = new masterdelete();
-    $md->MultiDelete('bugtracker', 'bugid');
-  }
+    if ($_GET['bugid'] != '') {
+        include_once('inc/classes/class_masterdelete.php');
+        $md = new masterdelete();
+        $md->Delete('bugtracker', 'bugid', $_GET['bugid']);
+    } else {
+        include_once('inc/classes/class_masterdelete.php');
+        $md = new masterdelete();
+        $md->MultiDelete('bugtracker', 'bugid');
+    }
 }
 
-function FetchState($state) {
-  global $bugtracker;
-  return $bugtracker->stati[$state];
+function FetchState($state)
+{
+    global $bugtracker;
+    return $bugtracker->stati[$state];
 }
 
-function FetchType($type) {
-  global $types, $line;
+function FetchType($type)
+{
+    global $types, $line;
 
-  $ret = $types[$type];
-  if ($line['price']) $ret .= '<br /><span style="white-space:nowrap;">'. (int)$line['price_payed'] .'&euro; / '. $line['price'] .'&euro; ['. (round((((int)$line['price_payed'] / (int)$line['price']) * 100), 1)) .'%]</span>';
-  return $ret;
+    $ret = $types[$type];
+    if ($line['price']) {
+        $ret .= '<br /><span style="white-space:nowrap;">'. (int)$line['price_payed'] .'&euro; / '. $line['price'] .'&euro; ['. (round((((int)$line['price_payed'] / (int)$line['price']) * 100), 1)) .'%]</span>';
+    }
+    return $ret;
 }
 
 if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
-  $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der Verwendung dieses Systems auftreten, sowie Feature Wünsche äußern. Können die Admins dieser Webseite sie nicht selbst beheben, haben diese die Möglichkeit sie an das Lansuite-Team weiterzureichen.'));
+    $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der Verwendung dieses Systems auftreten, sowie Feature Wünsche äußern. Können die Admins dieser Webseite sie nicht selbst beheben, haben diese die Möglichkeit sie an das Lansuite-Team weiterzureichen.'));
 
-  include_once('modules/mastersearch2/class_mastersearch2.php');
-  $ms2 = new mastersearch2('bugtracker');
+    include_once('modules/mastersearch2/class_mastersearch2.php');
+    $ms2 = new mastersearch2('bugtracker');
 
-  $quicklink = array();
-  $quicklink['name'] = 'Fehler (offen)';
-  $quicklink['link'] = 'index.php?mod=bugtracker&order_by=&order_dir=&EntsPerPage=&search_input%5B0%5D=&search_input%5B1%5D=&search_dd_input%5B0%5D=&search_dd_input%5B1%5D=&search_dd_input%5B2%5D=&search_dd_input%5B3%5D=&search_dd_input%5B4%5D%5B%5D=0&search_dd_input%5B4%5D%5B%5D=1&search_dd_input%5B4%5D%5B%5D=2&search_dd_input%5B4%5D%5B%5D=3&search_dd_input%5B4%5D%5B%5D=5&search_dd_input%5B4%5D%5B%5D=7&search_dd_input%5B5%5D%5B%5D=2&search_dd_input%5B5%5D%5B%5D=3&search_dd_input%5B5%5D%5B%5D=4&search_dd_input%5B5%5D%5B%5D=5&suchen=Suchen';
-  $ms2->quicklinks[] = $quicklink;
-  $quicklink['name'] = 'Wünsche (offen)';
-  $quicklink['link'] = 'index.php?mod=bugtracker&order_by=&order_dir=&EntsPerPage=&search_input%5B0%5D=&search_input%5B1%5D=&search_dd_input%5B0%5D=&search_dd_input%5B1%5D=&search_dd_input%5B2%5D=&search_dd_input%5B3%5D=&search_dd_input%5B4%5D%5B%5D=0&search_dd_input%5B4%5D%5B%5D=1&search_dd_input%5B4%5D%5B%5D=2&search_dd_input%5B4%5D%5B%5D=3&search_dd_input%5B4%5D%5B%5D=5&search_dd_input%5B4%5D%5B%5D=7&search_dd_input%5B5%5D%5B%5D=1&suchen=Suchen';
-  $ms2->quicklinks[] = $quicklink;
+    $quicklink = array();
+    $quicklink['name'] = 'Fehler (offen)';
+    $quicklink['link'] = 'index.php?mod=bugtracker&order_by=&order_dir=&EntsPerPage=&search_input%5B0%5D=&search_input%5B1%5D=&search_dd_input%5B0%5D=&search_dd_input%5B1%5D=&search_dd_input%5B2%5D=&search_dd_input%5B3%5D=&search_dd_input%5B4%5D%5B%5D=0&search_dd_input%5B4%5D%5B%5D=1&search_dd_input%5B4%5D%5B%5D=2&search_dd_input%5B4%5D%5B%5D=3&search_dd_input%5B4%5D%5B%5D=5&search_dd_input%5B4%5D%5B%5D=7&search_dd_input%5B5%5D%5B%5D=2&search_dd_input%5B5%5D%5B%5D=3&search_dd_input%5B5%5D%5B%5D=4&search_dd_input%5B5%5D%5B%5D=5&suchen=Suchen';
+    $ms2->quicklinks[] = $quicklink;
+    $quicklink['name'] = 'Wünsche (offen)';
+    $quicklink['link'] = 'index.php?mod=bugtracker&order_by=&order_dir=&EntsPerPage=&search_input%5B0%5D=&search_input%5B1%5D=&search_dd_input%5B0%5D=&search_dd_input%5B1%5D=&search_dd_input%5B2%5D=&search_dd_input%5B3%5D=&search_dd_input%5B4%5D%5B%5D=0&search_dd_input%5B4%5D%5B%5D=1&search_dd_input%5B4%5D%5B%5D=2&search_dd_input%5B4%5D%5B%5D=3&search_dd_input%5B4%5D%5B%5D=5&search_dd_input%5B4%5D%5B%5D=7&search_dd_input%5B5%5D%5B%5D=1&suchen=Suchen';
+    $ms2->quicklinks[] = $quicklink;
 
-  $ms2->query['from'] = "%prefix%bugtracker AS b
+    $ms2->query['from'] = "%prefix%bugtracker AS b
     LEFT JOIN %prefix%user AS r ON b.reporter = r.userid
     LEFT JOIN %prefix%user AS a ON b.agent = a.userid
     LEFT JOIN %prefix%comments AS c ON (c.relatedto_id = b.bugid AND c.relatedto_item = 'BugEintrag')
     ";
-  $ms2->query['where'] = '(!private OR '. (int)$auth['type'] .' >= 2)';
+    $ms2->query['where'] = '(!private OR '. (int)$auth['type'] .' >= 2)';
 #  $ms2->query['default_order_by'] = 'FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
   $ms2->query['default_order_by'] = 'changedate DESC, FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
-  $ms2->config['EntriesPerPage'] = 50;
-  $ms2->AddBGColor('state', $colors);
+    $ms2->config['EntriesPerPage'] = 50;
+    $ms2->AddBGColor('state', $colors);
 
-  $ms2->AddTextSearchField(t('Überschrift'), array('b.caption' => 'like'));
-  $ms2->AddTextSearchField(t('Text'), array('b.text' => 'fulltext', 'c.text' => 'fulltext'));
+    $ms2->AddTextSearchField(t('Überschrift'), array('b.caption' => 'like'));
+    $ms2->AddTextSearchField(t('Text'), array('b.text' => 'fulltext', 'c.text' => 'fulltext'));
 
-  $list = array('' => 'Alle');
-  $row = $db->qry('SELECT b.reporter, u.username FROM %prefix%bugtracker AS b LEFT JOIN %prefix%user AS u ON b.reporter = u.userid WHERE b.reporter > 0 ORDER BY u.username');
-  while($res = $db->fetch_array($row)) $list[$res['reporter']] = $res['username'];
-  $db->free_result($row);
-  $ms2->AddTextSearchDropDown('Reporter', 'b.reporter', $list);
+    $list = array('' => 'Alle');
+    $row = $db->qry('SELECT b.reporter, u.username FROM %prefix%bugtracker AS b LEFT JOIN %prefix%user AS u ON b.reporter = u.userid WHERE b.reporter > 0 ORDER BY u.username');
+    while ($res = $db->fetch_array($row)) {
+        $list[$res['reporter']] = $res['username'];
+    }
+    $db->free_result($row);
+    $ms2->AddTextSearchDropDown('Reporter', 'b.reporter', $list);
 
-  $list = array('' => 'Alle');
-  $row = $db->qry('SELECT module FROM %prefix%bugtracker WHERE module != "" GROUP BY module ORDER BY module');
-  while($res = $db->fetch_array($row)) $list[$res['module']] = $res['module'];
-  $db->free_result($row);
-  $ms2->AddTextSearchDropDown('Modul', 'module', $list);
+    $list = array('' => 'Alle');
+    $row = $db->qry('SELECT module FROM %prefix%bugtracker WHERE module != "" GROUP BY module ORDER BY module');
+    while ($res = $db->fetch_array($row)) {
+        $list[$res['module']] = $res['module'];
+    }
+    $db->free_result($row);
+    $ms2->AddTextSearchDropDown('Modul', 'module', $list);
 
-  $list = array('' => 'Alle');
-  $row = $db->qry('SELECT b.agent, u.username FROM %prefix%bugtracker AS b LEFT JOIN %prefix%user AS u ON b.agent = u.userid WHERE b.agent > 0 ORDER BY u.username');
-  while($res = $db->fetch_array($row)) $list[$res['agent']] = $res['username'];
-  $db->free_result($row);
-  $ms2->AddTextSearchDropDown('Bearbeiter', 'b.agent', $list);
+    $list = array('' => 'Alle');
+    $row = $db->qry('SELECT b.agent, u.username FROM %prefix%bugtracker AS b LEFT JOIN %prefix%user AS u ON b.agent = u.userid WHERE b.agent > 0 ORDER BY u.username');
+    while ($res = $db->fetch_array($row)) {
+        $list[$res['agent']] = $res['username'];
+    }
+    $db->free_result($row);
+    $ms2->AddTextSearchDropDown('Bearbeiter', 'b.agent', $list);
 
-  $list = array('' => 'Alle');
-  $row = $db->qry('SELECT c.creatorid, u.username FROM %prefix%comments AS c LEFT JOIN %prefix%user AS u ON c.creatorid = u.userid WHERE c.creatorid > 0 AND c.relatedto_item = \'BugEintrag\' ORDER BY u.username');
-  while($res = $db->fetch_array($row)) $list[$res['creatorid']] = $res['username'];
-  $db->free_result($row);
-  $ms2->AddTextSearchDropDown('Kommentator', 'c.creatorid', $list);
+    $list = array('' => 'Alle');
+    $row = $db->qry('SELECT c.creatorid, u.username FROM %prefix%comments AS c LEFT JOIN %prefix%user AS u ON c.creatorid = u.userid WHERE c.creatorid > 0 AND c.relatedto_item = \'BugEintrag\' ORDER BY u.username');
+    while ($res = $db->fetch_array($row)) {
+        $list[$res['creatorid']] = $res['username'];
+    }
+    $db->free_result($row);
+    $ms2->AddTextSearchDropDown('Kommentator', 'c.creatorid', $list);
 
-  $ms2->AddTextSearchDropDown('Status', 'b.state', $bugtracker->stati, '', 8);
-  $ms2->AddTextSearchDropDown('Typ', 'b.type', $types, '', 5);
+    $ms2->AddTextSearchDropDown('Status', 'b.state', $bugtracker->stati, '', 8);
+    $ms2->AddTextSearchDropDown('Typ', 'b.type', $types, '', 5);
 
 /*
   $list = array('' => 'Alle'));
@@ -120,118 +139,138 @@ if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
 */
 
   $ms2->AddResultField(t('Titel'), 'b.caption');
-  $ms2->AddSelect('r.userid');
-  $ms2->AddSelect('b.price');
-  $ms2->AddSelect('b.price_payed');
-  $ms2->AddResultField(t('Typ'), 'b.type', 'FetchType');
-  $ms2->AddResultField(t('Prio.'), 'b.priority');
-  $ms2->AddResultField(t('Status'), 'b.state', 'FetchState');
-  $ms2->AddResultField(t('Reporter'), 'r.username AS reporter', 'UserNameAndIcon');
-  $ms2->AddResultField(t('Bearbeiter'), 'a.username AS agent');
-  $ms2->AddResultField(t('Antw.'), 'COUNT(c.relatedto_id) AS comments');
-  $ms2->AddResultField(t('Datum'), 'UNIX_TIMESTAMP(b.date) AS date', 'MS2GetDate');
-  $ms2->AddResultField(t('Letzte Änderung'), 'UNIX_TIMESTAMP(b.changedate) AS changedate', 'MS2GetDate');
+    $ms2->AddSelect('r.userid');
+    $ms2->AddSelect('b.price');
+    $ms2->AddSelect('b.price_payed');
+    $ms2->AddResultField(t('Typ'), 'b.type', 'FetchType');
+    $ms2->AddResultField(t('Prio.'), 'b.priority');
+    $ms2->AddResultField(t('Status'), 'b.state', 'FetchState');
+    $ms2->AddResultField(t('Reporter'), 'r.username AS reporter', 'UserNameAndIcon');
+    $ms2->AddResultField(t('Bearbeiter'), 'a.username AS agent');
+    $ms2->AddResultField(t('Antw.'), 'COUNT(c.relatedto_id) AS comments');
+    $ms2->AddResultField(t('Datum'), 'UNIX_TIMESTAMP(b.date) AS date', 'MS2GetDate');
+    $ms2->AddResultField(t('Letzte Änderung'), 'UNIX_TIMESTAMP(b.changedate) AS changedate', 'MS2GetDate');
 
-  $ms2->SetTargetPage('comments', 20);
+    $ms2->SetTargetPage('comments', 20);
 
-  $ms2->AddIconField('details', 'index.php?mod=bugtracker&bugid=%id%&ms_page=%page%', t('Details'));
-  if ($auth['type'] >= 2) $ms2->AddIconField('edit', 'index.php?mod=bugtracker&action=add&bugid=', t('Editieren'));
-  if ($auth['type'] >= 3) $ms2->AddIconField('delete', 'index.php?mod=bugtracker&action=delete&bugid=', t('Löschen'));
+    $ms2->AddIconField('details', 'index.php?mod=bugtracker&bugid=%id%&ms_page=%page%', t('Details'));
+    if ($auth['type'] >= 2) {
+        $ms2->AddIconField('edit', 'index.php?mod=bugtracker&action=add&bugid=', t('Editieren'));
+    }
+    if ($auth['type'] >= 3) {
+        $ms2->AddIconField('delete', 'index.php?mod=bugtracker&action=delete&bugid=', t('Löschen'));
+    }
 
-  if ($auth['type'] >= 2) {
-    foreach($bugtracker->stati as $key => $val) $ms2->AddMultiSelectAction(t('Status') .' -> '. $val, 'index.php?mod=bugtracker&state='. $key);
+    if ($auth['type'] >= 2) {
+        foreach ($bugtracker->stati as $key => $val) {
+            $ms2->AddMultiSelectAction(t('Status') .' -> '. $val, 'index.php?mod=bugtracker&state='. $key);
+        }
 
-    $ms2->AddMultiSelectAction(t('Bearbeiter löschen'), 'index.php?mod=bugtracker&userid=0');
-    $res = $db->qry("SELECT userid, username FROM %prefix%user WHERE type >= 2");
-    while ($row = $db->fetch_array($res)) $ms2->AddMultiSelectAction(t('Bearbeiter') .' -> '. $row['username'], 'index.php?mod=bugtracker&userid='. $row['userid']);
-    $db->free_result($res);
+        $ms2->AddMultiSelectAction(t('Bearbeiter löschen'), 'index.php?mod=bugtracker&userid=0');
+        $res = $db->qry("SELECT userid, username FROM %prefix%user WHERE type >= 2");
+        while ($row = $db->fetch_array($res)) {
+            $ms2->AddMultiSelectAction(t('Bearbeiter') .' -> '. $row['username'], 'index.php?mod=bugtracker&userid='. $row['userid']);
+        }
+        $db->free_result($res);
 
-    $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=bugtracker&action=delete');
+        $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=bugtracker&action=delete');
+    } elseif ($auth['login']) {
+        $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[1], 'index.php?mod=bugtracker&state=1');
+        $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[2], 'index.php?mod=bugtracker&state=2');
+        $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[7], 'index.php?mod=bugtracker&state=7');
+    }
 
-  } elseif ($auth['login']) {
-    $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[1], 'index.php?mod=bugtracker&state=1');
-    $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[2], 'index.php?mod=bugtracker&state=2');
-    $ms2->AddMultiSelectAction(t('Status') .' -> '. $bugtracker->stati[7], 'index.php?mod=bugtracker&state=7');
-  }
-
-  $ms2->PrintSearch('index.php?mod=bugtracker', 'b.bugid');
+    $ms2->PrintSearch('index.php?mod=bugtracker', 'b.bugid');
 
 // Details page
 } else {
-  $func->SetRead('bugtracker', $_GET['bugid']);
+    $func->SetRead('bugtracker', $_GET['bugid']);
 
-  $row = $db->qry_first("SELECT b.*, UNIX_TIMESTAMP(b.changedate) AS changedate, UNIX_TIMESTAMP(b.date) AS date, r.username AS reporter_name, a.username AS agent_name FROM %prefix%bugtracker AS b
+    $row = $db->qry_first("SELECT b.*, UNIX_TIMESTAMP(b.changedate) AS changedate, UNIX_TIMESTAMP(b.date) AS date, r.username AS reporter_name, a.username AS agent_name FROM %prefix%bugtracker AS b
     LEFT JOIN %prefix%user AS r ON b.reporter = r.userid
     LEFT JOIN %prefix%user AS a ON b.agent = a.userid
     WHERE bugid = %int% AND (!private OR ". (int)$auth['type'] ." >= 2)", $_GET['bugid']
     );
 
-  $dsp->NewContent($row['caption'], $types[$row['type']] .', '. t('Priorität') .': '. $row['priority']);
-  $dsp->StartTabs();
+    $dsp->NewContent($row['caption'], $types[$row['type']] .', '. t('Priorität') .': '. $row['priority']);
+    $dsp->StartTabs();
   
-  $dsp->StartTab(t('Eintrag und Kommentare'), 'details');
-  $framework->AddToPageTitle($row['caption']);
+    $dsp->StartTab(t('Eintrag und Kommentare'), 'details');
+    $framework->AddToPageTitle($row['caption']);
 
-  $dsp->AddDoubleRow(t('Herkunft'), '<a href="http://'. $row['url'] .'" target="_blank">'. $row['url'] .'</a> Version('. $row['version'] .')');
-  $dsp->AddDoubleRow(t('Reporter'), $dsp->FetchUserIcon($row['reporter'], $row['reporter_name']));
-  $dsp->AddDoubleRow(t('Betrifft Modul'), $row['module']);
-  $dsp->AddDoubleRow(t('Meldezeitpunkt'), $func->unixstamp2date($row['date'], 'daydatetime'));
-  $dsp->AddDoubleRow(t('Letzte Änderung'), $func->unixstamp2date($row['changedate'], 'daydatetime'));
+    $dsp->AddDoubleRow(t('Herkunft'), '<a href="http://'. $row['url'] .'" target="_blank">'. $row['url'] .'</a> Version('. $row['version'] .')');
+    $dsp->AddDoubleRow(t('Reporter'), $dsp->FetchUserIcon($row['reporter'], $row['reporter_name']));
+    $dsp->AddDoubleRow(t('Betrifft Modul'), $row['module']);
+    $dsp->AddDoubleRow(t('Meldezeitpunkt'), $func->unixstamp2date($row['date'], 'daydatetime'));
+    $dsp->AddDoubleRow(t('Letzte Änderung'), $func->unixstamp2date($row['changedate'], 'daydatetime'));
 
-  $dsp->AddDoubleRow(t('Status'), $bugtracker->stati[$row['state']]);
-        if ($row['price']) $dsp->AddDoubleRow(t('Gespendet'), (int)$row['price_payed'] .'&euro; / '. $row['price'] .'&euro; ['. (round((((int)$row['price_payed'] / (int)$row['price']) * 100), 1)) .'%]<br /><font color="red">'. t('Dieses Feature wird erst umgesetzt, wenn genug dafür gespendet wurde. Um selbst etwas zu Spenden, schreibe bitte den eingetragenen Bearbeiter an. Dieser kann dir dann seine Kontodaten mitteilen') .'</font>');
-  if ($row['agent']) $dsp->AddDoubleRow(t('Bearbeiter'), $dsp->FetchUserIcon($row['agent'], $row['agent_name']));
-  else $dsp->AddDoubleRow(t('Bearbeiter'), t('Noch nicht zugeordnet'));
-
-  if ($row['revision']) $dsp->AddDoubleRow(t('SVN-Revision'), $row['revision'] .' (<a href="http://code.google.com/p/lansuite/source/detail?r='. $row['revision'] .'" target="_blank">'. t('Änderungen anzeigen') .'</a>)');
-
-  if ($auth['type'] >= 2) {
-    include_once('inc/classes/class_masterform.php');
-    $mf = new masterform();
-    $mf->AddField(t('Fix in SVN-Revision'), 'revision');
-    $mf->SendForm('', 'bugtracker', 'bugid', $_GET['bugid']);
-  }
-
-  $dsp->AddDoubleRow(t('Text'), $func->text2html($row['text']));
-  if ($row['file']) $dsp->AddDoubleRow(t('Anhang'), $dsp->FetchAttachmentRow($row['file']));
-  $dsp->AddDoubleRow('', $dsp->FetchSpanButton(t('Editieren'), 'index.php?mod=bugtracker&action=add&bugid='.$row['bugid']) . $dsp->FetchSpanButton(t('Zurück zur Übersicht'), 'index.php?mod=bugtracker'));
-
-  if ($auth['login']) {
-    include_once('inc/classes/class_masterform.php');
-    $mf = new masterform();
-    $mf->ManualUpdate = 1;
-    if ($auth['type'] >= 2) $mf->AddField(t('Status'), 'state', IS_SELECTION, $bugtracker->stati);
-    elseif ($row['state'] == 0) $mf->AddField(t('Status'), 'state', IS_SELECTION, array('1' => $bugtracker->stati['1']));
-    elseif ($row['state'] == 4) $mf->AddField(t('Status'), 'state', IS_SELECTION, array('7' => $bugtracker->stati['7']));
-    elseif ($row['state'] == 3) $mf->AddField(t('Status'), 'state', IS_SELECTION, array('2' => $bugtracker->stati['2']));
-
-    if ($mf->SendForm('', 'bugtracker', 'bugid', $_GET['bugid'])) {
-      $bugtracker->SetBugState($_GET['bugid'], $_POST['state']);
-      $func->confirmation(t('Geändert'), $mf->LinkBack);
+    $dsp->AddDoubleRow(t('Status'), $bugtracker->stati[$row['state']]);
+    if ($row['price']) {
+        $dsp->AddDoubleRow(t('Gespendet'), (int)$row['price_payed'] .'&euro; / '. $row['price'] .'&euro; ['. (round((((int)$row['price_payed'] / (int)$row['price']) * 100), 1)) .'%]<br /><font color="red">'. t('Dieses Feature wird erst umgesetzt, wenn genug dafür gespendet wurde. Um selbst etwas zu Spenden, schreibe bitte den eingetragenen Bearbeiter an. Dieser kann dir dann seine Kontodaten mitteilen') .'</font>');
     }
-  }
+    if ($row['agent']) {
+        $dsp->AddDoubleRow(t('Bearbeiter'), $dsp->FetchUserIcon($row['agent'], $row['agent_name']));
+    } else {
+        $dsp->AddDoubleRow(t('Bearbeiter'), t('Noch nicht zugeordnet'));
+    }
 
-  include('inc/classes/class_mastercomment.php');
-  new Mastercomment('BugEintrag', $_GET['bugid'], array('bugtracker' => 'bugid'));
-  $dsp->EndTab();
+    if ($row['revision']) {
+        $dsp->AddDoubleRow(t('SVN-Revision'), $row['revision'] .' (<a href="http://code.google.com/p/lansuite/source/detail?r='. $row['revision'] .'" target="_blank">'. t('Änderungen anzeigen') .'</a>)');
+    }
 
-  $dsp->StartTab(t('Log'), 'save');
-  include_once('modules/mastersearch2/class_mastersearch2.php');
-  $ms2 = new mastersearch2('bugtracker');
+    if ($auth['type'] >= 2) {
+        include_once('inc/classes/class_masterform.php');
+        $mf = new masterform();
+        $mf->AddField(t('Fix in SVN-Revision'), 'revision');
+        $mf->SendForm('', 'bugtracker', 'bugid', $_GET['bugid']);
+    }
 
-  $ms2->query['from'] = "%prefix%log AS l LEFT JOIN %prefix%user AS u ON l.userid = u.userid";
-  $ms2->query['where'] = "(sort_tag = 'bugtracker' AND target_id = ". (int)$_GET['bugid'] .')';
-  $ms2->config['EntriesPerPage'] = 50;
+    $dsp->AddDoubleRow(t('Text'), $func->text2html($row['text']));
+    if ($row['file']) {
+        $dsp->AddDoubleRow(t('Anhang'), $dsp->FetchAttachmentRow($row['file']));
+    }
+    $dsp->AddDoubleRow('', $dsp->FetchSpanButton(t('Editieren'), 'index.php?mod=bugtracker&action=add&bugid='.$row['bugid']) . $dsp->FetchSpanButton(t('Zurück zur Übersicht'), 'index.php?mod=bugtracker'));
 
-  $ms2->AddResultField('', 'l.description');
-  $ms2->AddSelect('u.userid');
-  $ms2->AddResultField('', 'u.username', 'UserNameAndIcon');
-  $ms2->AddResultField('', 'UNIX_TIMESTAMP(l.date) AS date', 'MS2GetDate');
-  $ms2->PrintSearch('index.php?mod=bugtracker&bugid='. $_GET['bugid'], 'logid');
-  $dsp->EndTab();
+    if ($auth['login']) {
+        include_once('inc/classes/class_masterform.php');
+        $mf = new masterform();
+        $mf->ManualUpdate = 1;
+        if ($auth['type'] >= 2) {
+            $mf->AddField(t('Status'), 'state', IS_SELECTION, $bugtracker->stati);
+        } elseif ($row['state'] == 0) {
+            $mf->AddField(t('Status'), 'state', IS_SELECTION, array('1' => $bugtracker->stati['1']));
+        } elseif ($row['state'] == 4) {
+            $mf->AddField(t('Status'), 'state', IS_SELECTION, array('7' => $bugtracker->stati['7']));
+        } elseif ($row['state'] == 3) {
+            $mf->AddField(t('Status'), 'state', IS_SELECTION, array('2' => $bugtracker->stati['2']));
+        }
+
+        if ($mf->SendForm('', 'bugtracker', 'bugid', $_GET['bugid'])) {
+            $bugtracker->SetBugState($_GET['bugid'], $_POST['state']);
+            $func->confirmation(t('Geändert'), $mf->LinkBack);
+        }
+    }
+
+    include('inc/classes/class_mastercomment.php');
+    new Mastercomment('BugEintrag', $_GET['bugid'], array('bugtracker' => 'bugid'));
+    $dsp->EndTab();
+
+    $dsp->StartTab(t('Log'), 'save');
+    include_once('modules/mastersearch2/class_mastersearch2.php');
+    $ms2 = new mastersearch2('bugtracker');
+
+    $ms2->query['from'] = "%prefix%log AS l LEFT JOIN %prefix%user AS u ON l.userid = u.userid";
+    $ms2->query['where'] = "(sort_tag = 'bugtracker' AND target_id = ". (int)$_GET['bugid'] .')';
+    $ms2->config['EntriesPerPage'] = 50;
+
+    $ms2->AddResultField('', 'l.description');
+    $ms2->AddSelect('u.userid');
+    $ms2->AddResultField('', 'u.username', 'UserNameAndIcon');
+    $ms2->AddResultField('', 'UNIX_TIMESTAMP(l.date) AS date', 'MS2GetDate');
+    $ms2->PrintSearch('index.php?mod=bugtracker&bugid='. $_GET['bugid'], 'logid');
+    $dsp->EndTab();
   
-  $dsp->EndTabs();
+    $dsp->EndTabs();
 }
 
 $dsp->AddContent();
-?>


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.