### PR TITLE
Let return auth::authorized() a value at every point in time

### DIFF
--- a/inc/classes/class_auth.php
+++ b/inc/classes/class_auth.php
@@ -502,7 +502,7 @@ class auth {
      * Check user rights and add a error message if needed
      *
      * @param int $requirement
-     * @return int
+     * @return boolean
      */
     public function authorized($requirement)
     {
@@ -512,7 +512,7 @@ class auth {
             // Logged in
             case 1:
                 if ($this->auth['login']) {
-                    return 1;
+                    return true;
 
                 } else {
                     $func->information('NO_LOGIN');
@@ -522,7 +522,7 @@ class auth {
             // Type is Admin, or Superadmin
             case 2:
                 if ($this->auth['type'] > 1) {
-                    return 1;
+                    return true;
 
                 } elseif (!$this->auth['login']) {
                     $func->information('NO_LOGIN');
@@ -535,7 +535,7 @@ class auth {
             // Type is Superadmin
             case 3:
                 if ($this->auth['type'] > 2) {
-                    return 1;
+                    return true;
 
                 } elseif (!$this->auth['login']) {
                     $func->information('NO_LOGIN');
@@ -548,7 +548,7 @@ class auth {
             // Type is User, or less
             case 4:
                 if ($this->auth['type'] < 2) {
-                    return 1;
+                    return true;
 
                 } else {
                     $func->information('ACCESS_DENIED');
@@ -558,7 +558,7 @@ class auth {
             // Logged out
             case 5:
                 if (!$this->auth['login']) {
-                    return 1;
+                    return true;
 
                 } else {
                     $func->information('ACCESS_DENIED');
@@ -566,8 +566,10 @@ class auth {
                 break;
 
             default:
-                return 1;
+                return true;
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
The method `auth::authorized` returns a value only if the user is authorized.
This is considered as a code smell. If a method returns a value, it should return a value at every point in time.
In many languages, this even doesn't compile.

Furthermore, we switched the return value from int to boolean, because only 1 (true) was used.
For all occurrences, it is also checked if the return value is bool.