### PR TITLE
Fixes cron2 triggering a warning if no job is to be executed.

### DIFF
--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -335,9 +335,12 @@ class DB
         if ($this->query_id === true) {
             return true;
         }
-
-        $row = $this->fetch_array();
-        $this->free_result();
+		if ($this->query_id->num_rows >0) { // only try to fetch something if we got a valid result
+			$row = $this->fetch_array();
+			$this->free_result();
+		} else {
+			$row = false; // just return false otherwise
+		}
         return $row;
     }
 

--- a/modules/cron2/Classes/Cron2.php
+++ b/modules/cron2/Classes/Cron2.php
@@ -17,17 +17,17 @@ class Cron2
         }
 
         $row = $db->qry_first("SELECT name, type, function FROM %prefix%cron WHERE jobid = %int%", $jobid);
-    
-        if ($row['type'] == 'sql') {
-            $db->qry('%plain%', $func->AllowHTML($row['function']));
-        } elseif ($row['type'] == "php") {
-            require_once 'ext_scripts/'.$row['function'];
+        if ($row != false) {
+            if ($row['type'] == 'sql') {
+                $db->qry('%plain%', $func->AllowHTML($row['function']));
+            } elseif ($row['type'] == "php") {
+                require_once 'ext_scripts/'.$row['function'];
+            }
+            $db->qry("UPDATE %prefix%cron SET lastrun = NOW() WHERE jobid = %int%", $jobid);
+            $func->log_event(t('Cronjob "%1" wurde ausgeführt', array($row['name'])), 1);
+            return $row['function'];
         }
-        $db->qry("UPDATE %prefix%cron SET lastrun = NOW() WHERE jobid = %int%", $jobid);
-
-        $func->log_event(t('Cronjob "%1" wurde ausgeführt', array($row['name'])), 1);
-
-        return $row['function'];
+        return false;
     }
 
     /**


### PR DESCRIPTION
Cron2 uses qry_first to get the next job to be Run
Only if there is none it causes a warning

This modifies DB.php to not iterate through an empty result and also stops processing in cron2 if nothing is to be done