### PR TITLE
Avoid SQL error during installation for admin_exists-check

### DIFF
--- a/index_module.inc.php
+++ b/index_module.inc.php
@@ -8,13 +8,13 @@ if ($cfg['sys_blocksite'] == 1) {
 }
 
 $missing_fields = 0;
-if ($func->admin_exists() and $_GET["mod"] != 'install') {
+if ($_GET["mod"] != 'install' && $func->admin_exists()) {
     // Check, if all required user data fields, are known and force user to add them, if not.
     if ($auth['login'] and $auth['userid']) {
         include_once('modules/usrmgr/missing_fields.php');
     }
 
-  // Reset $auth['type'], if no permission to Mod
+    // Reset $auth['type'], if no permission to Mod
     if ($auth['type'] > 1) {
         // Has at least someone (with rights equal or above) access to this mod?
         $permission = $db->qry_first("SELECT 1 AS found FROM %prefix%user_permissions AS p


### PR DESCRIPTION
During the installation, the database don't exist at point in time.
The following errors are thrown at the page bottom:

<img width="1086" alt="screen shot 2018-04-01 at 19 15 24" src="https://user-images.githubusercontent.com/320064/38175738-7591587c-35e1-11e8-808a-0264a556de70.png">

This error comes from the `admin_exists` function of the `func` class.
This function queries the `user` table, but this table don't exist on the first page in the installation module.

In PHP, if an if condition contains multiple checks and those are checked with `&&`, the condition will be aborted once the first don't match.