### PR TITLE
Switch LANSuite version string from configuration to constant LANSUITE_VERSION

### DIFF
--- a/inc/base/define.php
+++ b/inc/base/define.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * Version of LANSuite
+ */
+define('LANSUITE_VERSION', '5.0-dev');
+
 define('VALID_LS', true);
 
 define('HTML_NEWLINE', '<br/>');

--- a/index.php
+++ b/index.php
@@ -125,6 +125,9 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
 
 $PHPErrors = '';
 
+// Read definition file
+include_once('inc/base/define.php');
+
 // Read Config and Definitionfiles
 // Load Basic Config
 if (file_exists('inc/base/config.php')) {
@@ -134,7 +137,6 @@ if (file_exists('inc/base/config.php')) {
 } else {
     $config = [];
 
-    $config['lansuite']['version'] = 'Nightly';
     $config['lansuite']['default_design'] = 'simple';
     $config['lansuite']['chmod_dir'] = '777';
     $config['lansuite']['chmod_file'] = '666';
@@ -245,9 +247,6 @@ if (!get_magic_quotes_gpc()) {
         }
     }
 }
-
-// Read definition file
-include_once('inc/base/define.php');
 
 // Include and Initialize base classes
 $lang = [];

--- a/modules/about/credits.php
+++ b/modules/about/credits.php
@@ -1,5 +1,5 @@
 <?php
-$dsp->NewContent($config['lansuite']['version'], 'A web based lanparty administration tool');
+$dsp->NewContent(LANSUITE_VERSION, 'A web based lanparty administration tool');
 
 $dsp->AddSingleRow('<b>Contact</b>', 'align="center"');
 $dsp->AddSingleRow('internet: <a href="http://www.lansuite.de" target="_blank">http://www.lansuite.de</a><br />

--- a/modules/about/license.php
+++ b/modules/about/license.php
@@ -1,4 +1,4 @@
 <?php
-$dsp->NewContent($config['lansuite']['version'], 'A web based lanparty administration tool');
+$dsp->NewContent(LANSUITE_VERSION, 'A web based lanparty administration tool');
 $dsp->AddSmartyTpl('license', 'about');
 $dsp->AddBackButton("index.php?mod=about", "about/license");

--- a/modules/about/overview.php
+++ b/modules/about/overview.php
@@ -1,5 +1,5 @@
 <?php
-$dsp->NewContent($config['lansuite']['version'], 'A web based lanparty administration tool');
+$dsp->NewContent(LANSUITE_VERSION, 'A web based lanparty administration tool');
 
 $dsp->AddFieldsetStart(t('Information'));
 $dsp->AddDoubleRow('', '<a href="index.php?mod=about&action=credits">credits</a>');

--- a/modules/bugtracker/add.php
+++ b/modules/bugtracker/add.php
@@ -46,7 +46,7 @@ if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']
     if (!$_GET['bugid']) {
         $mf->AddFix('date', 'NOW()');
         if ($_SERVER['SERVER_NAME'] != 'lansuite.orgapage.de') {
-            $mf->AddFix('version', $config['lansuite']['version']);
+            $mf->AddFix('version', LANSUITE_VERSION);
         }
         $mf->AddFix('url', $_SERVER['SERVER_NAME']);
         $mf->AddFix('reporter', $auth['userid']);

--- a/modules/bugtracker/export.php
+++ b/modules/bugtracker/export.php
@@ -4,7 +4,7 @@ switch ($_GET['step']) {
         $dsp->NewContent(t('Bugtracker Export'), t('Nutze diese Funktion um einen Export der Bugtracker-Einträge zu erstellen, den sie auf lansuite.de importieren können'));
         $dsp->AddDoubleRow('', t('Bitte versuche Fehler zunächst selbst zu beheben und filter vor dem Export Probleme aus, die nicht von generellem Interesse für Lansuite sind. Es werden nur Probleme mit Status offen, oder bestätigt exportiert. Ergänze unvollständige Angaben, so gut du kannst. Danke, für die Hilfe!'));
         $dsp->SetForm('index.php?mod=bugtracker&action=export&step=2');
-        $dsp->AddTextFieldRow('version', t('Version'), $config['lansuite']['version'], '');
+        $dsp->AddTextFieldRow('version', t('Version'), LANSUITE_VERSION, '');
         $dsp->AddTextFieldRow('url', t('URL'), $_SERVER['SERVER_NAME'], '');
         $dsp->AddFormSubmitRow('next');
         break;

--- a/modules/install/Classes/Export.php
+++ b/modules/install/Classes/Export.php
@@ -292,7 +292,7 @@ class Export
 
         $seat2 = new Seat2();
 
-        $user_export = $config['lansuite']['version']." CSV Export\r\nParty: ". $_SESSION['party_info']['name'] ."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
+        $user_export = LANSUITE_VERSION." CSV Export\r\nParty: ". $_SESSION['party_info']['name'] ."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
 
         $user_export .= "tmp userid;email;username;name;firstname;sex;street;hnr;plz;city;md5pwd;usertype;paid;seatcontrol;clan;clanurl;wwclid;nglid;checkin;checkout;signondate;paiddate;birthday;seatblock;seat;ip;comment\r\n";
 
@@ -377,7 +377,7 @@ class Export
 
         $seat2 = new Seat2();
 
-        $user_export = $config['lansuite']['version']." CSV Export\r\nParty: ".$config['lanparty']['name']."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
+        $user_export = LANSUITE_VERSION." CSV Export\r\nParty: ".$config['lanparty']['name']."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
 
         $user_export .= "username;name;firstname;clan;seatblock;seat;ip\r\n";
         $query = $db->qry("
@@ -434,7 +434,7 @@ class Export
 
         $seat2 = new Seat2();
 
-        $user_export = $config['lansuite']['version']." CSV Export\r\nParty: ".$config['lanparty']['name']."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
+        $user_export = LANSUITE_VERSION." CSV Export\r\nParty: ".$config['lanparty']['name']."\r\nExportdate: ".$func->unixstamp2date(time(), 'daydatetime')."\r\n\r\n";
         $user_export .= "username;name;firstname;clan;seatblock;col;row;seat;ip\n";
     
         $query = $db->qry("

--- a/modules/usrmgr/Classes/UserManager.php
+++ b/modules/usrmgr/Classes/UserManager.php
@@ -229,7 +229,7 @@ class UserManager
         $xml = new \LanSuite\XML();
         $output = '<?xml version="1.0" encoding="UTF-8"?'.'>'."\r\n";
 
-        $system = $xml->write_tag('version', $config['lansuite']['version'], 2);
+        $system = $xml->write_tag('version', LANSUITE_VERSION, 2);
         $system .= $xml->write_tag('name', $cfg['feed_partyname'], 2);
         $system .= $xml->write_tag('link', $cfg['sys_partyurl'], 2);
         $system .= $xml->write_tag('language', 'de-de', 2);


### PR DESCRIPTION
The LANSuite Version is right now part of the configuration.
This configuration is created by the (end)user.

The string `version` defined which state of LANSuite you are using.
In the code itself, it is only used to show the version. But it doesn't have a bigger effect and should not be edited by the user.

The development team + contributor of LANSuite are defining by development the version of LANSuite. Furthermore, the version as constant can be used for a better upgrade procedure.