### PR TITLE
Fix "Warning: usort() expects parameter 2 to be a valid callback, function 'compare' not found or invalid function name"

### DIFF
--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -199,7 +199,7 @@ class Debug
      */
     private function sort_array_by_col($array)
     {
-        function compare($wert_a, $wert_b)
+        $compare = function ($wert_a, $wert_b)
         {
             $a = $wert_a[0];
             $b = $wert_b[0];
@@ -207,8 +207,8 @@ class Debug
                 return 0;
             }
             return ($a > $b) ? -1 : +1;
-        }
-        usort($array, 'compare');
+        };
+        usort($array, $compare);
         return $array;
     }
 


### PR DESCRIPTION
When you login, a warning will be thrown that the callback function `compare` is not found.