### PR TITLE
Apply coding style guide PSR 1 and PSR 2 to ./modules/popups

### DIFF
--- a/modules/popups/ls_row_textareamail_popup.php
+++ b/modules/popups/ls_row_textareamail_popup.php
@@ -4,11 +4,12 @@ $dsp->NewContent('Variable anklicken, um es ins Textfeld einzufügen');
 $variable = $db->qry("SELECT shortcut, title FROM %prefix%variables");
 $out = '';
 $z = 0;
-while($variables = $db->fetch_array($variable)){
-  $out .= '<a href="#" onclick="javascript:InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \''. $variables['shortcut'] .'\'); return false">'.$variables['title'].'</a>';
-  $z++;
-  if ($z % 1 == 0) $out .= '<br />';
+while ($variables = $db->fetch_array($variable)) {
+    $out .= '<a href="#" onclick="javascript:InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \''. $variables['shortcut'] .'\'); return false">'.$variables['title'].'</a>';
+    $z++;
+    if ($z % 1 == 0) {
+        $out .= '<br />';
+    }
 }
 $dsp->AddSingleRow($out);
 $dsp->AddSingleRow("ACHTUNG:" . HTML_NEWLINE . "Angemeldet?, Bezahlt?, Eingecheckt? damit diese Variablen korrekt funtkionieren muss *Nur Angemeldete* ausgewählt sein");
-?>

--- a/modules/popups/ls_row_textareaplus_link.php
+++ b/modules/popups/ls_row_textareaplus_link.php
@@ -2,19 +2,20 @@
 
 $dsp->NewContent('Wähle den Eintrag aus, der Verlinkt werden soll');
 
-function GetLinks($caption, $mod, $table, $id, $name, $link) {
-  global $func, $db, $dsp;
+function GetLinks($caption, $mod, $table, $id, $name, $link)
+{
+    global $func, $db, $dsp;
 
-  if ($func->isModActive($mod)) {
-    $out = '<select name="link" onChange="javascript:if (this.options[this.selectedIndex].value != \'\') InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \'[url='. $link .'\' + this.options[this.selectedIndex].value + \']\', \'[/url]\')">';
-    $out .= '<option value="">'. t('Bitte Link auswählen') .'</option>';
-    $res = $db->qry("SELECT %plain%, %plain% FROM %prefix%%plain%", $id, $name, $table);
-    while ($row = $db->fetch_array($res)) {
-      $out .= '<option value="'. $row[$id] .'">'. $row[$name] .'</option>';
+    if ($func->isModActive($mod)) {
+        $out = '<select name="link" onChange="javascript:if (this.options[this.selectedIndex].value != \'\') InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \'[url='. $link .'\' + this.options[this.selectedIndex].value + \']\', \'[/url]\')">';
+        $out .= '<option value="">'. t('Bitte Link auswählen') .'</option>';
+        $res = $db->qry("SELECT %plain%, %plain% FROM %prefix%%plain%", $id, $name, $table);
+        while ($row = $db->fetch_array($res)) {
+            $out .= '<option value="'. $row[$id] .'">'. $row[$name] .'</option>';
+        }
+        $out .= '</select>';
+        $dsp->AddDoubleRow($caption, $out);
     }
-    $out .= '</select>';
-    $dsp->AddDoubleRow($caption, $out);
-  }
 }
 
 GetLinks(t('News'), 'news', 'news', 'newsid', 'caption', 'index.php?mod=news&action=comment&newsid=');
@@ -27,5 +28,3 @@ GetLinks(t('Turnier'), 'tournament2', 'tournament_tournaments', 'tournamentid', 
 GetLinks(t('Turnier-Paarungen'), 'tournament2', 'tournament_tournaments', 'tournamentid', 'name', 'index.php?mod=tournament2&action=games&step=2&tournamentid=');
 GetLinks(t('Turnier-Spielbaum'), 'tournament2', 'tournament_tournaments', 'tournamentid', 'name', 'index.php?mod=tournament2&action=tree&step=2&tournamentid=');
 GetLinks(t('Turnier-Ranking'), 'tournament2', 'tournament_tournaments', 'tournamentid', 'name', 'index.php?mod=tournament2&action=rangliste&step=2&tournamentid=');
-
-?>

--- a/modules/popups/ls_row_textareaplus_popup.php
+++ b/modules/popups/ls_row_textareaplus_popup.php
@@ -4,12 +4,15 @@ $dsp->NewContent('Zeichen anklicken, um es ins Textfeld einzufügen');
 $smilie = $db->qry("SELECT shortcut, image FROM %prefix%smilies");
 $out = '';
 $z = 0;
-while($smilies = $db->fetch_array($smilie)) if (file_exists('ext_inc/smilies/'. $smilies['image'])) {
-  $out .= '<a href="#" onclick="javascript:InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \''. $smilies['shortcut'] .'\'); return false">
+while ($smilies = $db->fetch_array($smilie)) {
+    if (file_exists('ext_inc/smilies/'. $smilies['image'])) {
+        $out .= '<a href="#" onclick="javascript:InsertCode(opener.document.'. $_GET['form'] .'.'. $_GET['textarea'] .', \''. $smilies['shortcut'] .'\'); return false">
     <img src="ext_inc/smilies/'. $smilies['image'] .'" border="0" alt="'. $smilies['image'] .'" />
   </a>';
-  $z++;
-  if ($z % 12 == 0) $out .= '<br />';
+        $z++;
+        if ($z % 12 == 0) {
+            $out .= '<br />';
+        }
+    }
 }
 $dsp->AddSingleRow($out);
-?>

--- a/modules/popups/textareaplus_preview.php
+++ b/modules/popups/textareaplus_preview.php
@@ -1,4 +1,3 @@
 <?php
 $dsp->NewContent('Text-Vorschau');
 $dsp->AddSingleRow($func->text2html($func->NoHTML(str_replace('--NEWLINE--', "\n", $__POST[$_GET['textareaname']]))));
-?>


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.