### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/server2

### DIFF
--- a/modules/server2/admin.php
+++ b/modules/server2/admin.php
@@ -1,12 +1,11 @@
 <?php
 ob_start();
 
-define ('PHGDIR', 'ext_scripts/lgsl/');
+define('PHGDIR', 'ext_scripts/lgsl/');
 $use_file = 'index.php?mod=server2'; #basename(__FILE__);
 $use_bind = '&';#'?';
-require_once (PHGDIR . 'admin.php');
+require_once(PHGDIR . 'admin.php');
 
 $phg_content = ob_get_contents();
 ob_end_clean();
 $dsp->AddSingleRow($phg_content);
-?>

--- a/modules/server2/show.php
+++ b/modules/server2/show.php
@@ -1,10 +1,10 @@
 <?php
 ob_start();
 
-define ('PHGDIR', 'ext_scripts/lgsl/');
+define('PHGDIR', 'ext_scripts/lgsl/');
 $use_file = 'index.php?mod=server2'; #basename(__FILE__);
 $use_bind = '&';#'?';
-require_once (PHGDIR . 'index.php');
+require_once(PHGDIR . 'index.php');
 
 $phg_content = ob_get_contents();
 ob_end_clean();
@@ -22,4 +22,3 @@ td {
 </style>
 ';*/
 $dsp->AddSingleRow($style . $phg_content);
-?>


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.