### PR TITLE
Added remarks for Fedora as OS to readme

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -37,7 +37,13 @@ $ # Füge den Inhalt der Beispiel-Konfiguration (siehe unten) in ./inc/base/conf
 $ chmod 0777 ./inc/base/config.php
 $ chmod -R 0777 ./ext_inc/
 $ docker-compose up
+$ docker-compose run php composer install
 ```
+
+Hinweis: 
+Einige Distributionen (e.g. Fedora) erlauben nur dem Benutzer `root` Zugriff auf den Socket für den Docker Daemon.
+Dies resultiert in einer Fehlermeldung wie `ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?` 
+In diesem Fall  müssen die beiden `docker-compose` Befehle als Benutzer `root` (über `su` oder `sudo`) ausgeführt werden.
 
 Die Befehlsreihenfolge startet nun einen [Nginx webserver](https://nginx.org/) mit einer [php-fpm](https://secure.php.net/manual/en/install.fpm.php) Konfiguration und einer [MySQL Datenbank](https://www.mysql.com/).
 Wenn alles gestartet wurde, besuche http://<Your-Docker-IP>:8080/ und du siehst ein Einsatzbereites LANSuite-System.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ $ chmod -R 0777 ./ext_inc/
 $ docker-compose up
 $ docker-compose run php composer install
 ```
+Note: 
+Some distributions (e.g. Fedora) restrict access to the docker daemon socket to user `root` only .
+This results in a error message as `ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?` 
+Run the two `docker-compose` commands as user `root` (via `su`or `sudo`) in that case.
 
 This will start a [Nginx webserver](https://nginx.org/) with a [php-fpm](https://secure.php.net/manual/en/install.fpm.php) configuration and a [MySQL database](https://www.mysql.com/) for you.
 After everything started you should be able to visit http://`<Your-Docker-IP>`:8080/ and see a running LanSuite-System.


### PR DESCRIPTION
Based on the issue reported in #145
Updated documentation for Fedora (and I guess similar RedHat derivates) that requires root privileges.
Also found a difference in commands between german and english documentation, also added there
