### PR TITLE
Extract class barcode_system to an own file and add into autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
             "inc/classes/class.crypt.php",
             "inc/classes/class_auth.php",
             "inc/classes/class_barcode.php",
+            "inc/classes/class_barcode_system.php",
             "inc/classes/class_db_mysql.php",
             "inc/classes/class_debug.php",
             "inc/classes/class_display.php",

--- a/inc/classes/class_barcode.php
+++ b/inc/classes/class_barcode.php
@@ -1,7 +1,4 @@
 <?php
-
-
-
 //########################//
 //
 // Author :Harish Chauhan
@@ -22,9 +19,6 @@
 *
 * Reference : http://www.barcodeisland.com/symbolgy.phtml
 */
-
-define('BARCODE_PATH', 'ext_inc/barcodes/');
-
 class barcode
 {
     public $_encode;
@@ -1740,61 +1734,5 @@ class barcode
         }
 
         @imagedestroy($im);
-    }
-}
-
-
-class barcode_system
-{
-    public $class_barcode;
-    
-    public function __construct()
-    {
-        global $cfg, $db;
-        
-        $this->class_barcode = new barcode($cfg['sys_barcode_typ']);
-
-        $this->class_barcode->setHeight(50);
-        $this->class_barcode->setScale(1);
-        $this->class_barcode->setHexColor("#000000", "#FFFFFF");
-        
-        if (isset($_POST['barcodefield']) && $cfg['sys_barcode_on']) {
-            $data = $db->qry_first("SELECT userid FROM %prefix%user WHERE barcode=%string%", $_POST['barcodefield']);
-            $_POST['userid'] = $data['userid'];
-            $_GET['userid'] = $data['userid'];
-        }
-    }
-    
-    
-    public function gencode($userid)
-    {
-        $code = 768300000000;
-        $code = $code + ($userid * 10000);
-        $code = $code + mt_rand(0, 9999);
-        return $code;
-    }
-    
-    public function getcode($userid)
-    {
-        global $db,$cfg;
-        
-        $data = $db->qry_first("SELECT barcode FROM %prefix%user WHERE userid=%int%", $userid);
-        if ($data['barcode'] == "0") {
-            $data['barcode'] = $this->gencode($userid);
-
-            $db->qry_first("UPDATE %prefix%user SET barcode = %string% WHERE userid=%int%", $data['barcode'], $userid);
-        }
-        return $data['barcode'];
-    }
-    
-    public function get_image($userid, $filename)
-    {
-        $code = $this->getcode($userid);
-        return $this->class_barcode->genBarCode($code, "png", $filename);
-    }
-    
-    public function kill_image($filename)
-    {
-        unlink($filename . ".png");
     }
 }

--- a/inc/classes/class_barcode_system.php
+++ b/inc/classes/class_barcode_system.php
@@ -1,0 +1,75 @@
+<?php
+//########################//
+//
+// Author :Harish Chauhan
+// Created : 7July 2005
+//
+//########################//
+
+/*
+* This class is for generating barcodes in diffrenct encoding symbologies.
+* It supports EAN-13,EAN-8,UPC-A,UPC-E,ISBN ,2 of 5 Symbologies(std,ind,interleaved),postnet,
+* codabar,code128,code39,code93 symbologies.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*
+* Requirements : PHP with GD library support.
+*
+* Reference : http://www.barcodeisland.com/symbolgy.phtml
+*/
+class barcode_system
+{
+    public $class_barcode;
+    
+    public function __construct()
+    {
+        global $cfg, $db;
+        
+        $this->class_barcode = new barcode($cfg['sys_barcode_typ']);
+
+        $this->class_barcode->setHeight(50);
+        $this->class_barcode->setScale(1);
+        $this->class_barcode->setHexColor("#000000", "#FFFFFF");
+        
+        if (isset($_POST['barcodefield']) && $cfg['sys_barcode_on']) {
+            $data = $db->qry_first("SELECT userid FROM %prefix%user WHERE barcode=%string%", $_POST['barcodefield']);
+            $_POST['userid'] = $data['userid'];
+            $_GET['userid'] = $data['userid'];
+        }
+    }
+    
+    
+    public function gencode($userid)
+    {
+        $code = 768300000000;
+        $code = $code + ($userid * 10000);
+        $code = $code + mt_rand(0, 9999);
+        return $code;
+    }
+    
+    public function getcode($userid)
+    {
+        global $db,$cfg;
+        
+        $data = $db->qry_first("SELECT barcode FROM %prefix%user WHERE userid=%int%", $userid);
+        if ($data['barcode'] == "0") {
+            $data['barcode'] = $this->gencode($userid);
+
+            $db->qry_first("UPDATE %prefix%user SET barcode = %string% WHERE userid=%int%", $data['barcode'], $userid);
+        }
+        return $data['barcode'];
+    }
+    
+    public function get_image($userid, $filename)
+    {
+        $code = $this->getcode($userid);
+        return $this->class_barcode->genBarCode($code, "png", $filename);
+    }
+    
+    public function kill_image($filename)
+    {
+        unlink($filename . ".png");
+    }
+}

--- a/modules/pdf/class_pdf.php
+++ b/modules/pdf/class_pdf.php
@@ -16,6 +16,11 @@ class pdf
 {
 
     /**
+     * Storage of barcodes
+     */
+    const BARCODE_PATH ='ext_inc/barcodes/';
+
+    /**
      * Daten Array um M�glich Daten anzuzeigen
      *
      * @var array

--- a/modules/pdf/class_pdf.php
+++ b/modules/pdf/class_pdf.php
@@ -906,15 +906,15 @@ class pdf
                 
                 case 'barcode':
                     $imagename = mt_rand(100000, 999999);
-                    $barcode->get_image($_SESSION['userid'], BARCODE_PATH .$imagename);
-                    $image = getimagesize(BARCODE_PATH .$imagename . ".png");
+                    $barcode->get_image($_SESSION['userid'], static::BARCODE_PATH .$imagename);
+                    $image = getimagesize(static::BARCODE_PATH .$imagename . ".png");
                     if (($image[0]/2) > $this->object_width) {
                         $this->object_width = $image[0];
                     }
                     if (($image[1]/2) > $this->object_high) {
                         $this->object_high = $image[1];
                     }
-                    $barcode->kill_image(BARCODE_PATH . $imagename);
+                    $barcode->kill_image(static::BARCODE_PATH . $imagename);
                     
                 case 'data':
                     $width = $this->pdf->GetStringWidth($data[$templ[$i]['text']]);
@@ -971,9 +971,9 @@ class pdf
                     
                     case 'barcode':
                         $imagename = mt_rand(100000, 999999);
-                        $barcode->get_image($data['userid'], BARCODE_PATH . $imagename);
-                        $this->pdf->Image(BARCODE_PATH . $imagename . ".png", $templ[$i]['pos_x'] + $this->x, $templ[$i]['pos_y'] + $this->y);
-                        $barcode->kill_image(BARCODE_PATH . $imagename);
+                        $barcode->get_image($data['userid'], static::BARCODE_PATH . $imagename);
+                        $this->pdf->Image(static::BARCODE_PATH . $imagename . ".png", $templ[$i]['pos_x'] + $this->x, $templ[$i]['pos_y'] + $this->y);
+                        $barcode->kill_image(static::BARCODE_PATH . $imagename);
                     
 
                     case 'data':


### PR DESCRIPTION
This PR extracts the PHP class `barcode_system` into an own file and adds this class into autoloading.
Furthermore, the constant `BARCODE_PATH` was moved to the PDF module, because this is the only location where the constant is used.

PSR-1 say:
> This means each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name.

Source: https://www.php-fig.org/psr/psr-1/

Namespaces are not introduces (yet), but this is one more commit into this direction.