### PR TITLE
mastersearch2: Fix PHP7.2 warning about count() on now non-countable objects

### DIFF
--- a/modules/mastersearch2/templates/result_case.htm
+++ b/modules/mastersearch2/templates/result_case.htm
@@ -37,7 +37,7 @@ MultiSelectSecurityQuest = new Array({$security_questions});
     {if $v.link != ''}</a>{/if}
     </td>
   {/foreach}
-  {if $line.icons|@count > 0}
+  {if is_array($line.icons) && $line.icons|@count > 0}
     <td class="mastersearch2_result_row_value" valign="top" align="right" width="{$maxIcons*24}" {$line.bgcolor}>
     {foreach from=$line.icons item=v}
       {if $v.link != ''}<a href="{$v.link}" class="menu">{/if}


### PR DESCRIPTION
PHP7.2 is more strict on what can be count()'ed and what not.
This first checks if the object is an array and only then does the counting; fixing #370 while at it.

This should fix the template "count(): Parameter must be an array or an object that implements Countable" error.