### PR TITLE
Discord: Add configurable timeout for JSON data retrieval

### DIFF
--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -47,6 +47,8 @@ class Discord {
      */
     
     public function fetchServerData(){
+        global $cfg;
+
         clearstatcache('ext_inc/discord/cache.json');
         if (is_readable('ext_inc/discord/cache.json') && time()-filemtime('ext_inc/discord/cache.json') < 60) {
             // Cache file is readable and <60 seconds old.
@@ -59,7 +61,7 @@ class Discord {
         } else {
             // No cache file or too old; let's fetch data.
             $APIurl = 'https://discordapp.com/api/servers/'.$this->discordServerId .'/widget.json';
-            $JsonReturnData = @file_get_contents($APIurl);
+            $JsonReturnData = @file_get_contents($APIurl,false,stream_context_create(array('http' => array('timeout' => (isset($cfg['discord_json_timeout']) ? $cfg['discord_json_timeout'] : 4)))));
             if (is_writeable('ext_inc/discord/')) {
                 // Note: This intentionally also writes empty results to the cache file.
                 @file_put_contents('ext_inc/discord/cache.json', $JsonReturnData, LOCK_EX);

--- a/modules/discord/mod_settings/config.xml
+++ b/modules/discord/mod_settings/config.xml
@@ -11,6 +11,12 @@
                 <default></default>
                 <description>Discord server ID</description>
     	</item>
+        <item>
+                <name>discord_json_timeout</name>
+                <type>int</type>
+                <default>4</default>
+                <description>Timeout für den Abruf der Discord JSON Daten</description>
+        </item>
     </items>
   </group>
   <group>


### PR DESCRIPTION
Prevents site loading issues when Discord is slow/unreachable and the Discord info box enabled.