### PR TITLE
Clanmgr/Usrmgr: Properly deal with blank clan URLs

### DIFF
--- a/modules/clanmgr/Classes/Clan.php
+++ b/modules/clanmgr/Classes/Clan.php
@@ -22,7 +22,7 @@ class Clan
             return false;
         }
     
-        if (substr($url, 0, 7) != 'http://') {
+        if ($url!='' && substr($url, 0, 7) != 'http://') {
             $url = 'http://'. $url;
         }
         

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -45,7 +45,7 @@ switch ($_GET['step']) {
             $dsp->AddDoubleRow(t(''), '<img src="'. $row['clanlogo_path'] .'" alt="'.$row['name'].'">');
         }
         $dsp->AddDoubleRow(t('Clan'), $row['name']);
-        if (stristr($row['url'], 'http://') === false) {
+        if ($row['url']!='' && stristr($row['url'], 'http://') === false) {
             $row['url'] = "http://".$row['url'];
         }
         $dsp->AddDoubleRow(t('Webseite'), '<a href="'. $row['url'] .'" target="_blank">'. $row['url'] .'</a>');

--- a/modules/usrmgr/details.php
+++ b/modules/usrmgr/details.php
@@ -103,7 +103,7 @@ if (!$user_data['userid']) {
     if ($cfg['signon_show_clan']) {
         $clan = '<table width="100%" cellspacing="0" cellpadding="0"><tr><td>';
         $clan .= '<a href="index.php?mod=clanmgr&step=2&clanid='.$user_data["clanid"].'">'.$user_data["clan"].'</a>';
-        if (substr($user_data['clanurl'], 0, 7) != 'http://') {
+        if ($user_data['clanurl']!='' && substr($user_data['clanurl'], 0, 7) != 'http://') {
             $user_data['clanurl'] = 'http://'. $user_data['clanurl'];
         }
         if ($user_data['clanurl']) {


### PR DESCRIPTION
Fixes:
- New user sign up with new clan previously adding "http://" as url in the database when the clan url field was left blank
- Clanmgr and usrmgr module previously displaying "http://" as clan URL when no url was defined