### PR TITLE
TravisCI: Exclude modules from last phpcs call, because we handle them on their own

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ script:
   - phpcs --standard=PSR1,PSR2 --extensions=php -s --exclude=Generic.Files.LineLength modules/troubleticket
   - phpcs --standard=PSR1,PSR2 --extensions=php -s --exclude=Generic.Files.LineLength,PSR1.Methods.CamelCapsMethodName modules/usrmgr
   - phpcs --standard=PSR1,PSR2 --extensions=php -s --exclude=Generic.Files.LineLength modules/wiki
-  - phpcs --standard=PSR1,PSR2 --extensions=php -s --ignore="/ext_scripts/*,/ext_inc/*,/vendor/*" . || true # Allow failures for now
+  - phpcs --standard=PSR1,PSR2 --extensions=php -s --ignore="/ext_scripts/*,/ext_inc/*,/modules/*,/vendor/*" . || true # Allow failures for now
   - bin/phpunit


### PR DESCRIPTION
This will speed up the TravisCI checks a little bit, because the `module` folder is not checked twice.