### PR TITLE
Usrmgr: Allow settings modification regardless of user_self_details_change

### DIFF
--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -259,7 +259,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
 
     if (!$DoSignon && !$quick_signon) {
         // Settings
-        if ($auth['type'] >= 2 or !$_GET['userid'] or ($auth['userid'] == $_GET['userid'] and ($cfg['user_self_details_change'] or $missing_fields))) {
+        if ($auth['type'] >= 2 or !$_GET['userid'] or $auth['userid'] == $_GET['userid']) {
             if ($cfg['user_design_change']) {
                 $selections = [];
                 $selections[''] = t('System-Vorgabe');


### PR DESCRIPTION
Users can modify their own details only if `user_self_details_change` is set. However, there are certain user settings (for example their signature) that are basically not regarded as their details that users should be able to modify regardless of the `user_self_details_change` setting.
Current behavior is to show an empty page when attempting to edit anything (details / settings) as user when `user_self_details_change` is disabled. This should not be the case and "settings" should be displayed (or the "edit" button hidden).
Commit 3a78427fc856d1d8fe55af01e41760750ac34c35 moved user settings into the user table but failed to allow modifications. This was then fixed by e0cab1ea6fcc30afea7d1358679fc27f54890362 but unfortunately that one applied `user_self_details_change` restrictions also to "settings".
This PR again allows users to modify their settings.