### PR TITLE
Issue #380: Drop support for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - '7.0'
   - '7.1'
   - '7.2'
   - nightly


### PR DESCRIPTION
PHP 7.0 is not supported anymore.
See https://secure.php.net/supported-versions.php