### PR TITLE
Module stats: Avoid division by zero during stats calculation

### DIFF
--- a/modules/stats/hits.php
+++ b/modules/stats/hits.php
@@ -7,7 +7,12 @@ $dsp->AddDoubleRow(t('Besucher (Visits)'), $visits["insg"]);
 
 $hits = $db->qry_first("SELECT SUM(hits) AS insg FROM %prefix%stats_usage");
 $dsp->AddDoubleRow(t('Seitenaufrufe (Hits)'), $hits["insg"]);
-$dsp->AddDoubleRow(t('Seiten pro Besucher'), round($hits["insg"] / $visits["insg"], 2));
+
+$pagesPerUser = 0;
+if ($visits['insg'] > 0) {
+    $pagesPerUser = round($hits["insg"] / $visits["insg"], 2);
+}
+$dsp->AddDoubleRow(t('Seiten pro Besucher'), strval($pagesPerUser));
 
 $visit_timeout = time() - 60*60;
 $online = $db->qry_first("SELECT SUM(visits) AS insg FROM %prefix%stats_auth WHERE (lasthit > %int%)", $visit_timeout);


### PR DESCRIPTION
Before:
![screen shot 2018-04-11 at 14 57 40](https://user-images.githubusercontent.com/320064/38618208-34d14800-3d99-11e8-8751-08138320fa06.png)

After:
![screen shot 2018-04-11 at 14 59 58](https://user-images.githubusercontent.com/320064/38618219-3b456dd8-3d99-11e8-8fe4-608e4571962b.png)
