### PR TITLE
Set PHP5/PHP7 constructor of barcode_system

### DIFF
--- a/inc/classes/class_barcode.php
+++ b/inc/classes/class_barcode.php
@@ -1748,7 +1748,7 @@ class barcode_system
 {
     public $class_barcode;
     
-    public function barcode_system()
+    public function __construct()
     {
         global $cfg, $db;
         


### PR DESCRIPTION
Remove PHP deprecation message
```
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; barcode_system has a deprecated constructor in ./inc/classes/class_barcode.php on line 1747

Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; barcode_system has a deprecated constructor in ./inc/classes/class_barcode.php on line 1747
```