### PR TITLE
Fix #149: Set correct folders to check (vendor and template_c)

### DIFF
--- a/inc/Functions/DependencyPreCheck.php
+++ b/inc/Functions/DependencyPreCheck.php
@@ -8,24 +8,30 @@
 * @return bool check result. True if error found, false if all OK
 */
 function dependencyPreCheck(){
-	// Initialize variable holding error messages - if something was found, empty otherwise
-	$errmsg = '';
+    $errmsg = '';
 
-	// Check if composer was executed (folder ./vendor created)
-	if (!is_dir(__DIR__ . '/vendor')) {
-		$errmsg .= __DIR__ . '/vendor directory is missing. Did you run composer?<br/>' .PHP_EOL;
-	}
+    // __DIR__ will result in something like /code/inc/Functions
+    // But we want the document root (/code in this example)
+    $baseDirectoryParts = explode(DIRECTORY_SEPARATOR, __DIR__);
+    array_pop($baseDirectoryParts);
+    array_pop($baseDirectoryParts);
+    $baseDirectory = implode(DIRECTORY_SEPARATOR, $baseDirectoryParts);
 
-	// Check if Smarty-directory is writable
-	if (!is_writable(__DIR__ . '/ext_inc/templates_c')) {
-		$errmsg .= __DIR__ . '/ext_inc/templates_c seems not to be writable by the PHP user. Please confirm that file and folder access rights are applied correctly<br/>' . PHP_EOL;
-	}
+    // Check if composer was executed (folder ./vendor created)
+    $vendorDir = $baseDirectory . DIRECTORY_SEPARATOR . 'vendor';
+    if (!is_dir($vendorDir)) {
+        $errmsg .= $vendorDir . ' directory is missing. Did you run composer?<br/>' .PHP_EOL;
+    }
 
-	// Check error state and return stored messages if problem found
-	if (!empty($errmsg)) {
-		return 'The following issues were found while preparing to run the installation:<br/>'. PHP_EOL . $errmsg;
-	} else {
-		return false;
-	}
+    // Check if Smarty template cache directory is writable
+    $templateCacheDir = implode(DIRECTORY_SEPARATOR, [$baseDirectory, 'ext_inc', 'templates_c']);
+    if (!is_writable($templateCacheDir)) {
+        $errmsg .= $templateCacheDir . ' seems not to be writable by the PHP user. Please confirm that file and folder access rights are applied correctly<br/>' . PHP_EOL;
+    }
+
+    if (!empty($errmsg)) {
+        return 'The following issues were found while preparing to run the installation:<br/>'. PHP_EOL . $errmsg;
+    }
+
+    return false;
 }
-?>


### PR DESCRIPTION
Original version: There you see that the wrong folders are checked (because of the `__DIR__` usecase)

<img width="1032" alt="screen shot 2018-03-22 at 23 41 57" src="https://user-images.githubusercontent.com/320064/37802823-49f044ce-2e2c-11e8-86a3-1a5aaa177fd7.png">

Fixed version if only composer is missing:
<img width="489" alt="screen shot 2018-03-22 at 23 49 13" src="https://user-images.githubusercontent.com/320064/37802825-4a2532a6-2e2c-11e8-94d3-1b9b6fa013ba.png">

Fixed version if composer is missing and the template_c folder is not writable
<img width="945" alt="screen shot 2018-03-22 at 23 51 11" src="https://user-images.githubusercontent.com/320064/37802826-4a3dd450-2e2c-11e8-82e8-34bec2371f42.png">

Next to this we switched the intends from tabs to spaces.