### PR TITLE
Stats: Fix display of zero value when no page hits within the last hour

### DIFF
--- a/modules/stats/boxes/stats.php
+++ b/modules/stats/boxes/stats.php
@@ -20,9 +20,9 @@ $avg = $db->qry_first("
   WHERE
     DATE_FORMAT(time, '%Y-%m-%d %H:00:00') = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 HOUR), '%Y-%m-%d %H:00:00')");
 $box->DotRow(t('Besucher').':');
-$box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '', '.') .'<span class="infobox">'.$total['visits'].' '.t('Besucher insgesamt') .'</span></span>&nbsp;<span class="infolink">('. $avg['visits'] .')<span class="infobox">'.$avg['visits'].' '.t('Besucher in der letzten Stunde') .'</span></span>');
+$box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '', '.').'<span class="infobox">'.$total['visits'].' '.t('Besucher insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['visits'] ? $avg['visits'] : '0').')<span class="infobox">'.($avg['visits'] ? $avg['visits'] : '0').' '.t('Besucher in der letzten Stunde').'</span></span>');
 $box->DotRow(t('Aufrufe').':');
-$box->EngangedRow('<span class="infolink">'.number_format($total['hits'], 0, '', '.') .'<span class="infobox">'.$total['hits'].' '.t('Seitenzugriffe insgesamt') .'</span></span>&nbsp;<span class="infolink">('. $avg['hits'] .')<span class="infobox">'.$avg['hits'].' '. t('Seitenzugriffe in der letzten Stunde') .'</span></span>');
+$box->EngangedRow('<span class="infolink">'.number_format($total['hits'], 0, '', '.').'<span class="infobox">'.$total['hits'].' '.t('Seitenzugriffe insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['hits'] ? $avg['hits'] : '0').')<span class="infobox">'.($avg['hits'] ? $avg['hits'] : '0').' '.t('Seitenzugriffe in der letzten Stunde').'</span></span>');
 
 $box->DotRow(t('Online') .': '. count($authentication->online_users), 'index.php?mod=guestlist&action=onlineuser');
 foreach ($authentication->online_users as $userid) {


### PR DESCRIPTION
This fixes the display of an empty field when there were no visitors or page hits in (not within!) the last hour.

**Question:** Currently "in the last hour" means exactly "in the LAST hour" but not "within the last 60 minutes". This might be quite confusing and probably does not make that much sense.
What about changing this to "today"?
We currently store visitors and hits per hour (one table entry for each hour) so fetching values for "today" would be trivial. Everything else most likely returns values one would not expect.