### PR TITLE
Fix deprecated PHP constructors with the same name as the class itself

### DIFF
--- a/modules/bugtracker/class_bugtracker.php
+++ b/modules/bugtracker/class_bugtracker.php
@@ -4,7 +4,7 @@ class Bugtracker
     public $stati = array();
 
   // Constructor
-    public function Bugtracker()
+    public function __construct()
     {
         $this->stati[0] = t('Neu');
         $this->stati[1] = t('Bestätigt');

--- a/modules/cashmgr/class_accounting.php
+++ b/modules/cashmgr/class_accounting.php
@@ -22,7 +22,7 @@ class accounting
     /**
     * Konstruktor
     */
-    public function accounting($party_id = 0, $userid = null)
+    public function __construct($party_id = 0, $userid = null)
     {
         global $party, $auth;
         

--- a/modules/foodcenter/class_accounting.php
+++ b/modules/foodcenter/class_accounting.php
@@ -7,7 +7,7 @@ class accounting
     public $balance;
     
     
-    public function accounting($user_id)
+    public function __construct($user_id)
     {
         global $db;
         

--- a/modules/foodcenter/class_basket.php
+++ b/modules/foodcenter/class_basket.php
@@ -11,7 +11,7 @@ class basket
     public $product;
     public $account;
     
-    public function basket($backlink = null)
+    public function __construct($backlink = null)
     {
         global $auth;
         

--- a/modules/foodcenter/class_product.php
+++ b/modules/foodcenter/class_product.php
@@ -361,7 +361,7 @@ class product
      * @param int $id
      * @return product
      */
-    public function product($id = null)
+    public function __construct($id = null)
     {
         if ($id != null && $id > 0) {
             $this->id = $id;
@@ -1109,7 +1109,7 @@ class product_option
      * @param int $type
      * @return product_option
      */
-    public function product_option($id = null, $type = null)
+    public function __construct($id = null, $type = null)
     {
         $this->parenttyp = $type;
         if ($id != null && $id > 0) {
@@ -1395,7 +1395,7 @@ class supp
      * @param int $id
      * @return supp
      */
-    public function supp($id = null)
+    public function __construct($id = null)
     {
         if ($id != null && $id > 0) {
             $this->supp_id = $id;
@@ -1569,7 +1569,7 @@ class cat
      * @param int $id
      * @return cat
      */
-    public function cat($id = null)
+    public function __construct($id = null)
     {
         if ($id != null && $id > 0) {
             $this->cat_id = $id;

--- a/modules/foodcenter/print.php
+++ b/modules/foodcenter/print.php
@@ -9,7 +9,7 @@ class foodcenter_print
     public $row_file = "";
     public $row_temp = "";
 
-    public function foodcenter_print()
+    public function __construct()
     {
         global $func, $auth;
         if (!file_exists($this->path . $_POST['file']) || $_POST['file'] == "") {

--- a/modules/mastersearch2/class_mastersearch2.php
+++ b/modules/mastersearch2/class_mastersearch2.php
@@ -25,7 +25,7 @@ class MasterSearch2
     public $isExport = 0;
 
   // Constructor
-    public function MasterSearch2($module = '')
+    public function __construct($module = '')
     {
         global $ms_number;
 

--- a/modules/pdf/class_pdf.php
+++ b/modules/pdf/class_pdf.php
@@ -108,7 +108,7 @@ class pdf
      * @param int $templ_id
      * @return pdf
      */
-    public function pdf($templ_id)
+    public function __construct($templ_id)
     {
         $this->templ_id = $templ_id;
         // Typen Array erstellen

--- a/modules/pdf/class_templ_pdf.php
+++ b/modules/pdf/class_templ_pdf.php
@@ -6,7 +6,7 @@ class pdf_tmpl
     public $tmpl_id;
     
     // Konstruktor
-    public function pdf_tmpl($action, $tmpl_id)
+    public function __construct($action, $tmpl_id)
     {
         $this->action = $action;
         $this->tmpl_id = $tmpl_id;

--- a/modules/tournament2/sp_tree.class.php
+++ b/modules/tournament2/sp_tree.class.php
@@ -16,7 +16,7 @@ class lansuiteTree extends TourneyTree
     public $tree = null;
     public $db = null;
 
-    public function lansuiteTree($id, $size, &$db)
+    public function __construct($id, $size, &$db)
     {
         $this->size = $size;
         $this->st = "SELECT games.round, teams.name, teams.teamid, games.leaderid, games.gameid, games.score, games.position

--- a/modules/tournament2/tree.class.php
+++ b/modules/tournament2/tree.class.php
@@ -27,7 +27,7 @@ class TourneyTree
     public $lb_tbl = array();
     public $lb_indexes = array();
 
-    public function TourneyTree($size, $wb_teams, $lb_teams = false)
+    public function __construct($size, $wb_teams, $lb_teams = false)
     {
         // init vars !
         $this->size = $size;


### PR DESCRIPTION
PHP Deprecated: Methods with the same name as their class will not
be constructors in a future version of PHP;
<ClassName> has a deprecated constructor in <PathToFile>