### PR TITLE
Usrmgr: Allow identical username when username was not changed

### DIFF
--- a/modules/usrmgr/Functions/CheckValidUsername.php
+++ b/modules/usrmgr/Functions/CheckValidUsername.php
@@ -9,7 +9,11 @@ function CheckValidUsername($username)
 {
     global $cfg, $db;
     if ($cfg['signon_username_unique']) {
-        $row = $db->qry_first('SELECT * FROM %prefix%user WHERE username=%string%', $username);
+        if (isset($_GET['userid'])) {
+            $row = $db->qry_first('SELECT * FROM %prefix%user WHERE username=%string% AND userid!=%int%', $username, $_GET['userid']);
+        } else {
+            $row = $db->qry_first('SELECT * FROM %prefix%user WHERE username=%string%', $username);
+        }
         if ($row) {
             return t('Der gewählte Username existiert bereits');
         }


### PR DESCRIPTION
Fixes one of the issues mentioned in #384 where admin users are no longer able to modify user data as the username (obviously) already exists. This makes that check only trigger when the username is not identical to the one of the user currently being modified.