### PR TITLE
Fix #148: Don't enforce php-snmp, only suggest it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": "^7.0",
         "ext-gd": "*",
         "ext-mysqli": "*",
-        "ext-snmp": "*",
 
         "smarty/smarty": "^3.1",
         "geshi/geshi": "^1.0.9"
@@ -23,6 +22,9 @@
     "minimum-stability": "stable",
     "config": {
         "bin-dir": "bin"
+    },
+    "suggest": {
+        "ext-snmp": "Required to use the \"Network Operation Center\" module."
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd6161317d50940e576fdad0e778dd9a",
+    "content-hash": "74353f2c600da8a46752e6250f965326",
     "packages": [
         {
             "name": "geshi/geshi",
@@ -109,8 +109,7 @@
     "platform": {
         "php": "^7.0",
         "ext-gd": "*",
-        "ext-mysqli": "*",
-        "ext-snmp": "*"
+        "ext-mysqli": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
See #148 for details.

The PHP extension `snmp` is only used for the Network Operation Center module.
If the extension is not present, composer will suggest the extension.