### PR TITLE
Fixed some warnings by putting strings into quotes

### DIFF
--- a/modules/install/boxes/login.php
+++ b/modules/install/boxes/login.php
@@ -11,7 +11,7 @@ $smarty->assign('buttons_login', '<input type="submit" class="Button" name="logi
 
 // TODO Remove static IP address, because lansuite.orgapage.de is not the mainsite anymore
 // 62.67.200.4 = Proxy IP of https://sslsites.de/lansuite.orgapage.de
-if ($cfg['sys_partyurl_ssl'] && ($_SERVER['HTTPS'] != 'on' && getenv(REMOTE_ADDR) != "62.67.200.4")) {
+if ($cfg['sys_partyurl_ssl'] && ($_SERVER['HTTPS'] != 'on' && getenv('REMOTE_ADDR') != "62.67.200.4")) {
     $smarty->assign('ssl_link', $cfg['sys_partyurl_ssl']);
 }
 

--- a/modules/news/show.php
+++ b/modules/news/show.php
@@ -52,9 +52,9 @@ if ($overall_news == 0) {
             while ($row=$db->fetch_array($get_news)) {
                 $priority = $row["priority"];
                 if ($priority == 1) {
-                    $type = important;
+                    $type = 'important';
                 } else {
-                    $type = normal;
+                    $type = 'normal';
                 }
 
                 $smarty->assign('caption', $row["caption"]);
@@ -119,9 +119,9 @@ if ($overall_news == 0) {
             while ($row=$db->fetch_array($get_news)) {
                 $priority = $row["priority"];
                 if ($priority == 1) {
-                    $type = important;
+                    $type = 'important';
                 } else {
-                    $type = normal;
+                    $type = 'normal';
                 }
 
                 $smarty->assign('caption', $row["caption"]);

--- a/modules/sponsor/banner.php
+++ b/modules/sponsor/banner.php
@@ -1,7 +1,8 @@
 <?php
 
 // 62.67.200.4 = Proxy IP of https://sslsites.de/lansuite.orgapage.de
-if ($_SERVER['HTTPS'] == 'on' || getenv(REMOTE_ADDR) == "62.67.200.4") {
+// @TODO: Rework this!
+if ($_SERVER['HTTPS'] == 'on' || getenv('REMOTE_ADDR') == "62.67.200.4") {
     $where = "rotation AND ((pic_path != '' AND pic_path != 'http://') OR pic_path_banner != '') AND !ssl_hide_banner";
 } else {
     $where = "rotation AND ((pic_path != '' AND pic_path != 'http://') OR pic_path_banner != '')";

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -89,7 +89,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
                 $mf->AddFix('type', 1);
             }
   
-            $mf->AddField(t('E-Mail'), 'email', '', '', '', CheckValidEmail);
+            $mf->AddField(t('E-Mail'), 'email', '', '', '', 'CheckValidEmail');
             $mf->AddField(t('E-Mail wiederholen'), 'email2', '', '', '');
             if (($_GET['action'] != 'change' && $_GET['action'] != 'entrance') || ($_GET['action'] == 'entrance' && !$_GET['userid'])) {
                 if ($cfg['signon_autopw']) {


### PR DESCRIPTION
some of these are directly in use within `index.php` which makes this important to fix, because otherwise the debug mode is half-unusable (is triggered by the warning, instead of the issue you want to debug)