### PR TITLE
class barcode: Removed unreachable statement due to die() call

### DIFF
--- a/inc/classes/class_barcode.php
+++ b/inc/classes/class_barcode.php
@@ -36,7 +36,6 @@ class barcode
     {
         if (!function_exists("imagecreate")) {
             die("This class needs GD library support.");
-            return false;
         }
 
         $this->_error="";


### PR DESCRIPTION
The return statement has no effect at all, because it is considered as unreachable code due to the `die()` call