### PR TITLE
Fixed constructor names for PHP7 while calling installation

### DIFF
--- a/inc/classes/class.crypt.php
+++ b/inc/classes/class.crypt.php
@@ -29,7 +29,7 @@
 class AzDGCrypt
 {
     public $k;
-    public function AzDGCrypt($m)
+    public function __construct($m)
     {
         $this->k = $m;
     }

--- a/inc/classes/class_auth.php
+++ b/inc/classes/class_auth.php
@@ -40,7 +40,7 @@ class auth
    * @param mixed Frameworkmode for switch Stats
    *
    */
-    public function auth($frmwrkmode = "")
+    public function __construct($frmwrkmode = "")
     {
         global $db;
         

--- a/inc/classes/class_barcode.php
+++ b/inc/classes/class_barcode.php
@@ -38,7 +38,7 @@ class barcode
     public $_format;
     public $_n2w;
 
-    public function barcode($encoding = "EAN-13")
+    public function __construct($encoding = "EAN-13")
     {
         if (!function_exists("imagecreate")) {
             die("This class needs GD library support.");

--- a/inc/classes/class_db_mysql.php
+++ b/inc/classes/class_db_mysql.php
@@ -15,7 +15,7 @@ class db
     public $QueryArgs = array();
 
   // Construktor
-    public function db()
+    public function __construct()
     {
         if (extension_loaded("mysqli")) {
             $this->mysqli = 1;

--- a/inc/classes/class_debug.php
+++ b/inc/classes/class_debug.php
@@ -100,9 +100,9 @@ class debug
  * @param string Path for Filedebug
  * @return void
  */
-    public function debug($mode = "0", $debug_path = "")
+    public function __construct($mode = "0", $debug_path = "")
     {
-        // TODO : argvars verwenden um einfache Variablenübergabe zu ermöglischen.
+        // TODO : argvars verwenden um einfache Variablenï¿½bergabe zu ermï¿½glischen.
         // TODO : Debugbacktrace
         $this->mode = $mode;
         $this->debug_path = $debug_path;

--- a/inc/classes/class_display.php
+++ b/inc/classes/class_display.php
@@ -12,7 +12,7 @@ class display
     public $tabNames = array();
 
   // Constructor
-    public function display()
+    public function __construct()
     {
         $this->errortext_prefix = HTML_NEWLINE . HTML_FONT_ERROR;
         $this->errortext_suffix = HTML_FONT_END;

--- a/inc/classes/class_framework.php
+++ b/inc/classes/class_framework.php
@@ -39,7 +39,7 @@ class framework
   /**
    * CONSTRUCTOR : Initialize basic Variables
    */
-    public function framework()
+    public function __construct()
     {
         // Set Script-Start-Time, to calculate the scripts runtime
         $this->design = $design;

--- a/inc/classes/class_func.php
+++ b/inc/classes/class_func.php
@@ -30,7 +30,7 @@ class func
    * CONSTRUCTOR : Get referer and transform in a internal Link
    *
    */
-    public function func()
+    public function __construct()
     {
         define('NO_LINK', -1);
         $url_array = parse_url($_SERVER['HTTP_REFERER']);

--- a/inc/classes/class_gd.php
+++ b/inc/classes/class_gd.php
@@ -11,7 +11,7 @@ class gd
 
 
     // Constructor
-    public function gd()
+    public function __construct()
     {
         if (function_exists("gd_info")) {
             $GD = gd_info();

--- a/inc/classes/class_mastercomment.php
+++ b/inc/classes/class_mastercomment.php
@@ -48,7 +48,7 @@ class Mastercomment
 {
 
     // Construktor
-    public function Mastercomment($mod, $id, $update_table = array())
+    public function __construct($mod, $id, $update_table = array())
     {
         global $framework, $dsp, $auth, $db, $func, $cfg;
 

--- a/inc/classes/class_masterform.php
+++ b/inc/classes/class_masterform.php
@@ -54,7 +54,7 @@ class masterform
     public $FCKeditorID = 0;
     public $Pages = array();
 
-    public function masterform($MFID = 0)
+    public function __construct($MFID = 0)
     {
         global $mf_number;
     

--- a/inc/classes/class_masterrate.php
+++ b/inc/classes/class_masterrate.php
@@ -4,7 +4,7 @@ class masterrate
 {
 
     // Construktor
-    public function masterrate($mod, $id, $caption = '')
+    public function __construct($mod, $id, $caption = '')
     {
         global $auth, $db, $dsp, $framework, $smarty;
       

--- a/inc/classes/class_modules.php
+++ b/inc/classes/class_modules.php
@@ -23,7 +23,7 @@ class modules
    * CONSTRUCTOR : Initialize basic Variables
    *
    */
-    public function modules()
+    public function __construct()
     {
         global $db;
 

--- a/inc/classes/class_plugin.php
+++ b/inc/classes/class_plugin.php
@@ -25,7 +25,7 @@ class plugin
     public $count = 0;
     public $type = '';
 
-    public function plugin($type)
+    public function __construct($type)
     {
         global $db, $func;
 

--- a/inc/classes/class_translation.php
+++ b/inc/classes/class_translation.php
@@ -111,7 +111,7 @@ class translation
    * CONSTRUCTOR Translation
    *
    */
-    public function translation()
+    public function __construct()
     {
         $this->get_lang();          // Read Language from GET, POST & set
     }

--- a/modules/install/class_import.php
+++ b/modules/install/class_import.php
@@ -11,7 +11,7 @@ class Import
     public $installed_tables = array();
 
     // Constructor
-    public function Import()
+    public function __construct()
     {
         global $db;
 


### PR DESCRIPTION
While calling the installation in PHP7 + activated deprecated warnings, you will see messages like

```
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; ... has a deprecated constructor in ....class.php on line 64
```

This fixes a few of them by using the up to date constructor name