### PR TITLE
Move file inc/base/define.php to composer autoloading to be available from the start on

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
             "LanSuite\\": "inc/Classes"
         },
         "files": [
+            "inc/base/define.php",
             "inc/Functions/T.php",
             "inc/Functions/FetchDataRow.php",
             "inc/Functions/FetchPostRow.php",

--- a/index.php
+++ b/index.php
@@ -125,9 +125,6 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
 
 $PHPErrors = '';
 
-// Read definition file
-include_once('inc/base/define.php');
-
 // Read Config and Definitionfiles
 // Load Basic Config
 if (file_exists('inc/base/config.php')) {


### PR DESCRIPTION
This is a follow up from #373.
The constants are defined in `inc/base/define.php`.
This file is still loaded manual and is not available from the start on.

With moving it to composer this is available everywhere.
After applying this PR you need to fire a `composer dump-autoload`.