### PR TITLE
Fixed deprecated PHP functions create_function() and each()

### DIFF
--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -437,10 +437,11 @@ class Func
             if ($mode != 1) {
                 preg_replace_callback(
                     '#\[c\]((.)*)\[\/c\]#sUi',
-                    create_function(
-                        '$treffer',
-                        'global $HighlightCode, $HighlightCount; $HighlightCount++; $HighlightCode[$HighlightCount] = $treffer[1];'
-                    ),
+                    function ($treffer) {
+                        global $HighlightCode, $HighlightCount;
+                        $HighlightCount++;
+                        $HighlightCode[$HighlightCount] = $treffer[1];
+                    },
                     $string
                 );
             }
@@ -485,20 +486,19 @@ class Func
             if ($mode != 1) {
                 $string = preg_replace_callback(
                     '#\[c\](.)*\[\/c\]#sUi',
-                    create_function(
-                        '$treffer',
-                        'global $func, $HighlightCode, $HighlightCount2;
+                    function ($treffer) {
+                        global $HighlightCode, $HighlightCount2;
                         $HighlightCount2++;
-                        $geshi = new GeSHi($HighlightCode[$HighlightCount2], \'php\');
+                        $geshi = new GeSHi($HighlightCode[$HighlightCount2], 'php');
                         $geshi->set_header_type(GESHI_HEADER_NONE);
-                        return \'
+                        return '
                             <blockquote>
                                 <div class="tbl_small">Code:</div>
                                 <div class="tbl_7">
                                     \'. $func->AllowHTML(\'<code>\' . $geshi->parse_code() . \'</code>\') .\'
                                 </div>
-                            </blockquote>\';'
-                    ),
+                            </blockquote>';
+                    },
                     $string
                 );
             }

--- a/inc/Classes/GD.php
+++ b/inc/Classes/GD.php
@@ -264,7 +264,7 @@ class GD
             $text_parts = preg_split("\r\n", $text);
             $i = 0;
 
-            while (list($key, $val) = each($text_parts)) {
+            foreach ($text_parts as $val) {
                 ImageString($this->img, 2, $xpos, $ypos + $i, $val, $color);
                 $i += ($this->font_size + 2);
             }

--- a/inc/Classes/MasterComment.php
+++ b/inc/Classes/MasterComment.php
@@ -129,7 +129,8 @@ class MasterComment
             
                     // Update LastChange in $update_table, if $update_table is set
                     if ($update_table) {
-                        list($key, $val) = each($update_table);
+                        $key = key($update_table);
+                        $val = current($update_table);
                         $db->qry('UPDATE %prefix%'. $key .' SET changedate=NOW() WHERE '. $val .' = %int%', $id);
                     }
                 }


### PR DESCRIPTION
The PHP functions  [create_function()](https://secure.php.net/manual/en/function.create-function.php) and [each()](https://secure.php.net/manual/en/function.each.php) are deprecated and will be removed in future.