### PR TITLE
Module "picgallery": Fix PHP Warning: mysqli_free_result() expects parameter 1 to be mysqli_result, null given

### DIFF
--- a/modules/picgallery/hitlist.php
+++ b/modules/picgallery/hitlist.php
@@ -14,7 +14,7 @@ while ($row = $db->fetch_array($res)) {
     $smarty->assign('text2', '');
     $content .= $smarty->fetch('modules/home/templates/show_row.htm');
 }
-$db->free_result($row);
+$db->free_result($res);
 $smarty->assign('content', $content);
 $MainContent .= $smarty->fetch('modules/home/templates/show_item.htm');
 
@@ -30,7 +30,7 @@ while ($row = $db->fetch_array($res)) {
     $smarty->assign('text2', '');
     $content .= $smarty->fetch('modules/home/templates/show_row.htm');
 }
-$db->free_result($row);
+$db->free_result($res);
 $smarty->assign('content', $content);
 $MainContent .= $smarty->fetch('modules/home/templates/show_item.htm');
 
@@ -57,7 +57,7 @@ while ($row = $db->fetch_array($res)) {
     $smarty->assign('text2', '');
     $content .= $smarty->fetch('modules/home/templates/show_row.htm');
 }
-$db->free_result($row);
+$db->free_result($res);
 $smarty->assign('content', $content);
 $MainContent .= $smarty->fetch('modules/home/templates/show_item.htm');
 
@@ -83,7 +83,7 @@ while ($row = $db->fetch_array($res)) {
     $smarty->assign('text2', '');
     $content .= $smarty->fetch('modules/home/templates/show_row.htm');
 }
-$db->free_result($row);
+$db->free_result($res);
 $smarty->assign('content', $content);
 $MainContent .= $smarty->fetch('modules/home/templates/show_item.htm');
 


### PR DESCRIPTION
This fixes the warnings mentioned by @Pimmal in https://github.com/lansuite/lansuite/issues/322#issuecomment-395349162

Relates: #322