### PR TITLE
Remove hardcoded set date_default_timezone_set to Europe/Berlin

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,9 +10,6 @@ elseif (defined('E_DEPRECATED')) {
 else {
     error_reporting(E_ALL ^ E_NOTICE);
 } // For PHP < 5.3
-if (function_exists('date_default_timezone_set')) {
-    date_default_timezone_set('Europe/Berlin');
-} // As of PHP 5.3 this needs to be set. Otherwise some webservers will throw warnings
 if (function_exists('ini_set')) {
   // Disable SID in URL
     ini_set('url_rewriter.tags', '');


### PR DESCRIPTION
The is a hardcoded `date_default_timezone_set('Europe/Berlin')` in the start application.
This makes it hard for other people outside of the "german timezone" to use this app like US, Portugal or other countries.

This setting should be setted by the env in the server (php.ini)