### PR TITLE
Improve Discord module

### DIFF
--- a/ext_inc/.gitignore
+++ b/ext_inc/.gitignore
@@ -2,6 +2,7 @@ avatare
 board_upload
 bugtracker_upload
 clan
+discord
 newsfeed
 party_infos
 wiki

--- a/ext_inc/discord/info.txt
+++ b/ext_inc/discord/info.txt
@@ -1,0 +1,1 @@
+This folder will contain cache data for the discord module.

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -48,8 +48,8 @@ class Discord {
     
     public function fetchServerData(){
         $APIurl = 'https://discordapp.com/api/servers/'.$this->discordServerId .'/widget.json';
-        $JsonReturnData = file_get_contents($APIurl);
-        return json_decode($JsonReturnData, false);
+        $JsonReturnData = @file_get_contents($APIurl);
+        return ($JsonReturnData===false ? false : json_decode($JsonReturnData, false));
     }
 
     /**

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -80,7 +80,7 @@ class Discord {
 
         $boxContent ="<li class='discord_server_name'>{$discordServerData->name} ";
         // -------------------------------- MEMBERS ---------------------------------------- // 
-        if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1) {
+        if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots'] == 1) {
             $onlinemembers = 0;
             foreach ($discordServerData->members as $member) {
                 if (!$member->bot) {
@@ -117,7 +117,7 @@ class Discord {
                     });
             $boxContent .= '<ul class="online_sidebar_channel">';
             foreach ($discordServerData->members as $member) {
-                if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1 && $member->bot) {
+                if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots'] == 1 && $member->bot) {
                     continue;
                 }
                 if (array_key_exists('nick', $member) && !empty($member->channel_id)) {
@@ -128,6 +128,9 @@ class Discord {
                 }
             }
             foreach ($discordServerData->channels as $channel) {
+                if (isset($cfg['discord_hide_empty_channels']) && $cfg['discord_hide_empty_channels'] == 1 && empty($channel_members[$channel->id])) {
+                    continue;
+                }
                 $boxContent .= "<li class='channel'>{$channel->name}";
                 if (!empty($channel_members[$channel->id])) {
                     $boxContent .= '<ul>';

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -15,23 +15,23 @@ namespace LanSuite\Module\Discord;
 class Discord {
 
     // Storage for the discord server id
-    private $discordServerId = 0;
+    private $discordServerId = '';
     
 
     
-    public function __construct($discordServerId = 0){
+    public function __construct($discordServerId = ''){
         global $cfg,$func;
         
         //Have a look first, if OpenSSL is enabled as module...
        if (extension_loaded('openssl'))
        {
             //Check if server id was passed via constructor, use configuration value otherwise
-            if ($discordServerId){
+            if ($discordServerId!=''){
                 $this->discordServerId = $disordServerId;
             } elseif (isset($cfg['discord_server_id'])) {
                 $this ->discordServerId =  $cfg['discord_server_id'];
             } else {
-                $func->error(t('Es wurde keine Discord server ID konfiguriert oder übergeben'));
+                $func->error(t('Es wurde keine Discord Server ID konfiguriert oder übergeben'));
             } 
        }
         else {

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -47,9 +47,25 @@ class Discord {
      */
     
     public function fetchServerData(){
-        $APIurl = 'https://discordapp.com/api/servers/'.$this->discordServerId .'/widget.json';
-        $JsonReturnData = @file_get_contents($APIurl);
-        return ($JsonReturnData===false ? false : json_decode($JsonReturnData, false));
+        clearstatcache('ext_inc/discord/cache.json');
+        if (is_readable('ext_inc/discord/cache.json') && time()-filemtime('ext_inc/discord/cache.json') < 60) {
+            // Cache file is readable and <60 seconds old.
+            // Note: Discord itself currently seems to update the widget.json file only once every 300 seconds.
+            $JsonReturnData = file_get_contents('ext_inc/discord/cache.json');
+        } else if (is_readable('ext_inc/discord/cache.json') && filesize('ext_inc/discord/cache.json') < 2 && time()-filemtime('ext_inc/discord/cache.json') < 300) {
+            // Cache file exists but is too small. There was probably some issue retrieving Discord data.
+            // Only retry after 300 seconds.
+            return false;
+        } else {
+            // No cache file or too old; let's fetch data.
+            $APIurl = 'https://discordapp.com/api/servers/'.$this->discordServerId .'/widget.json';
+            $JsonReturnData = @file_get_contents($APIurl);
+            if (is_writeable('ext_inc/discord/')) {
+                // Note: This intentionally also writes empty results to the cache file.
+                @file_put_contents('ext_inc/discord/cache.json', $JsonReturnData, LOCK_EX);
+            }
+        }
+        return ($JsonReturnData === false ? false : json_decode($JsonReturnData, false));
     }
 
     /**

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -76,16 +76,32 @@ class Discord {
      * @return string Box content ready for output
      */
     public function genBoxContent($discordServerData){
+        global $cfg;
+
         $boxContent ="<li class='discord_server_name'>{$discordServerData->name} ";
         // -------------------------------- MEMBERS ---------------------------------------- // 
-        if (count($discordServerData->members) > 0) {
-            $boxContent .= '<span class="online_users badge green">' . count($discordServerData->members) . '</span>';
+        if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1) {
+            $onlinemembers = 0;
+            foreach ($discordServerData->members as $member) {
+                if (!$member->bot) {
+                    $onlinemembers++;
+                }
+            }
         }
         else {
-            $boxContent .= '<span class="online_users badge red">' . count($discordServerData->members) . '</span>';
+            $onlinemembers = count($discordServerData->members);
+        }
+        if ($onlinemembers > 0) {
+            $boxContent .= '<span class="online_users badge green">' . $onlinemembers . '</span>';
+        }
+        else {
+            $boxContent .= '<span class="online_users badge red">0</span>';
         } 
         $boxContent .= '<ul class="online_sidebar">';
         foreach($discordServerData->members as $member){
+            if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1 && $member->bot) {
+                continue;
+            }
             if (array_key_exists('nick', $member)) {
                 $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->nick . '</li>';
             }
@@ -101,6 +117,9 @@ class Discord {
                     });
             $boxContent .= '<ul class="online_sidebar_channel">';
             foreach ($discordServerData->members as $member) {
+                if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1 && $member->bot) {
+                    continue;
+                }
                 if (array_key_exists('nick', $member) && !empty($member->channel_id)) {
                     $channel_members[$member->channel_id][] = $member->nick;
                 }

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -60,7 +60,7 @@ class Discord {
      * @return string Box content ready for output
      */
     public function genBoxContent($discordServerData){
-        $boxContent ="<li class='discord_server_name'>{$discordServerData->name}<br>";
+        $boxContent ="<li class='discord_server_name'>{$discordServerData->name} ";
         // -------------------------------- MEMBERS ---------------------------------------- // 
         if (count($discordServerData->members) > 0) {
             $boxContent .= '<span class="online_users badge green">' . count($discordServerData->members) . '</span>';
@@ -104,8 +104,10 @@ class Discord {
                 $boxContent .= "</li>";
             }  
         }
-        $boxContent .= "<input class=\"btn-join\" type=button onClick=\"parent.open('". $discordServerData->instant_invite ." ')\" value='Join'>";
-        $boxContent .= '</ul>';
+        if (!is_null($discordServerData->instant_invite)) {
+            $boxContent .= "<input class=\"btn-join\" type=button onClick=\"parent.open('". $discordServerData->instant_invite ." ')\" value='Join'>";
+        }
+        $boxContent .= '</li>';
         return $boxContent;
     }
 }

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -103,12 +103,14 @@ class Discord {
                 if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots'] == 1 && $member->bot) {
                     continue;
                 }
+                $username = $member->username;
                 if (array_key_exists('nick', $member)) {
-                    $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->nick . '</li>';
+                    $username = $member->nick;
                 }
-                else {
-                    $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->username . '</li>';
+                if (isset($cfg['discord_max_user_length']) && strlen($username) > $cfg['discord_max_user_length']) {
+                    $username = substr($username, 0, $cfg['discord_max_user_length'] - 2).'..';
                 }
+                $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $username . '</li>';
             }
             $boxContent .= '</ul>';
         }
@@ -134,10 +136,17 @@ class Discord {
                     if (isset($cfg['discord_hide_empty_channels']) && $cfg['discord_hide_empty_channels'] == 1 && empty($channel_members[$channel->id])) {
                         continue;
                     }
-                    $boxContent .= "<li class='channel'>{$channel->name}";
+                    $channelname = $channel->name;
+                    if (isset($cfg['discord_max_channel_length']) && strlen($channelname) > $cfg['discord_max_channel_length']) {
+                        $channelname = substr($channelname, 0, $cfg['discord_max_channel_length'] - 2).'..';
+                    }
+                    $boxContent .= "<li class='channel'>{$channelname}";
                     if (!empty($channel_members[$channel->id])) {
                         $boxContent .= '<ul>';
                         foreach ($channel_members[$channel->id] as $username) {
+                            if (isset($cfg['discord_max_user_length']) && strlen($username) > $cfg['discord_max_user_length']) {
+                                $username = substr($username, 0, $cfg['discord_max_user_length'] - 2).'..';
+                            }
                             $boxContent .= "<li class='channel_member'>$username</li>";
                         }
                         $boxContent .= '</ul>';

--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -97,52 +97,56 @@ class Discord {
         else {
             $boxContent .= '<span class="online_users badge red">0</span>';
         } 
-        $boxContent .= '<ul class="online_sidebar">';
-        foreach($discordServerData->members as $member){
-            if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots']==1 && $member->bot) {
-                continue;
-            }
-            if (array_key_exists('nick', $member)) {
-                $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->nick . '</li>';
-            }
-            else {
-                $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->username . '</li>';
-            }
-        }
-        $boxContent .= '</ul>';
-        // -------------------------------- CHANNELS ---------------------------------------- //
-        if ($discordServerData->channels) {
-            usort($discordServerData->channels, function($a, $b) {
-            return ($a->position > $b->position) ? 1 : -1;
-                    });
-            $boxContent .= '<ul class="online_sidebar_channel">';
-            foreach ($discordServerData->members as $member) {
+        if (isset($cfg['discord_show_global_members']) && $cfg['discord_show_global_members'] == 1) {
+            $boxContent .= '<ul class="online_sidebar">';
+            foreach($discordServerData->members as $member){
                 if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots'] == 1 && $member->bot) {
                     continue;
                 }
-                if (array_key_exists('nick', $member) && !empty($member->channel_id)) {
-                    $channel_members[$member->channel_id][] = $member->nick;
+                if (array_key_exists('nick', $member)) {
+                    $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->nick . '</li>';
                 }
-                elseif (!empty($member->channel_id)) {
-                    $channel_members[$member->channel_id][] = $member->username;
+                else {
+                    $boxContent .= '<li><img src="'. $member->avatar_url .'" class="'. $member->status .' discord_avatar">' . $member->username . '</li>';
                 }
             }
-            foreach ($discordServerData->channels as $channel) {
-                if (isset($cfg['discord_hide_empty_channels']) && $cfg['discord_hide_empty_channels'] == 1 && empty($channel_members[$channel->id])) {
-                    continue;
-                }
-                $boxContent .= "<li class='channel'>{$channel->name}";
-                if (!empty($channel_members[$channel->id])) {
-                    $boxContent .= '<ul>';
-                    foreach ($channel_members[$channel->id] as $username) {
-                        $boxContent .= "<li class='channel_member'>$username</li>";
-                    }
-                    $boxContent .= '</ul>';
-                }
-                $boxContent .= "</li>";
-            }  
+            $boxContent .= '</ul>';
         }
-        if (!is_null($discordServerData->instant_invite)) {
+        // -------------------------------- CHANNELS ---------------------------------------- //
+        if (isset($cfg['discord_show_channels']) && $cfg['discord_show_channels'] == 1) {
+            if ($discordServerData->channels) {
+                usort($discordServerData->channels, function($a, $b) {
+                return ($a->position > $b->position) ? 1 : -1;
+                        });
+                $boxContent .= '<ul class="online_sidebar_channel">';
+                foreach ($discordServerData->members as $member) {
+                    if (isset($cfg['discord_hide_bots']) && $cfg['discord_hide_bots'] == 1 && $member->bot) {
+                        continue;
+                    }
+                    if (array_key_exists('nick', $member) && !empty($member->channel_id)) {
+                        $channel_members[$member->channel_id][] = $member->nick;
+                    }
+                    elseif (!empty($member->channel_id)) {
+                        $channel_members[$member->channel_id][] = $member->username;
+                    }
+                }
+                foreach ($discordServerData->channels as $channel) {
+                    if (isset($cfg['discord_hide_empty_channels']) && $cfg['discord_hide_empty_channels'] == 1 && empty($channel_members[$channel->id])) {
+                        continue;
+                    }
+                    $boxContent .= "<li class='channel'>{$channel->name}";
+                    if (!empty($channel_members[$channel->id])) {
+                        $boxContent .= '<ul>';
+                        foreach ($channel_members[$channel->id] as $username) {
+                            $boxContent .= "<li class='channel_member'>$username</li>";
+                        }
+                        $boxContent .= '</ul>';
+                    }
+                    $boxContent .= "</li>";
+                }
+            }
+        }
+        if (!is_null($discordServerData->instant_invite) && isset($cfg['discord_show_join_button']) && $cfg['discord_show_join_button'] == 1) {
             $boxContent .= "<input class=\"btn-join\" type=button onClick=\"parent.open('". $discordServerData->instant_invite ." ')\" value='Join'>";
         }
         $boxContent .= '</li>';

--- a/modules/discord/boxes/discord.php
+++ b/modules/discord/boxes/discord.php
@@ -12,5 +12,12 @@ if (file_exists('design/' . $auth['design'] . '/discord.css')) {
 } else {
     $framework->add_css_path('modules/discord/boxes/default.css');
 }
-$boxcontent = $discord->genBoxContent($discordServerData);
-$box->Row($boxcontent);
+if (!$discordServerData) {
+    // Failed to fetch Discord status XML.
+    // Possible reasons: No connectivity, Discord server issues, Widget not enabled in Discord server settings
+    // TODO: Improve error reporting.
+    $box->Row('<b>Error:</b> Unable to retrieve server data.');
+} else {
+    $boxcontent = $discord->genBoxContent($discordServerData);
+    $box->Row($boxcontent);
+}

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -30,6 +30,24 @@
                 <default>1</default>
                 <description>Sollen leere Channels ausgeblendet werden?</description>
         </item>
+        <item>
+                <name>discord_show_global_members</name>
+                <type>boolean</type>
+                <default>1</default>
+                <description>Soll eine generische Userliste angezeigt werden?</description>
+        </item>
+        <item>
+                <name>discord_show_channels</name>
+                <type>boolean</type>
+                <default>1</default>
+                <description>Sollen Channels angezeigt werden?</description>
+        </item>
+        <item>
+                <name>discord_show_join_button</name>
+                <type>boolean</type>
+                <default>1</default>
+                <description>Soll ein Join-Button angezeigt werden? (Hinweis: "Instant Invite" muss in Discord aktiv sein)</description>
+        </item>
     </items>
   </group>
 </config>

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -24,6 +24,12 @@
                 <default>1</default>
                 <description>Sollen Bots ausgeblendet werden?</description>
         </item>
+        <item>
+                <name>discord_hide_empty_channels</name>
+                <type>boolean</type>
+                <default>1</default>
+                <description>Sollen leere Channels ausgeblendet werden?</description>
+        </item>
     </items>
   </group>
 </config>

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -6,10 +6,10 @@
     </head>
     <items>
     	<item>
-    		<name>discord_server_id</name>
-    		<type>int</type>
-    		<default>0</default>
-    		<description>Discord server ID</description>
+                <name>discord_server_id</name>
+                <type>string</type>
+                <default></default>
+                <description>Discord server ID</description>
     	</item>
     </items>
   </group>

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -13,4 +13,17 @@
     	</item>
     </items>
   </group>
+  <group>
+    <head>
+      <name>Anzeigeeinstellungen</name>
+    </head>
+    <items>
+        <item>
+                <name>discord_hide_bots</name>
+                <type>boolean</type>
+                <default>1</default>
+                <description>Sollen Bots ausgeblendet werden?</description>
+        </item>
+    </items>
+  </group>
 </config>

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -48,6 +48,18 @@
                 <default>1</default>
                 <description>Soll ein Join-Button angezeigt werden? (Hinweis: "Instant Invite" muss in Discord aktiv sein)</description>
         </item>
+        <item>
+                <name>discord_max_user_length</name>
+                <type>int</type>
+                <default>20</default>
+                <description>Nach wievielen Zeichen sollen Usernamen gekürzt werden?</description>
+        </item>
+        <item>
+                <name>discord_max_channel_length</name>
+                <type>int</type>
+                <default>30</default>
+                <description>Nach wievielen Zeichen sollen Channelnamen gekürzt werden?</description>
+        </item>
     </items>
   </group>
 </config>


### PR DESCRIPTION
This should make the Discord module a bit more useful.
- Gracefully handle JSON retrieval issues
- Hides "Join" button when instant_invite is not enabled in Discord
- Caches remote Discord data to avoid hammering Discord (or better: Cloudflare) servers
- Adds support for running the Discord module on 32bit servers
- Additional config options:
  - Hide bots
  - Hide empty channels
  - Don't show global user list
  - Don't show channels
  - Username length limit
  - Channel name length limit
