### PR TITLE
class auth: Use undefined constant FORWARD as string, because it is checked as string

### DIFF
--- a/inc/classes/class_auth.php
+++ b/inc/classes/class_auth.php
@@ -421,7 +421,7 @@ class auth {
         $this->auth["userpassword"] = "";
         $this->auth["type"] = 0;
 
-        $func->confirmation(t('Du wurdest erfolgreich ausgeloggt. Vielen dank für deinen Besuch.'), "", 1, FORWARD);
+        $func->confirmation(t('Du wurdest erfolgreich ausgeloggt. Vielen dank für deinen Besuch.'), "", 1, 'FORWARD');
         return $this->auth;
     }
 


### PR DESCRIPTION
The constant `FORWARD` is never defined.
Furthermore, it seems that it was never used as a constant, because it is only compared with a string. See https://github.com/lansuite/lansuite/blob/master/inc/classes/class_func.php#L247