### PR TITLE
Fix email address validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -195,6 +195,7 @@
             "modules/usrmgr/Functions/CheckOldPW.php",
             "modules/usrmgr/Functions/CheckOptGender.php",
             "modules/usrmgr/Functions/CheckValidUsername.php",
+            "modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php",
             "modules/usrmgr/Functions/ClanURLLinkUsrMgrSearch.php",
             "modules/usrmgr/Functions/ClanURLLinkUsrMgrSearchInc.php",
             "modules/usrmgr/Functions/FieldNeeded.php",

--- a/inc/Functions/CheckValidEmail.php
+++ b/inc/Functions/CheckValidEmail.php
@@ -3,8 +3,8 @@
 use LanSuite\Validator\Email;
 
 /**
- * CheckValidEmail is a callback function for e.g. MasterForm to verify a given email adress against a set of requirements.
- * So far it uses a generic (configurable) Validator and checks if the given address is already in use
+ * CheckValidEmail is a callback function for e.g. MasterForm to verify a given email address against a set of requirements.
+ * So far it uses a generic (configurable) Validator
  *
  * @param string    $email
  * @return bool|mixed|string
@@ -66,17 +66,6 @@ function CheckValidEmail($email)
             break;
     }
 
-    // Compare first and second email entry.
-    // As only first entry is passed to this function, we have to get the second one from $_POST directly
-    if (!isset($_POST['email2']) || $email !== $_POST['email2']) {
-        return t('E-Mail-Adressen stimmen nicht überein. Bitte überprüfe deine Eingabe');
-    }
-    
-    // Check if we already have a user with that email address
-    $row = $db->qry_first('SELECT * FROM %prefix%user WHERE email = %string%', $email);
-    if ($row){
-        return t('Diese E-Mail-Adresse ist bereits in Verwendung. Bitte verwende die "Passwort zurücksetzen"-Funktion, um dein Passwort zurück zu setzen');
-    }
     // Check for forbidden trash mail services
     $TrashMailDomains = explode("\n", $cfg['mf_forbidden_trashmail_domains']);
     foreach ($TrashMailDomains as $key => $val) {

--- a/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
+++ b/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * CheckDuplicateAndValidEmail is a callback function to check a given email address for duplicates and
+ * to perform generic validations via CheckValidEmail.
+ *
+ * @param string    $email
+ * @return bool|mixed|string
+ */
+function CheckDuplicateAndValidEmail($email)
+{
+    global $cfg,$db;
+
+    $email = trim($email);
+
+    // Compare first and second email entry.
+    // As only first entry is passed to this function, we have to get the second one from $_POST directly
+    if (!isset($_POST['email2']) || $email !== $_POST['email2']) {
+        return t('E-Mail-Adressen stimmen nicht überein. Bitte überprüfe deine Eingabe');
+    }
+    
+    // Check if we already have a user with that email address
+    $row = $db->qry_first('SELECT * FROM %prefix%user WHERE email = %string%', $email);
+    if ($row){
+        return t('Diese E-Mail-Adresse ist bereits in Verwendung. Bitte verwende die "Passwort zurücksetzen"-Funktion, um dein Passwort zurück zu setzen');
+    }
+
+    // All checks succeeded; call global email validation routine
+    return CheckValidEmail($email); 
+}

--- a/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
+++ b/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
@@ -28,11 +28,11 @@ function CheckDuplicateAndValidEmail($email)
     
         // Check if we already have a user with that email address
         $row = $db->qry_first('SELECT * FROM %prefix%user WHERE email = %string%', $email);
-        if ($row){
+        if ($row) {
             return t('Diese E-Mail-Adresse ist bereits in Verwendung. Bitte verwende die "Passwort zurücksetzen"-Funktion, um dein Passwort zurück zu setzen');
         }
     }
 
     // All checks succeeded; call global email validation routine
-    return CheckValidEmail($email); 
+    return CheckValidEmail($email);
 }

--- a/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
+++ b/modules/usrmgr/Functions/CheckDuplicateAndValidEmail.php
@@ -13,16 +13,24 @@ function CheckDuplicateAndValidEmail($email)
 
     $email = trim($email);
 
-    // Compare first and second email entry.
-    // As only first entry is passed to this function, we have to get the second one from $_POST directly
-    if (!isset($_POST['email2']) || $email !== $_POST['email2']) {
-        return t('E-Mail-Adressen stimmen nicht überein. Bitte überprüfe deine Eingabe');
+    $useremail = null;
+    if (isset($_GET['userid'])) {
+        $userrow = $db->qry_first('SELECT email FROM %prefix%user WHERE userid=%int%', $_GET['userid']);
+        $useremail = $userrow['email'];
     }
+
+    if ($useremail === null || ($useremail!==null && $email != $useremail)) {
+        // Compare first and second email entry.
+        // As only first entry is passed to this function, we have to get the second one from $_POST directly
+        if (!isset($_POST['email2']) || $email !== $_POST['email2']) {
+            return t('E-Mail-Adressen stimmen nicht überein. Bitte überprüfe deine Eingabe');
+        }
     
-    // Check if we already have a user with that email address
-    $row = $db->qry_first('SELECT * FROM %prefix%user WHERE email = %string%', $email);
-    if ($row){
-        return t('Diese E-Mail-Adresse ist bereits in Verwendung. Bitte verwende die "Passwort zurücksetzen"-Funktion, um dein Passwort zurück zu setzen');
+        // Check if we already have a user with that email address
+        $row = $db->qry_first('SELECT * FROM %prefix%user WHERE email = %string%', $email);
+        if ($row){
+            return t('Diese E-Mail-Adresse ist bereits in Verwendung. Bitte verwende die "Passwort zurücksetzen"-Funktion, um dein Passwort zurück zu setzen');
+        }
     }
 
     // All checks succeeded; call global email validation routine

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -90,7 +90,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
             }
   
             $mf->AddField(t('E-Mail'), 'email', '', '', '', 'CheckDuplicateAndValidEmail');
-            $mf->AddField(t('E-Mail wiederholen'), 'email2', '', '', '');
+            $mf->AddField(t('E-Mail wiederholen'), 'email2', '', '', true);
             if (($_GET['action'] != 'change' && $_GET['action'] != 'entrance') || ($_GET['action'] == 'entrance' && !$_GET['userid'])) {
                 if ($cfg['signon_autopw']) {
                     $_SESSION['tmp_pass'] = $usrmgr->GeneratePassword();

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -89,7 +89,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
                 $mf->AddFix('type', 1);
             }
   
-            $mf->AddField(t('E-Mail'), 'email', '', '', '', 'CheckValidEmail');
+            $mf->AddField(t('E-Mail'), 'email', '', '', '', 'CheckDuplicateAndValidEmail');
             $mf->AddField(t('E-Mail wiederholen'), 'email2', '', '', '');
             if (($_GET['action'] != 'change' && $_GET['action'] != 'entrance') || ($_GET['action'] == 'entrance' && !$_GET['userid'])) {
                 if ($cfg['signon_autopw']) {


### PR DESCRIPTION
Together with #429 this fixes #384.
This addresses the current shortcomings described in https://github.com/lansuite/lansuite/issues/384#issuecomment-457778350.

This ..
- Splits email address validation checks and address duplicate check/verification into separate Functions, thus restoring `newmail` functionality
- Adjusts the `usrmgr` email address field to use both of these checks
- Limits email address duplicate check and field verfication (`email == email2`) to cases where the field value was modified, therefore restoring the functionality of being able to modify other fields without having to re-enter the email address (twice) all the time.
