### PR TITLE
Class db: Property $sql_error not defined, used dynamically

### DIFF
--- a/inc/classes/class_db_mysql.php
+++ b/inc/classes/class_db_mysql.php
@@ -52,6 +52,11 @@ class db
     private $QueryArgs = [];
 
     /**
+     * @var string
+     */
+    private $sql_error = '';
+
+    /**
      * @param string $msg
      * @param string $query_string_with_error
      * @return void


### PR DESCRIPTION
The property `sql_error` was never defined. Always used dynamically.