### PR TITLE
Composer: Added application requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,11 @@
         }
     ],
     "require": {
-        "php-64bit": "^7.0",
+        "php": "^7.0",
         "ext-gd": "*",
         "ext-mysqli": "*",
         "ext-snmp": "*",
+
         "smarty/smarty": "^3.1",
         "geshi/geshi": "^1.0.9"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lansuite/lansuite",
-    "type": "project",
     "description": "A Content Management System designed especially for the needs of LAN-Parties",
+    "type": "project",
     "keywords": ["lanparty", "cms", "gaming", "esports"],
     "homepage": "https://github.com/lansuite/lansuite",
     "license": "GPL-2.0",
@@ -12,7 +12,15 @@
         }
     ],
     "require": {
+        "php-64bit": "^7.0",
+        "ext-gd": "*",
+        "ext-mysqli": "*",
+        "ext-snmp": "*",
         "smarty/smarty": "^3.1",
         "geshi/geshi": "^1.0.9"
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "bin-dir": "bin"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "77b37454a4008d167f3f31039e445b44",
+    "content-hash": "4ba89adf20d672ec2772c2aa6dc5b3e0",
     "packages": [
         {
             "name": "geshi/geshi",
@@ -106,6 +106,11 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php-64bit": "^7.0",
+        "ext-gd": "*",
+        "ext-mysqli": "*",
+        "ext-snmp": "*"
+    },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ba89adf20d672ec2772c2aa6dc5b3e0",
+    "content-hash": "cd6161317d50940e576fdad0e778dd9a",
     "packages": [
         {
             "name": "geshi/geshi",
@@ -107,7 +107,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php-64bit": "^7.0",
+        "php": "^7.0",
         "ext-gd": "*",
         "ext-mysqli": "*",
         "ext-snmp": "*"


### PR DESCRIPTION
What we did here:

* Added PHP =7.0.* + extensions gd, mysqli and snmp
* Added `bin` folder for scripts installed by external dependencies

This was part of https://github.com/lansuite/lansuite/pull/100 before.