### PR TITLE
Function mysqli_free_result() returns void, return statement has no effect

### DIFF
--- a/inc/classes/class_db_mysql.php
+++ b/inc/classes/class_db_mysql.php
@@ -314,7 +314,7 @@ class db
             $this->query_id = $query_id;
         }
 
-        return mysqli_free_result($this->query_id);
+        mysqli_free_result($this->query_id);
     }
 
     /**


### PR DESCRIPTION
The function [mysqli_free_result](https://secure.php.net/manual/en/mysqli-result.free.php) returns void.
The return statement here doesn't have any effect at all.