### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/helplet

### DIFF
--- a/modules/helplet/helplet.php
+++ b/modules/helplet/helplet.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 $file = "modules/{$_GET['module']}/docu/{$language}_{$_GET['helpletid']}.php";
 if (!file_exists($file)) {

--- a/modules/helplet/helplet.php
+++ b/modules/helplet/helplet.php
@@ -1,16 +1,20 @@
 <?php 
 
 $file = "modules/{$_GET['module']}/docu/{$language}_{$_GET['helpletid']}.php";
-if (!file_exists($file)) $func->information(t('Zu diesem Modul steht leider derzeit keine Hilfe zur Verfügung'), NO_LINK);
-else {
-  include($file);
+if (!file_exists($file)) {
+    $func->information(t('Zu diesem Modul steht leider derzeit keine Hilfe zur Verfügung'), NO_LINK);
+} else {
+    include($file);
 
-  $dsp->NewContent($helplet['modul'] .' ('. $helplet['action'] .')', $helplet['info']);
-  $dsp->AddHruleRow();
+    $dsp->NewContent($helplet['modul'] .' ('. $helplet['action'] .')', $helplet['info']);
+    $dsp->AddHruleRow();
 
-  if ($helplet['key']) foreach ($helplet['key'] as $key) {
-  	$value = array_shift($helplet['value']);
-  	if ($key) $dsp->AddDoubleRow($key, $value);
-  }
+    if ($helplet['key']) {
+        foreach ($helplet['key'] as $key) {
+            $value = array_shift($helplet['value']);
+            if ($key) {
+                $dsp->AddDoubleRow($key, $value);
+            }
+        }
+    }
 }
-?>


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.