### PR TITLE
 Added symfony/debug component to get more information about errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 
         "smarty/smarty": "^3.1",
         "geshi/geshi": "^1.0.9",
-        "setasign/fpdf": "^1.8"
+        "setasign/fpdf": "^1.8",
+        "symfony/debug": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98ee49778f0eadb9cbb12598c3f412bb",
+    "content-hash": "a9f67ee5e6da225cf36339b5ad34fc1b",
     "packages": [
         {
             "name": "geshi/geshi",
@@ -45,6 +45,53 @@
             "description": "Generic Syntax Highlighter",
             "homepage": "http://qbnz.com/highlighter/",
             "time": "2017-05-05T05:51:25+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "setasign/fpdf",
@@ -137,6 +184,62 @@
                 "templating"
             ],
             "time": "2016-12-14T21:57:25+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b28fd73fefbac341f673f5efd707d539d6a19f68",
+                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-05-16T14:03:39+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -18,9 +18,7 @@ namespace LanSuite;
  *      $debug = new \LanSuite\Debug(1);
  *      $debug->tracker("BEFOREINCLUDE");            // Set Timerpoint
  *      $debug->addvar('$cfg Serverconfig',$cfg);    // Add an Debugvar (Arrays posible)
- *      $debug->timer_start('function sortarray');
  *      $array = sortarray($array)
- *      $debug->timer_stop('function sortarray');
  *      echo $sys_debug->show();                     // Show() generates simple HTML-Output
  *
  * @todo Add percentual display for Tracker/Timer
@@ -84,7 +82,13 @@ class Debug
     private $sql_query_list = [];
 
     /**
-     * debug constructor.
+     * @var bool
+     */
+    private $sql_query_running = false;
+
+    /**
+     * Debug constructor.
+     *
      * @param string $mode          0 = off, 1 = normal, 2 = file
      * @param string $debug_path    Path for filedebug
      */
@@ -164,6 +168,35 @@ class Debug
             } else {
                 $this->debugvars["debugvar_".count($this->debugvars)] = $value;
             }
+        }
+    }
+
+    /**
+     * Start Timer for Querys.
+     * Always use with query_stop()
+     *
+     * @param string $query Executed query string
+     * @return void
+     */
+    public function query_start($query){
+        if (($this->mode > 0) && (!$this->sql_query_running)) {
+            $this->sql_query_running = true;
+            $this->sql_query_start = microtime(true);
+            $this->sql_query_string = $query;
+        }
+    }
+
+    /**
+     * @param string $error
+     * @return void
+     */
+    public function query_stop($error = null){
+        if (($this->mode > 0) && ($this->sql_query_running)) {
+            $this->sql_query_running = false;
+            $sql_query_end = microtime(true);
+            $this->sql_query_list[] = [
+                round(($sql_query_end - $this->sql_query_start) * 1000, 4), $this->sql_query_string, $error
+            ];
         }
     }
 

--- a/index.php
+++ b/index.php
@@ -160,7 +160,9 @@ if (!$config['lansuite']['debugmode']) {
 // This component shows the error in a nice stack trace.
 // More information here: https://symfony.com/components/Debug
 } elseif ($config['lansuite']['debugmode'] > 0) {
-    Debug::enable();
+    // TODO Once LanSuite is notice free, we set the $errorReportingLevel back to E_ALL
+    $errorReportingLevel = E_ALL & ~E_NOTICE;
+    Debug::enable($errorReportingLevel);
 }
 
 // Start session-management


### PR DESCRIPTION
When you enable the `debugmode` in the configuration via

```
[lansuite]
debugmode = 1
```

PHP errors are shown this way:

<img width="1083" alt="standard-lansuite-db-error" src="https://user-images.githubusercontent.com/320064/41123582-6ca6b94e-6a9f-11e8-9f7e-c0e692a20d93.png">

The problem with this kind of errors: The root cause of Database errors (e.g. free calls) are not in the shown file and line. To get the real root cause, we typically need a stack trace.
The [symfony/debug](https://symfony.com/components/Debug) offers an easy way to print nice looking stack traces in error cases.
The same errors shown in the upper image are looking in the debug view like this:

![symfony-debug](https://user-images.githubusercontent.com/320064/41123609-87c1645e-6a9f-11e8-8ed6-0f2b4055be01.png)

The old error handler is still in use, but only if the debugmode is disabled.