### PR TITLE
Reset attributes of class Party back to public as workaround

### DIFF
--- a/modules/party/Classes/Party.php
+++ b/modules/party/Classes/Party.php
@@ -7,17 +7,17 @@ class Party
     /**
      * @var int
      */
-    private $party_id = 0;
+    public $party_id = 0;
 
     /**
      * @var int
      */
-    private $count = 0;
+    public $count = 0;
 
     /**
      * @var array
      */
-    private $data = [];
+    public $data = [];
 
     public function __construct()
     {


### PR DESCRIPTION
Better would be to write accessor functions, replace all direct accesses and reset the class attributes back to private

See issue reported in #293