### PR TITLE
Constant OUTPUT_PROC is not defined, moved to masterform

### DIFF
--- a/inc/classes/class_masterform.php
+++ b/inc/classes/class_masterform.php
@@ -37,6 +37,8 @@ class masterform
 
     const CHECK_ERROR_PROC = 1;
 
+    const OUTPUT_PROC = 2;
+
     /**
      * @var array
      */
@@ -931,7 +933,7 @@ class masterform
                                                 break;
 
                                             case self::IS_CALLBACK:
-                                                $ret = call_user_func($field['selections'], $field['name'], OUTPUT_PROC, $this->error[$field['name']]);
+                                                $ret = call_user_func($field['selections'], $field['name'], self::OUTPUT_PROC, $this->error[$field['name']]);
                                                 if ($ret) {
                                                     $dsp->AddDoubleRow($field['caption'], $ret);
                                                 }

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -160,7 +160,7 @@ function PersoInput($field, $mode, $error = '')
     global $dsp, $templ, $auth, $usrmgr, $smarty;
 
     switch ($mode) {
-        case OUTPUT_PROC:
+        case masterform::OUTPUT_PROC:
               $_POST[$field .'_1'] = substr($_POST[$field], 0, 11);
               $_POST[$field .'_2'] = substr($_POST[$field], 13, 7);
               $_POST[$field .'_3'] = substr($_POST[$field], 21, 7);
@@ -226,7 +226,7 @@ function Addr1Input($field, $mode, $error = '')
     global $dsp, $templ, $auth, $func;
 
     switch ($mode) {
-        case OUTPUT_PROC:
+        case masterform::OUTPUT_PROC:
             if ($_POST['street|hnr'] == '' and $_POST['street'] and $_POST['hnr']) {
                 $_POST['street|hnr'] = $_POST['street'] .' '. $_POST['hnr'];
             }
@@ -254,7 +254,7 @@ function Addr2Input($field, $mode, $error = '')
     global $dsp, $templ, $auth, $func;
 
     switch ($mode) {
-        case OUTPUT_PROC:
+        case masterform::OUTPUT_PROC:
             if ($_POST['plz|city'] == '' and $_POST['plz'] and $_POST['city']) {
                 $_POST['plz|city'] = $_POST['plz'] .' '. $_POST['city'];
             }


### PR DESCRIPTION
The constant `OUTPUT_PROC` was never defined. Always used and checked.
This raised a couple of PHP notices.

With this PR we define it and moved it to masterform.