### PR TITLE
 Make $link argument of Display::FetchIcon optional

### DIFF
--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -232,7 +232,7 @@ class Debug
      */
     private function sort_array_by_col($array)
     {
-        function compare($wert_a, $wert_b)
+        $compare = function ($wert_a, $wert_b)
         {
             $a = $wert_a[0];
             $b = $wert_b[0];
@@ -240,8 +240,8 @@ class Debug
                 return 0;
             }
             return ($a > $b) ? -1 : +1;
-        }
-        usort($array, 'compare');
+        };
+        usort($array, $compare);
         return $array;
     }
 

--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -1221,7 +1221,7 @@ class Display
      * @throws \Exception
      * @throws \SmartyException
      */
-    public function FetchIcon($picname, $link, $hint = null, $target = null, $align = 'left')
+    public function FetchIcon($picname, $link = '', $hint = null, $target = null, $align = 'left')
     {
         global $smarty;
 


### PR DESCRIPTION
This fixes the warnings mentioned by @Pimmal in https://github.com/lansuite/lansuite/issues/322#issuecomment-395383253

Relates: #322