### PR TITLE
Fix documentation config for correct URL generation

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -10,7 +10,6 @@
     "configuration": "Configuration",
     "installation": "Installation",
     "requirements": "Requirements",
-    "creating-module": "Creating a module",
     "upgrade": "Upgrade to a newer version",
     "Docs": "Docs",
     "Credits": "Credits",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -25,8 +25,8 @@ const siteConfig = {
   baseUrl: '/lansuite/',
 
   // Used for publishing and more
-  projectName: 'LANSuite',
-  organizationName: 'LANSuite',
+  projectName: 'lansuite',
+  organizationName: 'lansuite',
 
   headerLinks: [
     {doc: 'installation', label: 'Docs'},


### PR DESCRIPTION
Github pages seem to be case sensitive and related to the original repository name.
This PR fixes the URL generation for github pages.

Furthermore, I removed one documentation menu point, because the article "Creating a module" is not written yet.