### PR TITLE
module foodcenter: Fix PhanUndeclaredClassMethod errors from phan static analysis

### DIFF
--- a/modules/foodcenter/class_product.php
+++ b/modules/foodcenter/class_product.php
@@ -286,13 +286,13 @@ class product
     /**
      * Kategorie
      *
-     * @var cat_object
+     * @var \cat
      */
     public $cat;
     /**
      * Lieferant
      *
-     * @var supp_object
+     * @var \supp
      */
     public $supp;
     /**


### PR DESCRIPTION
I started to apply [the phan static analyzer](https://github.com/phan/phan) on lansuite.
 used the [Tutorial for Analyzing a Large Sloppy Code Base](https://github.com/phan/phan/wiki/Tutorial-for-Analyzing-a-Large-Sloppy-Code-Base) as a start.

This PR fixed the `PhanUndeclaredClassMethod` errors for the foodcenter module:

```
modules/foodcenter/class_product.php:399 PhanUndeclaredClassMethod Call to method read_post from undeclared class \cat_object
modules/foodcenter/class_product.php:400 PhanUndeclaredClassMethod Call to method read_post from undeclared class \supp_object
modules/foodcenter/class_product.php:448 PhanUndeclaredClassMethod Call to method check from undeclared class \cat_object
modules/foodcenter/class_product.php:451 PhanUndeclaredClassMethod Call to method check from undeclared class \supp_object
modules/foodcenter/class_product.php:508 PhanUndeclaredClassMethod Call to method write from undeclared class \supp_object
modules/foodcenter/class_product.php:511 PhanUndeclaredClassMethod Call to method write from undeclared class \cat_object
modules/foodcenter/class_product.php:657 PhanUndeclaredClassMethod Call to method cat_form from undeclared class \cat_object
modules/foodcenter/class_product.php:663 PhanUndeclaredClassMethod Call to method supp_form from undeclared class \supp_object
```