### PR TITLE
Tournament2: Fix teammgr admin guestlist paging

### DIFF
--- a/modules/tournament2/teammgr_admin.php
+++ b/modules/tournament2/teammgr_admin.php
@@ -112,7 +112,7 @@ switch ($_GET["step"]) {
             while ($tourney = $db->fetch_array($tourneys)) {
                 array_push($t_array, "<option value=\"{$tourney['tournamentid']}\">{$tourney['name']}</option>");
             }
-            $dsp->SetForm("?", NULL, 'GET');
+            $dsp->SetForm("?", null, 'GET');
             $t_hiddenfields  = '<input type="hidden" name="mod" value="tournament2" />';
             $t_hiddenfields .= '<input type="hidden" name="action" value="teammgr_admin" />';
             $t_hiddenfields .= '<input type="hidden" name="step" value="40" />';

--- a/modules/tournament2/teammgr_admin.php
+++ b/modules/tournament2/teammgr_admin.php
@@ -112,8 +112,11 @@ switch ($_GET["step"]) {
             while ($tourney = $db->fetch_array($tourneys)) {
                 array_push($t_array, "<option value=\"{$tourney['tournamentid']}\">{$tourney['name']}</option>");
             }
-            $dsp->SetForm("index.php?mod=tournament2&action=teammgr_admin&step=40");
-            $dsp->AddDropDownFieldRow("tournamentid", t('Neues Team (Spieler) anmelden<br />(Nur in Anmeldephase möglich)'), $t_array, "");
+            $dsp->SetForm("?", NULL, 'GET');
+            $t_hiddenfields  = '<input type="hidden" name="mod" value="tournament2" />';
+            $t_hiddenfields .= '<input type="hidden" name="action" value="teammgr_admin" />';
+            $t_hiddenfields .= '<input type="hidden" name="step" value="40" />';
+            $dsp->AddDropDownFieldRow("tournamentid", t('Neues Team (Spieler) anmelden<br />(Nur in Anmeldephase möglich)').$t_hiddenfields, $t_array, "");
             $dsp->AddFormSubmitRow(t('Abschicken'));
         }
         $db->free_result($tourneys);


### PR DESCRIPTION
Fixes a guestlist paging issue in the tournament2 admin teammgr.
Currently the form is submitted via POST which causes most parameters to get lost when trying to use the guestlist paging functionality to switch to any page but the first one, terminating these requests with a "Select a team first" failure message.
This PR changes the initial form submission from POST to GET so that these parameters are correctly handled by the guestlist, allowing to switch to subsequent pages and successfully add guests to teams.
Note: The way these fields are now added to the form doesn't seem to be a very clean solution but it solves the issue without having to rewrite huge parts of code in various places ..
Similar workarounds already seem to exist for example in the `install` module.