### PR TITLE
#6: Apply coding style guide PSR 1 and PSR 2 to docs/ folder (with php-cs-fixer)

### DIFF
--- a/docs/CHMdefaultConverter/media/stylesheet.css
+++ b/docs/CHMdefaultConverter/media/stylesheet.css
@@ -39,11 +39,11 @@ A:link{
     color: #336699;
 }
 
-A:visited           {
+A:visited {
     color: #003366;
 }
 
-A:active, A:hover   {
+A:active, A:hover {
     color: #6699CC;
 }
 
@@ -51,7 +51,7 @@ A:hover{
     text-decoration: underline;
 }
 
-SPAN.type           {
+SPAN.type {
     color: #336699;
     font-size: xx-small;
     font-weight: normal;
@@ -73,7 +73,7 @@ HR  {
     filter: Alpha (opacity=100,finishopacity=0,style=1);
 }
 
-DIV.sdesc           {
+DIV.sdesc {
     font-weight: bold;
     background-color: #EEEEEE;
     padding: 10px;
@@ -82,7 +82,7 @@ DIV.sdesc           {
     border-style: solid;
 }
 
-DIV.desc            {
+DIV.desc {
     font-family: monospace;
     background-color: #EEEEEE;
     padding: 10px;
@@ -91,11 +91,11 @@ DIV.desc            {
     border-style: solid;
 }
 
-SPAN.code           {
+SPAN.code {
     font-family: monospace;
 }
 
-CODE.varsummarydefault{
+CODE.varsummarydefault {
     padding: 1px;
     border-width: 1px;
     border-style: dashed;
@@ -105,8 +105,8 @@ CODE.varsummarydefault{
 UL.tute {
     margin:         0px;
     padding:        0px;
-    padding-left:       5px;
-    }
+    padding-left:   5px;
+}
 
 LI.tute {
     line-height: 140%;
@@ -116,15 +116,36 @@ LI.tute {
     padding-left:       14px;
 }
 
-.small{
+.small {
     font-size: 9pt;
 }
 
+.tute-tag {
+    color: #009999;
+}
 
-.tute-tag { color: #009999 }
-.tute-attribute-name { color: #0000FF }
-.tute-attribute-value { color: #0099FF }
-.tute-entity { font-weight: bold; }
-.tute-comment { font-style: italic }
-.tute-inline-tag { color: #636311; font-weight: bold }
-.src-code { font-family: 'Courier New', Courier, monospace; font-weight: normal; }
+.tute-attribute-name {
+    color: #0000FF;
+}
+
+.tute-attribute-value {
+    color: #0099FF;
+}
+
+.tute-entity {
+    font-weight: bold;
+}
+
+.tute-comment {
+    font-style: italic;
+}
+
+.tute-inline-tag {
+    color: #636311;
+    font-weight: bold;
+}
+
+.src-code {
+    font-family: 'Courier New', Courier, monospace;
+    font-weight: normal;
+}

--- a/docs/CHMdefaultConverter/media/stylesheet.css
+++ b/docs/CHMdefaultConverter/media/stylesheet.css
@@ -1,123 +1,123 @@
 BODY, DIV, SPAN, PRE, CODE, TD, TH {
-	line-height: 140%;
-	font-size: 10pt;
-	font-family: verdana,arial,sans-serif;
+    line-height: 140%;
+    font-size: 10pt;
+    font-family: verdana,arial,sans-serif;
 }
 
 H1 {
-	font-size: 12pt;
+    font-size: 12pt;
 }
 
 H4 {
-	font-size: 10pt;
-	font-weight: bold;
+    font-size: 10pt;
+    font-weight: bold;
 }
 
 P.label {
-	margin-bottom: 5px;
+    margin-bottom: 5px;
 }
 P.dt {
-	margin-top: 0px;
-	margin-bottom: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
 }
 P.indent {
-	margin-top: 0px;
-	margin-left: 20px;
-	margin-bottom: 0px;
+    margin-top: 0px;
+    margin-left: 20px;
+    margin-bottom: 0px;
 }
 P.method {
-	background-color: #f0f0f0;
-	padding: 2px;
-	border: 1px #cccccc solid;
+    background-color: #f0f0f0;
+    padding: 2px;
+    border: 1px #cccccc solid;
 }
 
 A {
-	text-decoration: none;
+    text-decoration: none;
 }
 
 A:link{
-	color: #336699;
+    color: #336699;
 }
 
-A:visited			{
-	color: #003366;
+A:visited           {
+    color: #003366;
 }
 
-A:active, A:hover	{
-	color: #6699CC;
+A:active, A:hover   {
+    color: #6699CC;
 }
 
 A:hover{
-	text-decoration: underline;
+    text-decoration: underline;
 }
 
-SPAN.type			{
-	color: #336699;
-	font-size: xx-small;
-	font-weight: normal;
-	}
+SPAN.type           {
+    color: #336699;
+    font-size: xx-small;
+    font-weight: normal;
+    }
 
-PRE	{
-	background-color: #EEEEEE;
-	padding: 10px;
-	border-width: 1px;
-	border-color: #336699;
-	border-style: solid;
+PRE {
+    background-color: #EEEEEE;
+    padding: 10px;
+    border-width: 1px;
+    border-color: #336699;
+    border-style: solid;
 }
 
-HR	{
-	color: #336699;
-	background-color: #336699;
-	border-width: 0px;
-	height: 1px;
-	filter: Alpha (opacity=100,finishopacity=0,style=1);
+HR  {
+    color: #336699;
+    background-color: #336699;
+    border-width: 0px;
+    height: 1px;
+    filter: Alpha (opacity=100,finishopacity=0,style=1);
 }
 
-DIV.sdesc			{
-	font-weight: bold;
-	background-color: #EEEEEE;
-	padding: 10px;
-	border-width: 1px;
-	border-color: #336699;
-	border-style: solid;
+DIV.sdesc           {
+    font-weight: bold;
+    background-color: #EEEEEE;
+    padding: 10px;
+    border-width: 1px;
+    border-color: #336699;
+    border-style: solid;
 }
 
-DIV.desc			{
-	font-family: monospace;
-	background-color: #EEEEEE;
-	padding: 10px;
-	border-width: 1px;
-	border-color: #336699;
-	border-style: solid;
+DIV.desc            {
+    font-family: monospace;
+    background-color: #EEEEEE;
+    padding: 10px;
+    border-width: 1px;
+    border-color: #336699;
+    border-style: solid;
 }
 
-SPAN.code			{
-	font-family: monospace;
+SPAN.code           {
+    font-family: monospace;
 }
 
 CODE.varsummarydefault{
-	padding: 1px;
-	border-width: 1px;
-	border-style: dashed;
-	border-color: #336699;
+    padding: 1px;
+    border-width: 1px;
+    border-style: dashed;
+    border-color: #336699;
 }
 
-UL.tute	{
-	margin:			0px;
-	padding:		0px;
-	padding-left:		5px;
-	}
+UL.tute {
+    margin:         0px;
+    padding:        0px;
+    padding-left:       5px;
+    }
 
-LI.tute	{
-	line-height: 140%;
-	font-size: 10pt;
-	text-indent:		-15px;
-	padding-bottom:		2px;
-	padding-left:		14px;
+LI.tute {
+    line-height: 140%;
+    font-size: 10pt;
+    text-indent:        -15px;
+    padding-bottom:     2px;
+    padding-left:       14px;
 }
 
 .small{
-	font-size: 9pt;
+    font-size: 9pt;
 }
 
 

--- a/docs/HTMLSmartyConverter/media/style.css
+++ b/docs/HTMLSmartyConverter/media/style.css
@@ -1,5 +1,5 @@
 .php {
-	padding: 1em;
+    padding: 1em;
 }
 .php-src { font-family: 'Courier New', Courier, monospace; font-weight: normal; }
 
@@ -139,8 +139,8 @@ span.smalllinenumber
 }
 
 ul {
-	margin-left:		0px;
-	padding-left:		8px;
+    margin-left:        0px;
+    padding-left:       8px;
 }
 /* Syntax highlighting */
 


### PR DESCRIPTION
Ticket: #6 

I applied [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and the [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) script for PSR 1 and PSR 2 to only the about module.

Be aware: Those automated tools don't fix everything, but ~90 or 95% percent. I think this is a good basement to continue.