### PR TITLE
Fix #269: XML Class in Translation not found

### DIFF
--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -363,7 +363,7 @@ class Translation
      */
     private function xml_read_to_array($module) {
         $records = [];
-        $xml = new xml();
+        $xml = new XML();
 
         $lang_file = $this->get_trans_filename($module);
         if (file_exists($lang_file)) {


### PR DESCRIPTION
This PR fixes #269.
The class name was forgotten while refactoring.

