### PR TITLE
Move global functions to composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,15 @@
             "LanSuite\\Module\\CashMgr\\": "modules/cashmgr/Classes/",
             "LanSuite\\Module\\Foodcenter\\": "modules/foodcenter/Classes/"
         },
+        "files": [
+            "inc/Functions/T.php",
+            "inc/Functions/FetchDataRow.php",
+            "inc/Functions/FetchPostRow.php",
+            "inc/Functions/MasterCommentEditAllowed.php",
+            "inc/Functions/CheckValidEmail.php",
+            "inc/Functions/Debug.php",
+            "inc/Functions/DependencyPreCheck.php"
+        ],
         "classmap": [
             "inc/classes/class.crypt.php",
             "inc/classes/class_auth.php",

--- a/index.php
+++ b/index.php
@@ -2,15 +2,6 @@
 // Composer autoloading
 require __DIR__ . '/vendor/autoload.php';
 
-// Load global functions
-// TODO Switch to function autoloading later on
-require_once('inc/Functions/T.php');
-require_once('inc/Functions/FetchDataRow.php');
-require_once('inc/Functions/FetchPostRow.php');
-require_once('inc/Functions/MasterCommentEditAllowed.php');
-require_once('inc/Functions/CheckValidEmail.php');
-
-
 // Set error_reporting.
 // It is set to this value on purpose, because otherwise
 // LanSuite might not work properly anymore.
@@ -240,7 +231,6 @@ $lang = [];
 
 // Debug initialisieren
 if ($config['lansuite']['debugmode'] > 0) {
-    require_once('inc/Functions/Debug.php');
     $debug = new debug($config['lansuite']['debugmode']);
 }
 

--- a/install.php
+++ b/install.php
@@ -3,9 +3,6 @@
 // Raise error reporting - could be interesting and this is automatically reset when index.php is executed
 error_reporting(E_ALL);
 
-// Include check function required for this
-require_once ('inc/Functions/DependencyPreCheck.php');
-
 // Execute install.php only if dependencies are met
 $preCheckResult = dependencyPreCheck();
 if ($preCheckResult){


### PR DESCRIPTION
It moves the global functions

- CheckValidEmail()
- d()
- dependencyPreCheck()
- FetchDataRow()
- FetchPostRow()
- MasterCommentEditAllowed()
- t() and t_no_html()

to the composer autoloader