### PR TITLE
Class Display: Fix bug that prevents preselection in date form fields

### DIFF
--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -872,20 +872,20 @@ class Display
         }
 
         if ($time > 0) {
-            $day = date("d", $time);
-            $month = date("m", $time);
+            $day = date("j", $time);
+            $month = date("n", $time);
             $year = date("Y", $time);
             $hour = date("H", $time);
             $min = date("i", $time);
         } elseif ($values['day'] != "" and $values['month'] != "" and $values['year'] != "") {
-            $day = $values['day'];
-            $month = $values['month'];
+            $day = ltrim($values['day'],'0');
+            $month = ltrim($values['month'],'0');
             $year = $values['year'];
             $hour = $values['hour'];
             $min = $values['min'];
         } else {
-            $day = date("d");
-            $month = date("m");
+            $day = date("j");
+            $month = date("n");
             $year = date("Y");
             $hour = date("H");
             $min = round(date("i") / 5) * 5;


### PR DESCRIPTION
Day selection fields get prefilled from 1..31 and month fields from 1..12. However when returned from the database these values are prefixed with zero when being below ten. Now when Smarty compares e.g. "5" to "05" this does not match, causing all date selection fields to start at their initial value (1) instead of the previously set one.
This fix removes the leading zero so these comparisons match and date/month are correctly preselected. This occurs, for example, when editing birth dates or party begin/end dates.