### PR TITLE
Docker: Remove quotes from lansuite database name to avoid naming a db with quotes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         image: mysql:5.5
         environment:
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-            - MYSQL_DATABASE="lansuite"
+            - MYSQL_DATABASE=lansuite
         networks:
             - code-network
 


### PR DESCRIPTION
When you hit docker-compose, the database is names `"lansuite"` (with `"`).
With this PR the database will be named `lansuite` (without `"`).