### PR TITLE
Remove the set of "error_reporting"

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,17 +1,10 @@
 <?php
-### Set Error Reporting & INI-Settings
+// Set error_reporting properly
+// Right now we depend on it. This will change in future.
+error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
 
-if (defined('E_STRICT')) {
-    error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
-} // Will work for PHP >= 5.3
-elseif (defined('E_DEPRECATED')) {
-    error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
-} // Will work for PHP >= 5.3
-else {
-    error_reporting(E_ALL ^ E_NOTICE);
-} // For PHP < 5.3
 if (function_exists('ini_set')) {
-  // Disable SID in URL
+    // Disable SID in URL
     ini_set('url_rewriter.tags', '');
 }
 

--- a/index.php
+++ b/index.php
@@ -1,15 +1,4 @@
 <?php
-### Set Error Reporting & INI-Settings
-
-if (defined('E_STRICT')) {
-    error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
-} // Will work for PHP >= 5.3
-elseif (defined('E_DEPRECATED')) {
-    error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
-} // Will work for PHP >= 5.3
-else {
-    error_reporting(E_ALL ^ E_NOTICE);
-} // For PHP < 5.3
 if (function_exists('date_default_timezone_set')) {
     date_default_timezone_set('Europe/Berlin');
 } // As of PHP 5.3 this needs to be set. Otherwise some webservers will throw warnings

--- a/modules/install/class_install.php
+++ b/modules/install/class_install.php
@@ -604,18 +604,8 @@ class Install
                 $ext_inc_check = $ok;
             }
         }
-          $dsp->AddDoubleRow(t('Schreibrechte im Ordner \'ext_inc\''), $ext_inc_check);
-
-        // Error Reporting
-        if (error_reporting() <= (E_ALL ^ E_NOTICE)) {
-              $errreport_check = $ok;
-        } else {
-            $errreport_check = $warning . t('In deiner php.ini ist \'error_reporting\' so konfiguriert, dass auch unwichtige Fehlermeldungen angezeigt werden. Dies kann dazu führen, dass störende Fehlermeldungen in Lansuite auftauchen. Wir empfehlen diese Einstellung auf \'E_ALL ^ E_NOTICE\' zu ändern. In dieser Einstellung werden dann nur noch Fehler angezeigt, welche die Lauffähigkeit des Skriptes beeinträchtigen.');
-        }
-        $dsp->AddDoubleRow("Error Reporting", $errreport_check);
-
+        $dsp->AddDoubleRow(t('Schreibrechte im Ordner \'ext_inc\''), $ext_inc_check);
         $dsp->AddFieldSetEnd();
-
 
         #### Warning ####
         $dsp->AddFieldSetStart("Warnungen - Lansuite kann trotz evtl. Fehler verwendet werden");


### PR DESCRIPTION
error_reporting should not be set in the app itself.
It should be set in the server configuration. The server / lansuite admin should evaluate what errors to show to the users and what not.

The issue here: If someone wants to get way more detailed error_reporting and is configured by the server, the app will overwrite it.