### PR TITLE
class display: Declared property form_name explicit instead dynamic

### DIFF
--- a/inc/classes/class_display.php
+++ b/inc/classes/class_display.php
@@ -51,6 +51,11 @@ class display
      */
     public $tabNames = [];
 
+    /**
+     * @var string
+     */
+    private $form_name = '';
+
     public function __construct()
     {
         $this->errortext_prefix = HTML_NEWLINE . HTML_FONT_ERROR;


### PR DESCRIPTION
The property `form_name` is used in the display class a couple of times, but this is declared dynamically.