### PR TITLE
Fix #118: Supress PHP Notices and fix a few

### DIFF
--- a/inc/classes/class_framework.php
+++ b/inc/classes/class_framework.php
@@ -21,7 +21,7 @@ class framework
     public $send_size = "0";
     public $content_crc = "";                  // Checksum of Content
     public $content_size = "";                 // Size of Content
-    
+
     public $internal_url_query = array();      // Clean URL-Query (keys : path, query, base)
     public $design = "simple";                 // Design
     public $modus = "";                        // Displaymodus (popup)
@@ -35,40 +35,44 @@ class framework
     public $IsMobileBrowser = false;
     public $pageTitle = '';
   /**#@-*/
-  
+
   /**
    * CONSTRUCTOR : Initialize basic Variables
    */
     public function __construct()
     {
         // Set Script-Start-Time, to calculate the scripts runtime
-        $this->design = $design;
+        $this->design = '';
         $this->timer = time();
         $this->timer2 = explode(' ', microtime());
 
         if (isset($_SERVER['REQUEST_URI'])) {
-            if ($_SERVER['HTTPS']) {
+            if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']) {
                 $url = 'https://'. $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
             } else {
                 $url = 'http://'. $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
             }
-            if ($CurentURL = parse_url($url)) {
-                $this->internal_url_query['base'] = $CurentURL['path'].'?'.$CurentURL['query']; // Enspricht alter $CurentURLBase;
-                $this->internal_url_query['query'] = preg_replace('/[&]?fullscreen=(no|yes)/sUi', '', $CurentURL['query']); // Enspricht alter $URLQuery;
-                $this->internal_url_query['host'] = $CurentURL['host'];
+
+            $CurentURL = parse_url($url);
+            $this->internal_url_query['base'] = $CurentURL['path'];
+            $this->internal_url_query['query'] = '';
+            if (isset($CurentURL['query']) && $CurentURL['query']) {
+                $this->internal_url_query['base'] .= '?' . $CurentURL['query'];
+                $this->internal_url_query['query'] = preg_replace('/[&]?fullscreen=(no|yes)/sUi', '', $CurentURL['query']);
             }
+            $this->internal_url_query['host'] = $CurentURL['host'];
         }
         if (!$this->internal_url_query['host']) {
             $this->internal_url_query['host'] = $_SERVER['SERVER_NAME'];
         }
-        
+
         $this->add_js_path('ext_scripts/jquery-min.js');
         $this->add_js_path('ext_scripts/jquery-ui/jquery-ui.custom.min.js');
         $this->add_js_path('scripts.js');
 
         $this->add_css_path('ext_scripts/jquery-ui/smoothness/jquery-ui.custom.css');
         $this->add_css_path('design/style.css');
-        
+
         if ($this->internal_url_query['query']) {
             $query = preg_replace('/&language=(de|en|it|fr|es|nl)/sUi', '', $this->internal_url_query['query']);
             $query = preg_replace('/&order_by=(.)*&/sUi', '&', $query);
@@ -97,7 +101,7 @@ class framework
     {
         $this->modus = $modus;
     }
-    
+
   /**
    * Add String/Html to MainContent
    *
@@ -289,7 +293,7 @@ class framework
                 $smarty->assign('MainContentStyleID', 'ContentFullscreen');
                 $smarty->display("design/simple/templates/main.htm");
                 break;
-  
+
             case 'popup':
                 // Make HTML for Popup
                 $smarty->assign('MainContentStyleID', 'ContentFullscreen');
@@ -309,17 +313,17 @@ class framework
                     $smarty->display("design/{$this->design}/templates/main.htm");
                 }
                 break;
-  
+
             case 'base':
                 // Make HTML for Sites Without HTML (e.g. for generation Pictures etc)
                 echo $this->main_content;
                 break;
-    
+
             case 'ajax':
                 // Make HTML for Sites Without HTML (e.g. for generation Pictures etc)
                 echo $this->main_content;
                 break;
-  
+
             default:
                 // Footer
                 $smarty->assign('main_footer_version', $templ['index']['info']['version']);
@@ -327,12 +331,12 @@ class framework
                 $smarty->assign('main_footer_countquery', $db->count_query);
                 $smarty->assign('main_footer_timer', round($this->out_work(), 2));
                 $smarty->assign('main_footer_cleanquery', $this->get_clean_url_query('query'));
-        
+
                 if ($cfg["sys_footer_impressum"]) {
                     $smarty->assign('main_footer_impressum', $cfg["sys_footer_impressum"]);
                 }
-        
-        
+
+
                 $main_footer_mem_usage = '';
                 if (function_exists('memory_get_peak_usage')) {
                     $main_footer_mem_usage = 'Memory-Usage: '. $func->FormatFileSize(memory_get_peak_usage()) .' |';
@@ -348,18 +352,18 @@ class framework
 
                 // Normal HTML-Output with Boxes
                 $smarty->assign('Design', $this->design);
-  
+
                 // Unterscheidung fullscreen / Normal
                 if ($_SESSION['lansuite']['fullscreen'] or $this->modus == 'beamer') {
                     $smarty->assign('MainContentStyleID', 'ContentFullscreen');
                 } else {
                     $smarty->assign('MainContentStyleID', 'Content');
                 }
-        
+
                 if ($auth['login']) {
                     $smarty->assign('MainLogout', '<a href="index.php?mod=auth&action=logout" class="menu">Logout</a>');
                 }
-    
+
                 // Ausgabe Hauptseite
                 if (!$_SESSION['lansuite']['fullscreen'] and !$this->modus == 'beamer') {
                     $smarty->assign('MainFrameworkmessages', $this->framework_messages);
@@ -373,7 +377,7 @@ class framework
                     // Ausgabe Vollbildmodus
                     $smarty->assign('CloseFullscreen', '<a href="index.php?'. $this->get_clean_url_query('query') .'&amp;fullscreen=no" class="menu"><img src="design/'. $this->design .'/images/arrows_delete.gif" border="0" alt="" /><span class="infobox">'. t('Vollbildmodus schließen') .'</span> Lansuite - Vollbildmodus</a>');
                 }
-    
+
                 // Start Javascript-Code for MainContent with JQuery-Tabs
                 /*$this->main_header_jscode .= "
                   $(document).ready(function(){
@@ -385,7 +389,7 @@ class framework
                     });
                   });
                 ";*/
-        
+
                 // MainContent with JQuery-Tabs for LS-Messenger
                 #$main_content_with_tabs .= "<div class='ui-tabs ui-widget ui-widget-content ui-corner-all' id='MainContentTabs'>\n";
                 #$main_content_with_tabs .= "  <ul class='ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all'>\n";
@@ -398,9 +402,9 @@ class framework
                 #$main_content_with_tabs .= "    </div>\n";
                 #$main_content_with_tabs .= "  </div>\n";
                 #$main_content_with_tabs .= "</div>\n";
-        
+
                 #$smarty->assign("MainContent", $main_content_with_tabs);
-    
+
                 // Ausgabe des Hautteils mit oder ohne Kompression
                 if ($compression_mode and $cfg['sys_compress_level']) {
                     header("Content-Encoding: $compression_mode");

--- a/inc/classes/class_func.php
+++ b/inc/classes/class_func.php
@@ -33,8 +33,18 @@ class func
     public function __construct()
     {
         define('NO_LINK', -1);
-        $url_array = parse_url($_SERVER['HTTP_REFERER']);
-        $this->internal_referer = "index.php?".$url_array['query'].$url_array['fragment'];
+        $url_array = [];
+        $this->internal_referer = 'index.php';
+
+        if (isset($_SERVER['HTTP_REFERER'])) {
+            $url_array = parse_url($_SERVER['HTTP_REFERER']);
+        }
+        if (isset($url_array['query']) && $url_array['query']) {
+            $this->internal_referer .= '?' . $url_array['query'];
+        }
+        if (isset($url_array['fragment']) && $url_array['fragment']) {
+            $this->internal_referer .= $url_array['fragment'];
+        }
     }
 
 
@@ -47,6 +57,7 @@ class func
     public function read_db_config()
     {
         global $db;
+        $cfg = [];
 
         // Idea: Select current mod only, does not work with plugin.
         // $res = $db->qry('SELECT cfg_value, cfg_key, cfg_type FROM %prefix%config WHERE cfg_module = "install" OR cfg_module = %string%', $mod);
@@ -1024,9 +1035,11 @@ class func
         $this->ActiveModules['auth'] = 'Auth';
     }
 
-    public function isModActive($mod, &$caption = '')
-    {
-        $caption = $this->ActiveModules[$mod];
+    public function isModActive($mod, &$caption = '') {
+        if (array_key_exists($mod, $this->ActiveModules)) {
+            $caption = $this->ActiveModules[$mod];
+        }
+
         return array_key_exists($mod, $this->ActiveModules);
     }
 }

--- a/index.php
+++ b/index.php
@@ -122,14 +122,16 @@ session_start();
 // Initialise Frameworkclass for Basic output
 include_once("inc/classes/class_framework.php");
 $framework = new framework();
-$framework->fullscreen($_GET['fullscreen']);
+if (isset($_GET['fullscreen'])) {
+    $framework->fullscreen($_GET['fullscreen']);
+}
 
 // Compromise ... design as base and popup should be deprecated
-if ($_GET['design'] == 'base' || $_GET['design'] == 'popup' || $_GET['design'] == 'ajax' || $_GET['design'] == 'print' || $_GET['design'] == 'beamer') {
+if (isset($_GET['design']) && ($_GET['design'] == 'base' || $_GET['design'] == 'popup' || $_GET['design'] == 'ajax' || $_GET['design'] == 'print' || $_GET['design'] == 'beamer')) {
     $frmwrkmode = $_GET['design'];
 }
 // Set Popupmode via GET (base, popup)
-if ($_GET['frmwrkmode']) {
+if (isset($_GET['frmwrkmode']) && $_GET['frmwrkmode']) {
     $frmwrkmode = $_GET['frmwrkmode'];
 }
 // Set Popupmode via GET (base, popup)
@@ -169,7 +171,9 @@ foreach ($_GET as $key => $val) {
 }
 
 $_SERVER['REQUEST_URI'] = $func->NoHTML($_SERVER['REQUEST_URI'], 1);
-$_SERVER['HTTP_REFERER'] = $func->NoHTML($_SERVER['HTTP_REFERER'], 1);
+if (isset($_SERVER['HTTP_REFERER'])) {
+    $_SERVER['HTTP_REFERER'] = $func->NoHTML($_SERVER['HTTP_REFERER'], 1);
+}
 $_SERVER['QUERY_STRING'] = $func->NoHTML($_SERVER['QUERY_STRING'], 1);
 
 // Save original Array
@@ -289,7 +293,7 @@ if ($config['environment']['configured'] == 0) {
     $auth["login"] = 1;
 
     // Load DB-Data after installwizard step 3
-    if ($_GET["action"] == "wizard" && $_GET["step"] > 3) {
+    if ($_GET["action"] == "wizard" && isset($_GET["step"]) && $_GET["step"] > 3) {
         $cfg = $func->read_db_config();
     }
 
@@ -297,10 +301,12 @@ if ($config['environment']['configured'] == 0) {
     // Normal auth cycle and Database-init
     $db->connect(0);
     $IsAboutToInstall = 0;
-    $translation->load_trans('db', $_GET['mod']);
+    if (isset($_GET['mod'])) {
+        $translation->load_trans('db', $_GET['mod']);
+    }
 
     // Reset DB-Success in Setup if no Adm.-Account was found, because a connection could work, but prefix is wrong
-    if (!$func->admin_exists() && (($_GET["action"] == "wizard" && $_GET["step"] <= 3) || ($_GET["action"] == "ls_conf"))) {
+    if (!$func->admin_exists() && isset($_GET["action"]) && (($_GET["action"] == "wizard" && $_GET["step"] <= 3) || ($_GET["action"] == "ls_conf"))) {
         $db->success = 0;
     }
 
@@ -377,14 +383,14 @@ function initializeDesign()
     }
 
     // Design switch by URL
-    if ($_GET['design'] && $_GET['design'] != 'popup' && $_GET['design'] != 'base') {
+    if (isset($_GET['design']) && $_GET['design'] != 'popup' && $_GET['design'] != 'base') {
         $auth['design'] = $_GET['design'];
     }
 
     // Fallback design is 'simple'
     if (!$auth['design'] || !file_exists('design/' . $auth['design'] . '/templates/main.htm')) {
         $auth['design'] = 'simple';
-        if ($_GET['design'] != 'popup' && $_GET['design'] != 'base') {
+        if (!isset($_GET['design']) || ($_GET['design'] != 'popup' && $_GET['design'] != 'base')) {
             $_GET['design'] = 'simple';
         }
     }

--- a/index.php
+++ b/index.php
@@ -17,6 +17,26 @@ if (function_exists('ini_set')) {
 function myErrorHandler($errno, $errstr, $errfile, $errline) {
     global $PHPErrors, $PHPErrorsFound, $db, $auth;
 
+    // Only show errors, which sould be reported according to error_reporting
+    // Also filters @ (for @ will have error_reporting "0")
+    // Why this is necessary at all?
+    // From the PHP docs of "set_error_handler"
+    //      It is important to remember that the standard PHP error handler is completely bypassed for the error types specified by error_types unless the callback function returns FALSE.
+    // Source: https://secure.php.net/manual/en/function.set-error-handler.php
+    // LanSuite is _at the moment_ (2018-01-13) not PHP Notice free.
+    // We are working on this. Once this is done, we can remove the next two
+    // conditions and move along.
+    // Until this time we have to keep it.
+    // Otherwise the system might not be usable at all.
+    $rep = ini_get('error_reporting');
+    if (!($rep & $errno)) {
+        return false;
+    }
+
+    if (error_reporting() == 0) {
+        return false;
+    }
+
     switch ($errno) {
         case E_ERROR:
             $errors = "Error";


### PR DESCRIPTION
In https://github.com/lansuite/lansuite/commit/d9c1ea18a893491c23170d973a931bdcbef00822#diff-828e0013b8f3bc1bb22b4f57172b019d i removed the part that suppressed errors.
I thought the correct error_reporting setting would not delegate all errors to our own error_handler. I was wrong.
To ensure that this don't happen again i commented this explicit and added the code again.

Further more i fixed several PHP Notice warning from the code.
LanSuite is _right now_ not able to operate in a env where PHP Notices are reported.