### PR TITLE
Fix IP whois lookup link

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -361,7 +361,7 @@ class Auth
                                    FROM %prefix%login_errors
                                    WHERE userid = %int%', $user['userid']);
                     while ($row = $db->fetch_array($res)) {
-                        $msg .= t('Am') .' '. $row['time'] .' von der IP: <a href="http://www.dnsstuff.com/tools/whois.ch?ip='. $row['ip'] .'" target="_blank">'. $row['ip'] .'</a>'. HTML_NEWLINE;
+                        $msg .= t('Am') .' '. $row['time'] .' von der IP: <a href="https://dnsquery.org/ipwhois/'. $row['ip'] .'" target="_blank">'. $row['ip'] .'</a>'. HTML_NEWLINE;
                     }
                     $db->free_result($res);
                     if ($msg != '') {

--- a/modules/board/thread.php
+++ b/modules/board/thread.php
@@ -139,7 +139,7 @@ if (!$thread and $tid) {
 
         $type = $userdata["type"];
         if ($auth['type'] >= 2) {
-            $type .= '<br />IP: <a href="http://www.dnsstuff.com/tools/whois.ch?ip='. $row['ip'] .'" target="_blank">'. $row['ip'] .'</a>';
+            $type .= '<br />IP: <a href="https://dnsquery.org/ipwhois/'. $row['ip'] .'" target="_blank">'. $row['ip'] .'</a>';
         }
         $smarty->assign('type', $userdata["type"]);
 


### PR DESCRIPTION
As the current IP whois link at dnsstuff.com returns a 404 and the current tool there only seems to return very generic ARIN based info for European IP space I propose to switch to dnsquery.org which is fast and also properly handles IPv6.