### PR TITLE
Remove deprecated functions ereg and split and replace them with preg_match and preg_split

### DIFF
--- a/inc/classes/class_func.php
+++ b/inc/classes/class_func.php
@@ -641,7 +641,7 @@ class func
         }
 
         for ($i=0; $i<=3; $i++) {
-            if (ereg("[^0-9]", $IPParts[$i])) {
+            if (preg_match("[^0-9]", $IPParts[$i])) {
                 return 0;
             }
 

--- a/inc/classes/class_gd.php
+++ b/inc/classes/class_gd.php
@@ -265,7 +265,7 @@ class gd
 
         } else {
             $ypos = $ypos - 3;
-            $text_parts = split("\r\n", $text);
+            $text_parts = preg_split("\r\n", $text);
             $i = 0;
 
             while (list($key, $val) = each($text_parts)) {


### PR DESCRIPTION
ereg is deprecated since PHP 5.3.0. We should use preg_match() instead.
See https://secure.php.net/manual/en/function.ereg.php

split is deprecated since PHP 5.3.0. We should use preg_split() instead.
See https://secure.php.net/manual/en/function.split.php