### PR TITLE
Module "stats": Fix wrong mysql_free_result to avoid a sql error

### DIFF
--- a/modules/stats/hits.php
+++ b/modules/stats/hits.php
@@ -28,7 +28,4 @@ $total_time = $db->qry_first("SELECT time, size FROM %prefix%stats");
 $dsp->AddDoubleRow(t('Bis jetzt ben&ouml;tigte Zeit f&uuml;r Skript'), $total_time['time'] . " " . t('Sekunde(n)'));
 $dsp->AddDoubleRow(t('Bis jetzt &uuml;bertragene Daten'), $total_time['size'] . " kB");
 
-
-$db->free_result($res);
-#$dsp->AddBackButton("index.php?mod=stats", "stats/user");
 $dsp->AddContent();


### PR DESCRIPTION
The stats module throws an error, because a mysql_free_result is done on a non existing variable.

Screenshot:
<img width="1034" alt="screen shot 2018-01-05 at 21 55 32" src="https://user-images.githubusercontent.com/320064/34628153-ac3313be-f263-11e7-8797-8b0e31ea8fef.png">
