### PR TITLE
Limit API of inc/classes while switching visibility for properties and methods

### DIFF
--- a/inc/classes/class.crypt.php
+++ b/inc/classes/class.crypt.php
@@ -20,7 +20,7 @@ class AzDGCrypt
     /**
      * @var string
      */
-    public $k;
+    private $k;
 
     /**
      * @param string $m
@@ -34,7 +34,7 @@ class AzDGCrypt
      * @param string $t
      * @return string
      */
-    public function ed($t)
+    private function ed($t)
     {
         $r = md5($this->k);
         $c=0;

--- a/inc/classes/class_auth.php
+++ b/inc/classes/class_auth.php
@@ -14,70 +14,70 @@ class auth {
      *
      * @var array
      */
-    public $auth = [];
+    private $auth = [];
 
     /**
      * Time
      *
      * @var int
      */
-    public $timestamp;
+    private $timestamp;
 
     /**
      * Cookie data
      *
      * @var array
      */
-    public $cookie_data = [];
+    private $cookie_data = [];
 
     /**
      * Cookie name
      *
      * @var string
      */
-    public $cookie_name = 'LSAUTH';
+    private $cookie_name = 'LSAUTH';
 
     /**
      * Cookie version
      *
      * @var string
      */
-    public $cookie_version = '1';
+    private $cookie_version = '1';
 
     /**
      * Domain
      *
      * @var string
      */
-    public $cookie_domain = '';
+    private $cookie_domain = '';
 
     /**
      * Duration in days
      *
      * @var string
      */
-    public $cookie_time = '30';
+    private $cookie_time = '30';
 
     /**
      * Cookie path
      *
      * @var string
      */
-    public $cookie_path = '';
+    private $cookie_path = '';
 
     /**
      * Crypt Cookie with AzDGCrypt
      *
      * @var bool
      */
-    public $cookie_crypt = true;
+    private $cookie_crypt = true;
 
     /**
      * Passphrase for AzDGCrypt
      *
      * @var string
      */
-    public $cookie_crypt_pw = "iD9ww32e";
+    private $cookie_crypt_pw = "iD9ww32e";
 
     /**
      * Array containing all users, currently online
@@ -379,7 +379,7 @@ class auth {
      * @param string $uniquekey
      * @return void
      */
-    public function login_cookie($userid, $uniquekey)
+    private function login_cookie($userid, $uniquekey)
     {
         global $func;
 
@@ -585,7 +585,7 @@ class auth {
      *
      * @return mixed
      */
-    public function loadAuthBySID()
+    private function loadAuthBySID()
     {
         global $db;
         // Put all User-Data into $auth-Array
@@ -609,7 +609,7 @@ class auth {
      * @param string $frmwrkmode
      * @return void
      */
-    public function update_visits($frmwrkmode = "")
+    private function update_visits($frmwrkmode = "")
     {
         global $db;
         if ($frmwrkmode != "ajax" && $frmwrkmode != "print" && $frmwrkmode != "popup" && $frmwrkmode != "base") {
@@ -633,7 +633,7 @@ class auth {
      * @param int $userid
      * @return void
      */
-    public function set_cookie_pw($userid)
+    private function set_cookie_pw($userid)
     {
         global $db;
 
@@ -653,7 +653,7 @@ class auth {
      *
      * @return int Return the Cookiestatus. 1=OK, 0=NOK
      */
-    public function cookie_read()
+    private function cookie_read()
     {
         $ok = 0;
 
@@ -678,7 +678,7 @@ class auth {
      *
      * @return void
      */
-    public function cookie_set()
+    private function cookie_set()
     {
         setcookie(
             $this->cookie_name,
@@ -694,7 +694,7 @@ class auth {
      *
      * @return void
      */
-    public function cookie_unset()
+    private function cookie_unset()
     {
         setcookie(
             $this->cookie_name,
@@ -710,7 +710,7 @@ class auth {
      *
      * @return string
      */
-    public function cookiedata_pack()
+    private function cookiedata_pack()
     {
         $data = array($this->cookie_data['userid'],
                       $this->cookie_data['uniqekey'],
@@ -734,7 +734,7 @@ class auth {
      * @param string $cookie
      * @return void
      */
-    public function cookiedata_unpack($cookie)
+    private function cookiedata_unpack($cookie)
     {
         // Crypt only via Config. See Construktor
         if ($this->cookie_crypt) {
@@ -755,7 +755,7 @@ class auth {
      * @param int $count
      * @return string
      */
-    public function gen_rnd_key($count)
+    private function gen_rnd_key($count)
     {
         $possible = '0123456789abcdefghijklmnopqrstuvwxyz';
         $key = '';

--- a/inc/classes/class_barcode_system.php
+++ b/inc/classes/class_barcode_system.php
@@ -17,7 +17,7 @@
  */
 class barcode_system
 {
-    public $class_barcode;
+    private $class_barcode;
     
     public function __construct()
     {
@@ -40,7 +40,7 @@ class barcode_system
      * @param int $userid
      * @return int
      */
-    public function gencode($userid)
+    private function gencode($userid)
     {
         $code = 768300000000;
         $code = $code + ($userid * 10000);
@@ -52,7 +52,7 @@ class barcode_system
      * @param int $userid
      * @return int
      */
-    public function getcode($userid)
+    private function getcode($userid)
     {
         global $db;
         

--- a/inc/classes/class_db_mysql.php
+++ b/inc/classes/class_db_mysql.php
@@ -5,17 +5,17 @@ class db
     /**
      * @var int
      */
-    public $link_id = 0;
+    private $link_id = 0;
 
     /**
      * @var int
      */
-    public $query_id = 0;
+    private $query_id = 0;
 
     /**
      * @var array
      */
-    public $record = [];
+    private $record = [];
 
     /**
      * @var bool
@@ -30,7 +30,7 @@ class db
     /**
      * @var string
      */
-    public $errors = '';
+    private $errors = '';
 
     /**
      * @var int
@@ -49,14 +49,14 @@ class db
     /**
      * @var array
      */
-    public $QueryArgs = [];
+    private $QueryArgs = [];
 
     /**
      * @param string $msg
      * @param string $query_string_with_error
      * @return void
      */
-    public function print_error($msg, $query_string_with_error)
+    private function print_error($msg, $query_string_with_error)
     {
         global $config, $auth;
 
@@ -75,7 +75,7 @@ class db
      * @param array $match
      * @return int|mixed|string
      */
-    public function escape($match)
+    private function escape($match)
     {
         $CurrentArg = array_shift($this->QueryArgs);
 
@@ -359,7 +359,7 @@ class db
     /**
      * Returns the version of the MySQL server
      *
-     * @return string
+     * @return string|bool
      */
     public function getServerInfo() {
         if ($this->link_id) {

--- a/inc/classes/class_debug.php
+++ b/inc/classes/class_debug.php
@@ -34,47 +34,47 @@ class debug
      *
      * @var string
      */
-    public $timer_first = '';
+    private $timer_first = '';
 
     /**
      * Helpvar Timer
      *
      * @var string
      */
-    public $timer_last = '';
+    private $timer_last = '';
 
     /**
      * Helpvar Timer (Outputstring)
      *
      * @var string
      */
-    public $timer_out = '';
+    private $timer_out = '';
 
     /**
      * @var string
      */
-    public $timer_all;
+    private $timer_all;
 
     /**
      * Uservars to show
      *
      * @var array
      */
-    public $debugvars = [];
+    private $debugvars = [];
 
     /**
      * Debug mode
      *
      * @var string
      */
-    public $mode = '';
+    private $mode = '';
 
     /**
      * Debugpath for Filedebug
      *
      * @var string
      */
-    public $debug_path = '';
+    private $debug_path = '';
 
     /**
      * debug constructor.
@@ -132,7 +132,7 @@ class debug
     /**
      * @return string
      */
-    public function timer_show()
+    private function timer_show()
     {
         if ($this->mode > 0) {
             return $this->timer_out;
@@ -164,7 +164,7 @@ class debug
      *
      * @return string
      */
-    public function query_fetchlist()
+    private function query_fetchlist()
     {
         if (($this->mode > 0) && is_array($this->sql_query_list)) {
             $this->sql_query_list = $this->sort_array_by_col($this->sql_query_list);
@@ -187,7 +187,7 @@ class debug
      * @param array $array
      * @return array
      */
-    public function sort_array_by_col($array)
+    private function sort_array_by_col($array)
     {
         function compare($wert_a, $wert_b) {
             $a = $wert_a[0];
@@ -207,7 +207,7 @@ class debug
      * @param string $name  Table heading
      * @return string       HTML-Row for table (<tr><td>...</td></tr>)
      */
-    public function row_top($name)
+    private function row_top($name)
     {
         $out = "<tr><td width=\"100%\" colspan=\"2\" bgcolor=\"#C0C0C0\">".$name."</td></tr>\n";
         return $out;
@@ -219,7 +219,7 @@ class debug
      * @param string $name  Text
      * @return string       HTML-Row for table (<tr><td>...</td></tr>)
      */
-    public function row_single($name)
+    private function row_single($name)
     {
         $out = "<tr><td width=\"100%\" colspan=\"2\" align=\"left\">".$name."</td></tr>";
         $out .= "<tr><td width=\"100%\" height=\"1\" bgcolor=\"#C0C0C0\" colspan=\"2\"></td></tr>\n";
@@ -233,7 +233,7 @@ class debug
      * @param string $value     Variable
      * @return string           HTML-Row for Table (<tr><td>...</td></tr>)
      */
-    public function row_double($key, $value)
+    private function row_double($key, $value)
     {
         $out = "<tr><td width=\"20%\" align=\"left\">".$key."</td><td width=\"80%\" align=\"left\">".wordwrap($value, 65, "<br />\n", true)."&nbsp;</td></tr>";
         $out .= "<tr><td width=\"100%\" height=\"1\" bgcolor=\"#C0C0C0\" colspan=\"2\"></td></tr>\n";
@@ -249,7 +249,7 @@ class debug
      * @param int       $array_level    For recursive calls
      * @return string
      */
-    public function row_array($array, $array_node = null, $array_level = 0)
+    private function row_array($array, $array_node = null, $array_level = 0)
     {
         $out = '';
         if ($array_level == 0) {

--- a/inc/classes/class_display.php
+++ b/inc/classes/class_display.php
@@ -19,7 +19,7 @@ class display
     /**
      * @var int
      */
-    public $formcount = 1;
+    private $formcount = 1;
 
     /**
      * @var string
@@ -34,22 +34,22 @@ class display
     /**
      * @var int
      */
-    public $FirstLine = 1;
+    private $FirstLine = 1;
 
     /**
      * @var int
      */
-    public $CurrentTab = 0;
+    private $CurrentTab = 0;
 
     /**
      * @var string
      */
-    public $TabsMainContentTmp = '';
+    private $TabsMainContentTmp = '';
 
     /**
      * @var array
      */
-    public $tabNames = [];
+    private $TabNames = [];
 
     public function __construct()
     {
@@ -326,7 +326,6 @@ class display
         } else {
             $checked = '';
         }
-
 
         if ($disabled) {
             $disabled = 'disabled';

--- a/inc/classes/class_framework.php
+++ b/inc/classes/class_framework.php
@@ -6,31 +6,26 @@ class framework
     /**
      * @var int|string
      */
-    public $timer = '';
+    private $timer = '';
 
     /**
      * @var array|string
      */
-    public $timer2 = '';
-
-    /**
-     * @var string
-     */
-    public $send_size = '0';
+    private $timer2 = '';
 
     /**
      * Checksum of Content
      *
      * @var string
      */
-    public $content_crc = '';
+    private $content_crc = '';
 
     /**
      * Size of Content
      *
      * @var string
      */
-    public $content_size = '';
+    private $content_size = '';
 
     /**
      * Clean URL-Query (keys : path, query, base)
@@ -44,7 +39,7 @@ class framework
      *
      * @var string
      */
-    public $design = "simple";
+    private $design = "simple";
 
     /**
      * Displaymodus (popup)
@@ -58,49 +53,49 @@ class framework
      *
      * @var string
      */
-    public $framework_messages = '';
+    private $framework_messages = '';
 
     /**
      * Content
      *
      * @var string
      */
-    public $main_content = '';
+    private $main_content = '';
 
     /**
      * Headercode for Meta Tags
      *
      * @var string
      */
-    public $main_header_metatags = '';
+    private $main_header_metatags = '';
 
     /**
      * Headercode for JS-Files
      *
      * @var string
      */
-    public $main_header_jsfiles = '';
+    private $main_header_jsfiles = '';
 
     /**
      * Headercode for JS-Code
      *
      * @var string
      */
-    public $main_header_jscode = '';
+    private $main_header_jscode = '';
 
     /**
      * Headercode for CSS-Files
      *
      * @var string
      */
-    public $main_header_cssfiles = '';
+    private $main_header_cssfiles = '';
 
     /**
      * Headercode for CSS-Code
      *
      * @var string
      */
-    public $main_header_csscode = '';
+    private $main_header_csscode = '';
 
     /**
      * @var bool
@@ -110,7 +105,7 @@ class framework
     /**
      * @var string
      */
-    public $pageTitle = '';
+    private $pageTitle = '';
 
     public function __construct()
     {
@@ -165,6 +160,7 @@ class framework
     {
         $this->design = $design;
     }
+
     /**
      * Set the display modus
      *
@@ -226,7 +222,7 @@ class framework
      * @param string $csspath
      * @return void
      */
-    public function add_css_path($csspath)
+    private function add_css_path($csspath)
     {
         $this->main_header_cssfiles .= "<link rel=\"stylesheet\" type=\"text/css\" href=\"".$csspath."\" />\n";
     }
@@ -236,7 +232,7 @@ class framework
      *
      * @return string
      */
-    public function out_work()
+    private function out_work()
     {
         $timer = explode(' ', microtime());
         $worktime = $timer[1] - $this->timer2[1];
@@ -250,7 +246,7 @@ class framework
      *
      * @return int|string
      */
-    public function check_optimizer()
+    private function check_optimizer()
     {
         global $PHPErrors, $db;
 

--- a/inc/classes/class_func.php
+++ b/inc/classes/class_func.php
@@ -234,7 +234,7 @@ class func
      * @param string $link_type
      * @return void
      */
-    public function GeneralDialog($type, $text, $link_target = '', $JustReturn = 0, $link_type = '')
+    private function GeneralDialog($type, $text, $link_target = '', $JustReturn = 0, $link_type = '')
     {
         global $smarty, $dsp, $FrameworkMessages;
 

--- a/inc/classes/class_gd.php
+++ b/inc/classes/class_gd.php
@@ -10,27 +10,27 @@ class gd
     /**
      * @var int
      */
-    public $height;
+    private $height;
 
     /**
      * @var int
      */
-    public $width;
+    private $width;
 
     /**
      * @var string
      */
-    public $font;
+    private $font;
 
     /**
      * @var int
      */
-    public $font_size;
+    private $font_size;
 
     /**
      * @var int
      */
-    public $free_type = 0;
+    private $free_type = 0;
 
     /**
      * @var int
@@ -209,7 +209,7 @@ class gd
      * @param int $font_size
      * @return void
      */
-    public function SetFont($font = null, $font_size = null)
+    private function SetFont($font = null, $font_size = null)
     {
         global $cfg;
 
@@ -279,7 +279,7 @@ class gd
      * @param string $filename
      * @return int|resource
      */
-    public function OpenImage($filename)
+    private function OpenImage($filename)
     {
         if (!file_exists($filename)) {
             return 0;

--- a/inc/classes/class_masterdelete.php
+++ b/inc/classes/class_masterdelete.php
@@ -10,11 +10,6 @@ class masterdelete
     /**
      * @var array
      */
-    public $SubReferences = [];
-
-    /**
-     * @var array
-     */
     public $DeleteIfEmpty = [];
 
     /**
@@ -28,7 +23,7 @@ class masterdelete
      * @param int       $id
      * @return bool|int|mysqli_result
      */
-    public function DoDelete($table, $idname, $id)
+    private function DoDelete($table, $idname, $id)
     {
         global $func, $db, $config;
     

--- a/inc/classes/class_masterform.php
+++ b/inc/classes/class_masterform.php
@@ -25,42 +25,32 @@ class masterform
     /**
      * @var array
      */
-    public $FormFields = [];
+    private $FormFields = [];
 
     /**
      * @var array
      */
-    public $Groups = [];
+    private $Groups = [];
 
     /**
      * @var array
      */
-    public $SQLFields = [];
+    private $SQLFields = [];
 
     /**
      * @var array
      */
-    public $WYSIWYGFields = [];
+    private $WYSIWYGFields = [];
 
     /**
      * @var array
      */
-    public $SQLFieldTypes = [];
+    private $DependOn = [];
 
     /**
      * @var array
      */
-    public $SQLFieldUnique = [];
-
-    /**
-     * @var array
-     */
-    public $DependOn = [];
-
-    /**
-     * @var array
-     */
-    public $error = [];
+    private $error = [];
 
     /**
      * @var string
@@ -90,7 +80,7 @@ class masterform
     /**
      * @var int
      */
-    public $DependOnStarted = 0;
+    private $DependOnStarted = 0;
 
     /**
      * @var bool
@@ -100,12 +90,12 @@ class masterform
     /**
      * @var string
      */
-    public $FormEncType = '';
+    private $FormEncType = '';
 
     /**
      * @var int
      */
-    public $PWSecID = 0;
+    private $PWSecID = 0;
 
     /**
      * @var string
@@ -125,7 +115,7 @@ class masterform
     /**
      * @var int
      */
-    public $NumFields = 0;
+    private $NumFields = 0;
 
     /**
      * @var int
@@ -150,27 +140,27 @@ class masterform
     /**
      * @var int
      */
-    public $OptGroupOpen = 0;
+    private $OptGroupOpen = 0;
 
     /**
      * @var int
      */
-    public $MultiLineID = 0;
+    private $MultiLineID = 0;
 
     /**
      * @var array
      */
-    public $MultiLineIDs = [];
+    private $MultiLineIDs = [];
 
     /**
      * @var int
      */
-    public $FCKeditorID = 0;
+    private $FCKeditorID = 0;
 
     /**
      * @var array
      */
-    public $Pages = [];
+    private $Pages = [];
 
     public function __construct($MFID = 0)
     {
@@ -184,7 +174,7 @@ class masterform
      * @param string    $name
      * @return void
      */
-    public function AddToSQLFields($name)
+    private function AddToSQLFields($name)
     {
         if (!in_array($name, $this->SQLFields)) {
             $this->SQLFields[] = $name;
@@ -1152,7 +1142,7 @@ class masterform
      * @param string    $string     Fieldname ($field['type'] = "varchar(10))
      * @return int
      */
-    public function get_fieldlength($string)
+    private function get_fieldlength($string)
     {
         if (!(strrpos($string, "varchar") === false)) {
             preg_match("/(varchar\()(\\d{1,3})(\))/i", $string, $treffer);

--- a/inc/classes/class_plugin.php
+++ b/inc/classes/class_plugin.php
@@ -11,32 +11,32 @@ class plugin
     /**
      * @var array
      */
-    public $modules = [];
+    private $modules = [];
 
     /**
      * @var array
      */
-    public $captions = [];
+    private $captions = [];
 
     /**
      * @var array
      */
-    public $icons = [];
+    private $icons = [];
 
     /**
      * @var int
      */
-    public $currentIndex = 0;
+    private $currentIndex = 0;
 
     /**
      * @var int
      */
-    public $count = 0;
+    private $count = 0;
 
     /**
      * @var string
      */
-    public $type = '';
+    private $type = '';
 
     public function __construct($type)
     {

--- a/inc/classes/class_translation.php
+++ b/inc/classes/class_translation.php
@@ -17,7 +17,7 @@ class translation
      *
      * @var string
      */
-    public $transfile_name = 'translation.xml';
+    private $transfile_name = 'translation.xml';
 
     /**
      * @var array
@@ -50,14 +50,14 @@ class translation
      *
      * @var int
      */
-    public $cachemod_loaded_db = 0;
+    private $cachemod_loaded_db = 0;
 
     /**
      * Is cache for module loaded (xml)
      *
      * @var int
      */
-    public $cachemod_loaded_xml  = 0;
+    private $cachemod_loaded_xml  = 0;
 
     public function __construct()
     {
@@ -129,7 +129,7 @@ class translation
      * @param string $module    Module name or DB / System
      * @return void
      */
-    public function load_cache_bydb($module)
+    private function load_cache_bydb($module)
     {
         global $db;
 
@@ -159,7 +159,7 @@ class translation
      * @param string    $module     Module name or DB / System
      * @return void
      */
-    public function load_cache_byfile($module)
+    private function load_cache_byfile($module)
     {
         $xmldata = $this->xml_read_to_array($module);
         if (is_array($xmldata)) {
@@ -359,7 +359,7 @@ class translation
      * @param string    $module     Module name e.g. file-field
      * @return array
      */
-    public function xml_read_to_array($module) {
+    private function xml_read_to_array($module) {
         $records = [];
         $xml = new xml();
 
@@ -393,7 +393,7 @@ class translation
      * @param string    $module     Module name (System, DB, Module ...)
      * @return string
      */
-    public function get_trans_filename($module)
+    private function get_trans_filename($module)
     {
         switch ($module) {
             case 'DB':

--- a/inc/classes/class_xml.php
+++ b/inc/classes/class_xml.php
@@ -149,7 +149,7 @@ class xml {
      * @param int       $level
      * @return string
      */
-    public function level2tab($level) {
+    private function level2tab($level) {
         $tab = '';
         for ($i = 0; $i < $level; $i++) {
             $tab .= "\t";

--- a/modules/install/class_import.php
+++ b/modules/install/class_import.php
@@ -805,7 +805,7 @@ class Import
                 $db->qry("INSERT INTO %prefix%usersettings SET userid=%int%", $id);
             }
 
-            switch (mysql_affected_rows($db->link_id)) {
+            switch ($db->get_affected_rows()) {
                 case "-1":
                     $import["error"]++;
                     break;


### PR DESCRIPTION
LanSuite was written when PHP didn't support any kind of visibility.
When we started to work on LanSuite again, we made everything public (which was the default). This commit switches the visibility from public to private for properties and methods that are not accessed
by other entities.

This change allows us to define a more granular API, refactoring and testing.