### PR TITLE
Reworked README / README-DE with a little bit more condense information

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -1,0 +1,98 @@
+# LANSuite - Web based LAN-Party Management System
+
+[![Build Status](https://travis-ci.org/lansuite/lansuite.svg?branch=master)](https://travis-ci.org/lansuite/lansuite)
+
+LANSuite ist ein Administrationssystem für LAN-Partys.
+
+*Englische Version der README*: Kann unter [README.md](./README.md) gefunden werden.
+
+## Features
+
+* Organisation von Turnieren
+* Registrierung von und für LAN-Partys
+* News- und Nachrichten-System
+* Support für Beamer
+* Geld / Budget Organisation
+* Organisation von Essen
+* Hardware / Server inventory
+* Bildergalerie
+* Sitzpläne
+* und viele weitere ...
+
+## Requirements
+
+* PHP 7 (mit den Extensions `mysqli`, `snmp` und `gd`)
+
+## Installation
+
+### Docker
+
+Wir setzen eine einsatzbereite [Docker Community Edition](https://www.docker.com/community-edition) voraus.
+
+```
+$ git clone https://github.com/lansuite/lansuite.git
+$ cd lansuite
+$ touch ./inc/base/config.php
+$ # Füge den Inhalt der Beispiel-Konfiguration (siehe unten) in ./inc/base/config.php ein 
+$ chmod 0777 ./inc/base/config.php
+$ chmod -R 0777 ./ext_inc/
+$ docker-compose up
+```
+
+Die Befehlsreihenfolge startet nun einen [Nginx webserver](https://nginx.org/) mit einer [php-fpm](https://secure.php.net/manual/en/install.fpm.php) Konfiguration und einer [MySQL Datenbank](https://www.mysql.com/).
+Wenn alles gestartet wurde, besuche http://<Your-Docker-IP>:8080/ und du siehst ein Einsatzbereites LANSuite-System.
+
+### Konfigurationsdatei
+
+Eine Beispiel-Konfiguration kann folgendermaßen aussehen:
+
+```ini
+[lansuite]
+version=Nightly
+default_design=simple
+chmod_dir=777
+chmod_file=666
+debugmode=0
+
+[database]
+server=mysql
+user=root
+passwd=
+database=lansuite
+prefix=ls_
+charset=utf8
+```
+
+**Warnung**: 
+Chmod auf `0777` zu setzen ist nicht für Produktionssysteme zu empfehlen. Nur euer eigener Webserver sollte in Schreibrechte haben.
+
+## Development
+
+### Contribution Guide
+
+Wie du bei diesem Projekt mitwirken kannst, ist in unserem [Contribution Guide](./CONTRIBUTING-DE.md) beschrieben.
+
+### Sprache
+
+Die Hauptsprache des Projektes ist Englisch.
+Wir unterstützen Bugs und Pull-Requests auch in deutscher Sprache.
+Der Grund ist, dass LANSuite ein altes System ist und viele der bisherigen Nutzer nur Deutsch sprechen.
+Um diese Nutzerschaft nicht zu verlieren, supporten wir beide Sprachen.
+Weitere Details können dem Ticket [Switch language of documentation, development, communication to english #2](https://github.com/lansuite/lansuite/issues/2) entnommen werden.
+
+### Coding style guide
+
+Das Projekt folgt folgenden coding guideline Standards:
+
+* [PSR-1: Basic Coding Standard](http://www.php-fig.org/psr/psr-1/)
+* [PSR-2: Coding Style Guide](http://www.php-fig.org/psr/psr-2/)
+
+### Generierung der API Dokumentation
+
+Vorherige Versionen von LANSuite haben eine API Dokumentation im Ordner `docs/` mitgeliefert.
+Um diese API Dokumentation im HTML-Format zu generieren, kann [phpDocumentor](https://www.phpdoc.org/) genutzt werden:
+
+```
+$ composer install
+$ bin/phpdoc run --progressbar -t ./docs/
+```

--- a/README.md
+++ b/README.md
@@ -1,47 +1,27 @@
-# Lansuite - Webbased LAN-Party Management System
+# LANSuite - Web based LAN-Party Management System
 
-Lansuite ist ein Lanparty-Administrationssystem, basierend auf PHP und MySQL.
-Es greift den Organisatoren von Lanparties in vielen Bereichen wie Turnierorganistation, Anmeldung oder Nachrichtenverwaltung unter die Arme und ermöglicht so, dass sich die Organisatoren auf die wesentlichen Dinge Ihrer Party konzentieren können.
+[![Build Status](https://travis-ci.org/lansuite/lansuite.svg?branch=master)](https://travis-ci.org/lansuite/lansuite)
 
-Auch für die Partybesucher bietet Lansuite eine Vielzahl von Möglichkeiten, am wichtigsten dürften hier die Kommunikationskomponenten von Lansuite, wie der ICQ-ähnliche Messenger und die Boards sein, aber auch die Möglichkeit sich über aktuelle Geschehnisse in den News zu Informieren, sowie den aktuellen Stand der Turniere zu sehen.
+LANSuite is a administration system for LAN-Parties based.
 
-In den Turnierbereichen von Lansuite können die Gäste bequem ihre Spielergebnisse melden und mit dem integrierten Sitzplan behalten sowohl Organisatoren als auch Gäste immer den vollen Überblick über die Lanparty.
+*German version of this README*: Can be found at [README-DE.md](./README-DE.md).
 
-Lansuite ist vollständig Lansurfer-kompatibel und unterstützt die Austragung von WWCL-, NGL- und LGZ-Turnieren.
+## Features
 
-Durch die Verwendung von PHP/MySQL kann Lansuite auf jedem beliebigen System, auf dem ein aktueller Browser installiert ist, benutzt werden, sowie mit fast allen Hosting-Angeboten, die Scriptsprache und Datenbank anbieten im Internet betrieben werden.
-
-Serverseitig können sowohl Linux/Unix- als auch Windows- und Mac-Systeme eingesetzt werden.
-
-## Dies sind die Ziele auf die bei der Entwicklung von Lansuite besonders geachtet wird:
-
-- **Einfache Bedienung, Benutzerfreundlichkeit mit möglichst einfachen Abläufen**
-
-Dieses Ziel stellt die größte Veränderung zu Lansuite Version 1 da. Viele der Konzepte wurden über Bord geworfen, da deren Bedienung zu komplex war. So wurde z.B. das Turniersystem radikal verändert und von unnötigem Ballast befreit. Die einfache Bedienbarkeit und das Learning-by-doing sind wichtige Entwicklungsziele der Version 2. Auch die "unterschwellige" und "leise" Unterstützung des Benutzers war uns wichtig, so sind z.B. alle Tabellen sortierbar usw.
-
-- **Mächtiges Verwaltungswerkzeug für die Organisatoren, das dennoch übersichtlich und einfach zu bedienen ist**
-
-"Nehmt die Orgas an die Hand und gebt ihnen Sicherheit, denn sie haben schon genug zu tun". Getreu diesem Motto wurden die Verwaltungswerkzeuge von Lansuite entwickelt. Da wir selbst Erfahrung im Organisieren von Lanparties haben, wissen wir wo es Probleme gibt und wie kritische Situationen (Anmeldung) gelöst werden können. Lansuite versucht eben diese Situation so einfach wie möglich zu gestalten, insbesondere beim Einchecken der Gäste zu Beginn der Party.
-
-- **Auswahl zwischen unterschiedlichen Designs, möglichst einfache Anpassung/Erstellung von Designs durch Organisatoren**
-
-Das optische Erscheinungsbild von Lansuite kann komplett geändert werden. Mit Lansuite werden mehrere Designs geliefert, zwischen denen der User wählen kann. Wir haben uns für ein Template-Konzept entschieden, da damit die Organisatoren recht einfach eigene Designs erstellen, oder die Standarddesigns anpassen können. Eine Dokumenation dazu ist ebenfalls enthalten.
-
-- **Erhöhung der Sicherheit**
-
-Wenn der Webserver es unterstützt, was wir ausdrücklich empfehlen, arbeitet Lansuite komplett SSL-verschlüsselt. Durch einige Sicherheitskonzepte im Session-Tracking ist ein Session-Hijacking und somit das Ergaunern von Passwörtern auch ohne SSL-Support fast unmöglich. Zusammen mit SSL haben Hacker / Cracker kaum Chancen Passwörter zu knacken. Auch in der Lansuite-Datenbank werden sensible Daten nur verschlüsselt gespeichert.
-
-- **Kleine Hilfebuttons (Helpletts) die zu fast jeder Situation eine on-line Hilfe bieten**
-
-Lansuite bietet zu vielen Fachwörtern kleine Popup-Fenster mit deren Erklärung an. Dieses Prinzip wird konseqent angewendet und beantwortet so die meisten Fragen. Zu wichtigen Bereichen ist außerdem eine Onlinehilfe verfügbar.
-
-- **Gute, ausführliche Dokumentation**
-
-Sollten Onlinehilfe und Helpletts nicht weiterhelfen, kann der Anwender im Wiki blättern. Für die Organisatoren und Entwickler gibt es dort sehr nützliche Hinweise und Tipps.
+* Organisation of tournaments
+* Registration for parties
+* News- and messaging system
+* Projector support
+* Cash / Money management
+* Foodcenter
+* Hardware / Server inventory
+* Picture gallery
+* Seat plans
+* and many more ...
 
 ## Requirements
 
-* PHP 7 (with mysqli, snmp and gd extensions)
+* PHP 7 (with `mysqli`, `snmp` and `gd` extensions)
 
 ## Installation
 
@@ -60,11 +40,11 @@ $ docker-compose up
 ```
 
 This will start a [Nginx webserver](https://nginx.org/) with a [php-fpm](https://secure.php.net/manual/en/install.fpm.php) configuration and a [MySQL database](https://www.mysql.com/) for you.
-After everythign started you should be able to visit http://<Your-Docker-IP>:8080/ and see a running LanSuite-System.
+After everything started you should be able to visit http://<Your-Docker-IP>:8080/ and see a running LanSuite-System.
 
-### Example configuration file
+### Configuration file
 
-An example configuration file:
+An example configuration file looks like:
 
 ```ini
 [lansuite]
@@ -83,19 +63,21 @@ prefix=ls_
 charset=utf8
 ```
 
-**Warning**: Setting directories to 0777 is not suggested for production. Only your webserver user should be able to write into this directory.
+**Warning**: Setting directories to `0777` is not suggested for production. Only your webserver user should be able to write into this directory.
 
 ## Development
 
 ### Contribution Guide
 
-#### English
+Checkout how to contribute in our [Contribution Guide](./CONTRIBUTING.md).
 
-How to contribute is described in detail in our [Contribution Guide](./CONTRIBUTING.md).
+### Language
 
-#### German / Deutsch
-
-Wie man zu diesem Projekt etwas beisteuert ist sehr detailliert in unserem [Contribution Guide](./CONTRIBUTING-DE.md) beschrieben.
+Main language of this project is english.
+We also support issues and pull requests in german.
+The reason is that LANSuite is a quite old system and a massive userbase only speaks german.
+To not loose them, we will support both languages.
+See [Switch language of documentation, development, communication to english #2](https://github.com/lansuite/lansuite/issues/2) for more details.
 
 ### Coding style guide
 
@@ -104,12 +86,12 @@ This project follows the coding guideline standards:
 * [PSR-1: Basic Coding Standard](http://www.php-fig.org/psr/psr-1/)
 * [PSR-2: Coding Style Guide](http://www.php-fig.org/psr/psr-2/)
 
-
 ### Generating API docs
 
 Former versions of LANSuite bundled an API documentation in the `docs/` folder.
-To regenerate an API documentation in a HTML-Version you can use [phpDocumentor](https://www.phpdoc.org/):
+To generate an API documentation in a HTML-Version you can use [phpDocumentor](https://www.phpdoc.org/):
 
 ```
-phpdoc --progressbar -t ./lansuite-apidocs-html/ -d ./lansuite-code/
+$ composer install
+$ bin/phpdoc run --progressbar -t ./docs/
 ```


### PR DESCRIPTION
I've reworked the README.md a little bit.

### Why did i reworked it?

* The current README has a german / language mix. This makes it hard to read. Especially for non german speaker
* The current README contains _a lot_ prosa text. This text might not be uninteresting, but most of the people on github want to have a quick look at the README to gain the information on what LANSuite is
* The current README also contains not 100% up to date information (e.g. the easy to use goal)

### What has changed

* README.md only contains english text, README-DE.md only contains german text
* Include the TravisCI Build Badge
* Summed up what LANSuite is in one sentence
* Quick list of the most used / usable features (e.g. for new users to get a first view)
* Removed project goals, because these goals are a) modern standard (like usability) or b) system features (like different designs)
* New chapter about the project language
* Fixed the `phpdoc` command (dependency to #100 )

### German version

We had/have a lot of german users. So i translated the README and provided a german version.

*Personal opinion*: I would love to drop the german language for documentation / readme / contribution, because this is a lot of effort to translate every document. And like we see our time is already limited for improvements / contributions for this project.
We can continue with accepting issues / PRs in german, but for documents in the project, i like to raise the question, if we should drop `README-DE.md` and `CONTRIBUTING-DE.md`.

### Results

Checkout the results and how it looks like here:
* [README.md](https://github.com/lansuite/lansuite/blob/readme-language/README.md)
* [README-DE.md](https://github.com/lansuite/lansuite/blob/readme-language/README-DE.md)