### PR TITLE
Add initial Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - phpenv rehash
 script:
   - find . -name '*.php' -print0 | xargs -0 -n1 php -lf || true # Allow failures for now
-  - phpcs --standard=PSR1,PSR2 --extensions=php . || true # Allow failures for now
+  - phpcs --standard=PSR1,PSR2 --extensions=php --ignore="^$(pwd)/ext_scripts/*" . || true # Allow failures for now

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - nightly
+install:
+  - pear install PHP_CodeSniffer
+  - phpenv rehash
+script:
+  - find . -name '*.php' -print0 | xargs -0 -n1 php -lf || true # Allow failures for now
+  - phpcs --standard=PSR1,PSR2 --extensions=php . || true # Allow failures for now


### PR DESCRIPTION
Run PHP syntax and code style checks on Travis CI for PHP versions 5.6, 7.0, 7.1 and nightly.
All checks are currently non-fatal and don't fail on errors.
This should be changed when the codebase improves.

Fixes #85