### PR TITLE
Fix #375: Used correct string handling for constant HTML_NEWLINE

### DIFF
--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -763,7 +763,7 @@ class Install
                 if ($env_stats == "") {
                     $server_stats = $ok;
                 } else {
-                    $server_stats = $not_possible . str_replace("{FEHLER}", $env_stats, t('Auf ihrem System leider nicht möglich. Der Befehl oder die Datei HTML_NEWLINE{FEHLER} wurde nicht gefunden. Evtl. sind nur die Berechtigungen der Datei nicht ausreichend gesetzt.'));
+                    $server_stats = $not_possible . str_replace("{FEHLER}", $env_stats, t('Auf ihrem System leider nicht möglich. Der Befehl oder die Datei ' . HTML_NEWLINE . '{FEHLER} wurde nicht gefunden. Evtl. sind nur die Berechtigungen der Datei nicht ausreichend gesetzt.'));
                 }
 
                 $config["server_stats"]["status"] = 1;
@@ -773,7 +773,7 @@ class Install
                     $server_stats = $ok;
                 } else {
                     $env_stats = "<strong>modules/stats/ls_getinfo.exe</strong>" . HTML_NEWLINE;
-                    $server_stats = $not_possible . str_replace("{FEHLER}", $env_stats, t('Auf ihrem System leider nicht möglich. Der Befehl oder die Datei HTML_NEWLINE{FEHLER} wurde nicht gefunden. Evtl. sind nur die Berechtigungen der Datei nicht ausreichend gesetzt.'));
+                    $server_stats = $not_possible . str_replace("{FEHLER}", $env_stats, t('Auf ihrem System leider nicht möglich. Der Befehl oder die Datei ' . HTML_NEWLINE . '{FEHLER} wurde nicht gefunden. Evtl. sind nur die Berechtigungen der Datei nicht ausreichend gesetzt.'));
                 }
             }
               $dsp->AddDoubleRow("Server Stats", $server_stats);

--- a/modules/install/modules.php
+++ b/modules/install/modules.php
@@ -31,7 +31,7 @@ switch ($_GET["step"]) {
 
     // Question: Reset all Modules
     case 3:
-        $func->question(t('Sollen wirklich <b>\'alle Module\'</b> zurückgesetzt werden?HTML_NEWLINEDies wirkt sich <u>nicht</u> auf die Datenbankeinträge der Module aus, jedoch gehen alle Einstellungen und Menüänderungen verloren, die zu den Modulen getätigt worden sind. Außerdem sind danach nur noch die Standardmodule aktiviert.'), "index.php?mod=install&action=modules&rewrite=all", "index.php?mod=install&action=modules");
+        $func->question(t('Sollen wirklich <b>\'alle Module\'</b> zurückgesetzt werden?' . HTML_NEWLINE . ' Dies wirkt sich <u>nicht</u> auf die Datenbankeinträge der Module aus, jedoch gehen alle Einstellungen und Menüänderungen verloren, die zu den Modulen getätigt worden sind. Außerdem sind danach nur noch die Standardmodule aktiviert.'), "index.php?mod=install&action=modules&rewrite=all", "index.php?mod=install&action=modules");
         break;
 
     // Question: Reset this Module
@@ -95,7 +95,7 @@ switch ($_GET["step"]) {
     case 23:
         $row = $db->qry_first("SELECT requirement FROM %prefix%menu WHERE id=%int%", $_GET["id"]);
         if ($row['requirement'] > 0) {
-            $func->information(t('Mit diesem Eintrag ist eine Zugriffsberechtigung verknüpft. Du solltest diesen Eintrag daher nicht löschen, da sonst jeder Zugriff auf die betreffende Datei hat.HTML_NEWLINEWenn du nur den Menülink entfernen möchten, lösche die Felder Titel und Linkziel.HTML_NEWLINEWenn du wirklich jedem Zugriff auf die Datei geben möchten, setze den Zugriff auf Jeder und lösche dann den Eintrag.'), "index.php?mod=install&action=modules&step=20&module={$_GET["module"]}");
+            $func->information(t('Mit diesem Eintrag ist eine Zugriffsberechtigung verknüpft. Du solltest diesen Eintrag daher nicht löschen, da sonst jeder Zugriff auf die betreffende Datei hat.' . HTML_NEWLINE . 'Wenn du nur den Menülink entfernen möchten, lösche die Felder Titel und Linkziel.' . HTML_NEWLINE . 'Wenn du wirklich jedem Zugriff auf die Datei geben möchten, setze den Zugriff auf Jeder und lösche dann den Eintrag.'), "index.php?mod=install&action=modules&step=20&module={$_GET["module"]}");
         } else {
             $db->qry("DELETE FROM %prefix%menu WHERE id=%int%", $_GET["id"]);
             $func->confirmation(t('Der Menü-Eintrag wurde erfolgreich gelöscht'), "index.php?mod=install&action=modules&step=20&module={$_GET["module"]}");

--- a/modules/msgsys/add.php
+++ b/modules/msgsys/add.php
@@ -97,7 +97,7 @@ switch ($_GET['step']) {
                     $names1 .= "$item";
                 }
                 $func->confirmation(str_replace('%NAMES1%', $names1, t('Die folgenden Benutzer wurden in deiner Buddy-Liste hinzugef&uuml;gt:
-                                           <b>%NAMES1%</b> HTML_NEWLINE Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf sichtbar.')));
+                                           <b>%NAMES1%</b> ' . HTML_NEWLINE . ' Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf sichtbar.')));
 
             // Partly Successful
             } elseif (count($sux) > "0" && count($err) > "0") {
@@ -114,23 +114,23 @@ switch ($_GET['step']) {
                     $names2 .= "$item";
                 }
                 $func->confirmation(str_replace('%NAMES2%', $names2, str_replace('%NAMES1%', $names1, t('Die folgenden Benutzer wurden in deiner Buddy-Liste hinzugef&uuml;gt:
-                                           <b>%NAMES1%</b> HTML_NEWLINE
+                                           <b>%NAMES1%</b> ' . HTML_NEWLINE . '
                                            Folgende Benutzer konnten nicht in deiner Buddy-Liste hinzugef&uuml;gt werden:
-                                           <b>%NAMES2%</b> HTML_NEWLINE
-                                           Dies kann folgende Ursachen haben: HTML_NEWLINE
-                                           - Der Benutzer ist bereits in deiner Buddy-Liste HTML_NEWLINE
-                                           - Der Benutzer existiert nicht HTML_NEWLINE
-                                           - Es sind bereits zuviele Benutzer in deiner Buddy-Liste HTML_NEWLINE
-                                           - Du versuchst dich selbst in die Buddy-Liste hinzuzuf&uuml;gen HTML_NEWLINE
+                                           <b>%NAMES2%</b> ' . HTML_NEWLINE . '
+                                           Dies kann folgende Ursachen haben: ' . HTML_NEWLINE . '
+                                           - Der Benutzer ist bereits in deiner Buddy-Liste ' . HTML_NEWLINE . '
+                                           - Der Benutzer existiert nicht ' . HTML_NEWLINE . '
+                                           - Es sind bereits zuviele Benutzer in deiner Buddy-Liste ' . HTML_NEWLINE . '
+                                           - Du versuchst dich selbst in die Buddy-Liste hinzuzuf&uuml;gen ' . HTML_NEWLINE . '
                                            Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf sichtbar.'))), "");
                 // Not successful
             } elseif (count($sux) == "0" && count($err) > "0") {
-                $func->error(t('Es konnten keine Benutzer in die Buddy-Liste hinzugef&uuml;gt werden. HTML_NEWLINE
-                      Dies kann folgende Ursachen haben: HTML_NEWLINE
-                      - Der Benutzer ist bereits in deiner Buddy-Liste HTML_NEWLINE
-                      - Der Benutzer existiert nicht HTML_NEWLINE
-                      - Es sind bereits zuviele Benutzer in deiner Buddy-Liste HTML_NEWLINE
-                      - Du versuchst dich selbst in die Buddy-Liste hinzuzuf&uuml;gen HTML_NEWLINE'));
+                $func->error(t('Es konnten keine Benutzer in die Buddy-Liste hinzugef&uuml;gt werden. ' . HTML_NEWLINE . '
+                      Dies kann folgende Ursachen haben: ' . HTML_NEWLINE . '
+                      - Der Benutzer ist bereits in deiner Buddy-Liste ' . HTML_NEWLINE . '
+                      - Der Benutzer existiert nicht ' . HTML_NEWLINE . '
+                      - Es sind bereits zuviele Benutzer in deiner Buddy-Liste ' . HTML_NEWLINE . '
+                      - Du versuchst dich selbst in die Buddy-Liste hinzuzuf&uuml;gen ' . HTML_NEWLINE));
             }
         }
         break;

--- a/modules/noc/class_noc.php
+++ b/modules/noc/class_noc.php
@@ -202,11 +202,11 @@ class noc
                         $dsp->AddHRuleRow();
                     }
                 } else {
-                    $dsp->AddSingleRow(t('Die Adresse konnte nicht gefunden werden.HTML_NEWLINEDie Adressen werden bei der Ansicht des Device aktuallisiert.'));
+                    $dsp->AddSingleRow(t('Die Adresse konnte nicht gefunden werden.' . HTML_NEWLINE . 'Die Adressen werden bei der Ansicht des Device aktuallisiert.'));
                 }
             }
         } else {
-            $dsp->AddSingleRow(t('Die Adresse konnte nicht gefunden werden.HTML_NEWLINEDie Adressen werden bei der Ansicht des Device aktuallisiert.'));
+            $dsp->AddSingleRow(t('Die Adresse konnte nicht gefunden werden.' . HTML_NEWLINE . 'Die Adressen werden bei der Ansicht des Device aktuallisiert.'));
         }
     }
 }

--- a/modules/noc/device_add.php
+++ b/modules/noc/device_add.php
@@ -53,7 +53,7 @@ switch ($_GET["step"]) {
     default:
     case 1:
         $dsp->NewContent(t('Device hinzuf&uuml;gen'), t('Um einen Device zum NOC hinzuzuf&uuml;gen, f&uuml;lle bitte
-				         		  das folgende Formular vollst&auml;ndig aus.HTML_NEWLINEF&uuml;r das Feld Name
+				         		  das folgende Formular vollst&auml;ndig aus.' . HTML_NEWLINE . 'F&uuml;r das Feld Name
               					   stehen 30 Zeichen zur Verf&uuml;gung. '));
         $dsp->SetForm("index.php?mod=noc&action=add_device&step=2", "noc");
         $dsp->AddTextFieldRow("device_caption", t('Name'), $_POST['device_caption'], $noc_error['device_caption']);
@@ -71,16 +71,16 @@ switch ($_GET["step"]) {
     // Store Everything, print confirmation
     case 2:
         if ($noc->checkSNMPDevice($_POST["device_ip"], $_POST["device_read"]) != 1) {
-            $func->error(t('HTML_NEWLINEDas Device konnte nicht erreicht werden. M&ouml;gl. Ursachen:HTML_NEWLINEHTML_NEWLINE
-				      				- Das Device hat keinen StromHTML_NEWLINE
-				      				- Das Device hat noch keine IP-AdresseHTML_NEWLINE
-				      				- Das Device unterst&uuml;tzt kein SNMPHTML_NEWLINE
-				      				- Du hast eine falsche Read-Community angegebenHTML_NEWLINE
-				      				- Du hast eine falsche IP-Adresse angegebenHTML_NEWLINE
-				      				- Du hast vergessen, SNMP am device einzuschaltenHTML_NEWLINE
-				      				- Dieses PHP unterst&uuml;tzt kein SNMP, kompilieren sie es mit SNMPHTML_NEWLINE
-				      				&nbsp; &nbsp;oder laden sie sich ein vorkompiliertes PHP mit SNMP vonHTML_NEWLINE
-				      				&nbsp; &nbsp;<a href="http://de.php.net">Der Deutschen PHP Seite</a> herunterHTML_NEWLINE, '), "index.php?mod=noc&action=add_device&step=1");
+            $func->error(t(HTML_NEWLINE . 'Das Device konnte nicht erreicht werden. M&ouml;gl. Ursachen:' . HTML_NEWLINE . HTML_NEWLINE . '
+				      				- Das Device hat keinen Strom' . HTML_NEWLINE . '
+				      				- Das Device hat noch keine IP-Adresse' . HTML_NEWLINE . '
+				      				- Das Device unterst&uuml;tzt kein SNMP' . HTML_NEWLINE . '
+				      				- Du hast eine falsche Read-Community angegeben' . HTML_NEWLINE . '
+				      				- Du hast eine falsche IP-Adresse angegeben' . HTML_NEWLINE . '
+				      				- Du hast vergessen, SNMP am device einzuschalten' . HTML_NEWLINE . '
+				      				- Dieses PHP unterst&uuml;tzt kein SNMP, kompilieren sie es mit SNMP' . HTML_NEWLINE . '
+				      				&nbsp; &nbsp;oder laden sie sich ein vorkompiliertes PHP mit SNMP von' . HTML_NEWLINE . '
+				      				&nbsp; &nbsp;<a href="http://de.php.net">Der Deutschen PHP Seite</a> herunter' . HTML_NEWLINE . ', '), "index.php?mod=noc&action=add_device&step=1");
             break;
         }
 
@@ -213,11 +213,11 @@ switch ($_GET["step"]) {
             $confirmationtext = t('Das Device wurde erfolgreich eingetragen.');
             
             if ($_POST['device_write'] == "private") {
-                $confirmationtext .= t('HTML_NEWLINEHTML_NEWLINE<big>Warnung:</big> Eine Standardm&auml;ßig eingestellte Write-Community ( /\'/private/\'/ ) beinhaltet ein hohes Sicherheitsrisiko!');
+                $confirmationtext .= t(HTML_NEWLINE . HTML_NEWLINE . '<big>Warnung:</big> Eine Standardm&auml;ßig eingestellte Write-Community ( /\'/private/\'/ ) beinhaltet ein hohes Sicherheitsrisiko!');
             }
             
             if ($_POST['device_read'] == "public") {
-                $confirmationtext .= t('HTML_NEWLINEHTML_NEWLINE<big>Warnung:</big> Eine Standardm&auml;ßig eingestellte Read-Community ( /\'/public/\'/ ) beinhaltet ein hohes Sicherheitsrisiko!');
+                $confirmationtext .= t(HTML_NEWLINE . HTML_NEWLINE . '<big>Warnung:</big> Eine Standardm&auml;ßig eingestellte Read-Community ( /\'/public/\'/ ) beinhaltet ein hohes Sicherheitsrisiko!');
             }
         
             $func->confirmation($confirmationtext, "");

--- a/modules/noc/device_change.php
+++ b/modules/noc/device_change.php
@@ -62,7 +62,7 @@ switch ($_GET["step"]) {
             $device_write = $row["writecommunity"];
 
             $dsp->NewContent(t('Device hinzuf&uuml;gen'), t('Um einen Device zum NOC hinzuzuf&uuml;gen, f&uuml;lle bitte
-				         		  das folgende Formular vollst&auml;ndig aus.HTML_NEWLINEF&uuml;r das Feld Name
+				         		  das folgende Formular vollst&auml;ndig aus.' . HTML_NEWLINE . 'F&uuml;r das Feld Name
               					   stehen 30 Zeichen zur Verf&uuml;gung. '));
             $dsp->SetForm("index.php?mod=noc&action=change_device&step=3&deviceid=" . $_GET["deviceid"], "noc");
             $dsp->AddTextFieldRow("device_caption", t('Name'), $device_caption, $noc_error['device_caption']);
@@ -85,16 +85,16 @@ switch ($_GET["step"]) {
     // Check and Update Device Data
     case 3:
         if ($noc->checkSNMPDevice($_POST["device_ip"], $_POST["device_read"]) != 1) {
-            $func->error(t('HTML_NEWLINEDas Device konnte nicht erreicht werden. M&ouml;gl. Ursachen:HTML_NEWLINEHTML_NEWLINE
-				      				- Das Device hat keinen StromHTML_NEWLINE
-				      				- Das Device hat noch keine IP-AdresseHTML_NEWLINE
-				      				- Das Device unterst&uuml;tzt kein SNMPHTML_NEWLINE
-				      				- Du hast eine falsche Read-Community angegebenHTML_NEWLINE
-				      				- Du hast eine falsche IP-Adresse angegebenHTML_NEWLINE
-				      				- Du hast vergessen, SNMP am device einzuschaltenHTML_NEWLINE
-				      				- Dieses PHP unterst&uuml;tzt kein SNMP, kompilieren sie es mit SNMPHTML_NEWLINE
-				      				&nbsp; &nbsp;oder laden sie sich ein vorkompiliertes PHP mit SNMP vonHTML_NEWLINE
-				      				&nbsp; &nbsp;<a href="http://de.php.net">Der Deutschen PHP Seite</a> herunterHTML_NEWLINE, '));
+            $func->error(t(HTML_NEWLINE . 'Das Device konnte nicht erreicht werden. M&ouml;gl. Ursachen:' . HTML_NEWLINE . HTML_NEWLINE . '
+				      				- Das Device hat keinen Strom' . HTML_NEWLINE . '
+				      				- Das Device hat noch keine IP-Adresse' . HTML_NEWLINE . '
+				      				- Das Device unterst&uuml;tzt kein SNMP' . HTML_NEWLINE . '
+				      				- Du hast eine falsche Read-Community angegeben' . HTML_NEWLINE . '
+				      				- Du hast eine falsche IP-Adresse angegeben' . HTML_NEWLINE . '
+				      				- Du hast vergessen, SNMP am device einzuschalten' . HTML_NEWLINE . '
+				      				- Dieses PHP unterst&uuml;tzt kein SNMP, kompilieren sie es mit SNMP' . HTML_NEWLINE . '
+				      				&nbsp; &nbsp;oder laden sie sich ein vorkompiliertes PHP mit SNMP von' . HTML_NEWLINE . '
+				      				&nbsp; &nbsp;<a href="http://de.php.net">Der Deutschen PHP Seite</a> herunter' . HTML_NEWLINE .', '));
             break;
         } // END IF
         

--- a/modules/noc/device_delete.php
+++ b/modules/noc/device_delete.php
@@ -10,7 +10,7 @@ switch ($_GET["step"]) {
         break;
     
     case 2:
-        $func->question(t('Willst du dieses Device wirklich l&ouml;schen?HTML_NEWLINE
+        $func->question(t('Willst du dieses Device wirklich l&ouml;schen?' . HTML_NEWLINE . '
 				 				   Dadurch gehen alle (auch f&uuml;r die Statistik relevante) Informationen verloren'), "index.php?mod=noc&action=delete_device&step=3&deviceid=" . $_GET["deviceid"], "index.php?mod=noc");
          
         break;

--- a/modules/noc/device_details.php
+++ b/modules/noc/device_details.php
@@ -347,7 +347,7 @@ if (!$row = $db->fetch_array()) {
 
                         $text .= $noc_data . t('Der Portstatus wurde ge&auml;ndert') . HTML_NEWLINE;
                     } else {
-                        $text .= $noc_data . t('Der Port auf konnte nicht ge&auml;ndert werden.HTML_NEWLINE
+                        $text .= $noc_data . t('Der Port auf konnte nicht ge&auml;ndert werden.' . HTML_NEWLINE . '
 											 Pr&uuml;fen sie die Einstellung der Write-Community') . HTML_NEWLINE;
                     }
                 }
@@ -387,7 +387,7 @@ if (!$row = $db->fetch_array()) {
 
                     $text .= $noc_data . t('Der Portstatus wurde ge&auml;ndert') . HTML_NEWLINE;
                 } else {
-                    $text .= $noc_data . t('Der Port auf konnte nicht ge&auml;ndert werden.HTML_NEWLINE
+                    $text .= $noc_data . t('Der Port auf konnte nicht ge&auml;ndert werden.' . HTML_NEWLINE . '
 											 Pr&uuml;fen sie die Einstellung der Write-Community') . HTML_NEWLINE;
                     $noc_error = 1;
                 }

--- a/modules/noc/port_details.php
+++ b/modules/noc/port_details.php
@@ -105,7 +105,7 @@ switch ($_GET["step"]) {
             
                 $func->confirmation(t('Der Portstatus wurde ge&auml;ndert'), "index.php?mod=noc&action=port_details&portid={$_GET["portid"]}");
             } else {
-                $func->error(t('Der Port auf konnte nicht ge&auml;ndert werden.HTML_NEWLINE
+                $func->error(t('Der Port auf konnte nicht ge&auml;ndert werden.' . HTML_NEWLINE . '
 											 Pr&uuml;fen sie die Einstellung der Write-Community'), "index.php?mod=noc&action=port_details&portid={$_GET["portid"]}");
             }
         }//port exists

--- a/modules/seating/seatadmin.php
+++ b/modules/seating/seatadmin.php
@@ -98,10 +98,10 @@ switch ($_GET['step']) {
                     $questionarray = array();
                     $linkarray = array();
                     if ($new_user['paid'] == 0) {
-                        $markinfo = "HTML_NEWLINE(Alle markierten Sitzplätze von %1 werden gelöscht, da %1 noch nicht bezahlt hat)";
+                        $markinfo = HTML_NEWLINE . "(Alle markierten Sitzplätze von %1 werden gelöscht, da %1 noch nicht bezahlt hat)";
                     }
 
-                    array_push($questionarray, t('Sitzplatz für %1 reservierenHTML_NEWLINE(Ein evtl. zuvor für diesen Benutzer reservierter Platz wird freigegeben)', $new_user['username']));
+                    array_push($questionarray, t('Sitzplatz für %1 reservieren' . HTML_NEWLINE . '(Ein evtl. zuvor für diesen Benutzer reservierter Platz wird freigegeben)', $new_user['username']));
                     array_push($linkarray, "index.php?mod=seating&action=seatadmin&step=11&userid={$_GET['userid']}&blockid={$_GET['blockid']}&row={$_GET['row']}&col={$_GET['col']}");
 
                     array_push($questionarray, t('Sitzplatz für %1 markieren'.$markinfo, $new_user['username']));
@@ -110,7 +110,7 @@ switch ($_GET['step']) {
                     array_push($questionarray, t('Aktion abbrechen. Zurück zum Sitzplan'));
                     array_push($linkarray, "index.php?mod=seating&action=seatadmin&step=3&userid={$_GET['userid']}&blockid={$_GET['blockid']}");
             
-                    $func->multiquestion($questionarray, $linkarray, t('Dieser Sitzplatz ist noch frei (bzw. nur markiert)HTML_NEWLINESoll er fest reserviert oder nur markiert werden?'));
+                    $func->multiquestion($questionarray, $linkarray, t('Dieser Sitzplatz ist noch frei (bzw. nur markiert)' . HTML_NEWLINE . 'Soll er fest reserviert oder nur markiert werden?'));
                 }
                 break;
 


### PR DESCRIPTION
This one is a more proper solution of the usage of `HTML_NEWLINE` constant.
See also #375