### PR TITLE
Fix "Warning: mysqli_num_rows() expects parameter 1 to be mysqli_result, array given"

### DIFF
--- a/modules/foodcenter/Classes/Category.php
+++ b/modules/foodcenter/Classes/Category.php
@@ -50,9 +50,10 @@ class Category
     private function read()
     {
         global $db;
+
         if ($this->cat_id != null) {
             $row = $db->qry_first("SELECT * FROM %prefix%food_cat WHERE cat_id=%int%", $this->cat_id);
-            if ($db->num_rows($row) > 0) {
+            if (is_array($row)) {
                 $this->name = $row['name'];
                 return true;
             } else {

--- a/modules/foodcenter/Classes/Supplier.php
+++ b/modules/foodcenter/Classes/Supplier.php
@@ -119,7 +119,7 @@ class Supplier
 
         if ($this->supp_id != null) {
             $row = $db->qry_first("SELECT * FROM %prefix%food_supp WHERE supp_id=%int%", $this->supp_id);
-            if ($db->num_rows($row) > 0) {
+            if (is_array($row)) {
                 $this->supp_caption = $row['name'];
                 $this->supp_desc    = $row['s_desc'];
                 return true;


### PR DESCRIPTION
This fixes the warnings mentioned by @Pimmal in https://github.com/lansuite/lansuite/issues/322#issuecomment-395383253

Relates: #322