### PR TITLE
Docker: Make MySQL accessible from external (dev setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ docker-compose up
 This will start a [Nginx webserver](https://nginx.org/) with a [php-fpm](https://secure.php.net/manual/en/install.fpm.php) configuration and a [MySQL database](https://www.mysql.com/) for you.
 After everything started you should be able to visit http://<Your-Docker-IP>:8080/ and see a running LanSuite-System.
 
+*Attention*: This docker setup is not suggested for production.
+
 ### Configuration file
 
 An example configuration file looks like:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
             - code-network
     mysql:
         image: mysql:5.5
+        ports:
+            - "3306:3306"
         environment:
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE="lansuite"


### PR DESCRIPTION
In the docker setup you can start via `docker-compose up`, the mysql database is only accessible by the webserver container. In a production env this is good practice to limit the access.

For development purposes it make sense to enable external access to the mysql database.
This PR enables it.