### PR TITLE
install: Properly count 2nd MasterForm; fixes form submission

### DIFF
--- a/modules/install/mod_cfg.php
+++ b/modules/install/mod_cfg.php
@@ -329,6 +329,7 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
             }
 
             $mf = new \LanSuite\MasterForm();
+            $mf->IncrementNumber();
 
             $res = $db->qry('SELECT * FROM %prefix%menu WHERE module = %string% AND caption != \'\' ORDER BY level, requirement, pos', $_GET['module']);
             while ($row = $db->fetch_array($res)) {


### PR DESCRIPTION
Commit 3ead54a2610a3c7a6162f0139c6503615a9b22c7 changed from a global MasterForm counter to a class-local one. Now when a 2nd (or 3rd, ..) class is initialized the MasterForm counter needs to be manually set (increased) in order to properly handle form input. Otherwise stuff will break big time and wrong values will be set when submitting the 2nd MasterForm - for example   https://github.com/lansuite/lansuite/issues/365