### PR TITLE
Install: Add system checks for OpenSSL and allow_url_fopen

### DIFF
--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -795,6 +795,22 @@ class Install
         }
         $dsp->AddDoubleRow("FTP Library", $ftp_check);
 
+        // OpenSSL
+        if (extension_loaded('openssl')) {
+            $openssl_check = $ok;
+        } else {
+            $openssl_check = $not_possible . t('Auf deinem System konnte das PHP-Modul <b>OpenSSL</b> nicht gefunden werden. Dies hat zur Folge dass Module, die HTTPS Verbindungen zu anderen Servern aufbauen, nicht funktionieren');
+        }
+        $dsp->AddDoubleRow("OpenSSL", $openssl_check);
+
+        // allow_url_fopen
+        if (ini_get('allow_url_fopen')) {
+            $allowurlfopen_check = $ok;
+        } else {
+            $allowurlfopen_check = $not_possible . t('In deiner PHP Konfiguration ist <b>allow_url_fopen</b> nicht aktiviert. Dadurch können einige Module (z.B. Discord, Partylist) keine externen Verbindungen aufbauen und werden daher nicht funktionieren');
+        }
+        $dsp->AddDoubleRow("allow_url_fopen", $allowurlfopen_check);
+
         $dsp->AddFieldSetEnd();
 
         // Information

--- a/modules/install/mod_settings/translation.xml
+++ b/modules/install/mod_settings/translation.xml
@@ -3559,116 +3559,26 @@
 				<it>Dettagli</it>
 				<file>install</file>
 			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
-			<entry>
-				<id></id>
-				<org></org>
-				<file>install</file>
-			</entry>
+                        <entry>
+                                <id>6907ea946b45f307548691a0a7d6f105</id>
+                                <org>Auf deinem System konnte das PHP-Modul &lt;b&gt;OpenSSL&lt;/b&gt; nicht gefunden werden. Dies hat zur Folge dass Module, die HTTPS Verbindungen zu anderen Servern aufbauen, nicht funktionieren</org>
+                                <en>The &lt;b&gt;OpenSSL&lt;/b&gt; PHP module was not found on your system. This will cause issues with modules that establish HTTPS connections to other servers</en>
+                                <es>The &lt;b&gt;OpenSSL&lt;/b&gt; PHP module was not found on your system. This will cause issues with modules that establish HTTPS connections to other servers</es>
+                                <fr>The &lt;b&gt;OpenSSL&lt;/b&gt; PHP module was not found on your system. This will cause issues with modules that establish HTTPS connections to other servers</fr>
+                                <nl>The &lt;b&gt;OpenSSL&lt;/b&gt; PHP module was not found on your system. This will cause issues with modules that establish HTTPS connections to other servers</nl>
+                                <it>The &lt;b&gt;OpenSSL&lt;/b&gt; PHP module was not found on your system. This will cause issues with modules that establish HTTPS connections to other servers</it>
+                                <file>install</file>
+                        </entry>
+                        <entry>
+                                <id>29a2d7fdd3ed7396ad1a30993edf6597</id>
+                                <org>In deiner PHP Konfiguration ist &lt;b&gt;allow_url_fopen&lt;/b&gt; nicht aktiviert. Dadurch können einige Module (z.B. Discord, Partylist) keine externen Verbindungen aufbauen und werden daher nicht funktionieren</org>
+                                <en>In your PHP configuration the setting &lt;b&gt;allow_url_fopen&lt;/b&gt; is not enabled. This will cause issues with modules (such as Discord, Partylist) that attempt to connect to external sites</en>
+                                <es>In your PHP configuration the setting &lt;b&gt;allow_url_fopen&lt;/b&gt; is not enabled. This will cause issues with modules (such as Discord, Partylist) that attempt to connect to external sites</es>
+                                <fr>In your PHP configuration the setting &lt;b&gt;allow_url_fopen&lt;/b&gt; is not enabled. This will cause issues with modules (such as Discord, Partylist) that attempt to connect to external sites</fr>
+                                <nl>In your PHP configuration the setting &lt;b&gt;allow_url_fopen&lt;/b&gt; is not enabled. This will cause issues with modules (such as Discord, Partylist) that attempt to connect to external sites</nl>
+                                <it>In your PHP configuration the setting &lt;b&gt;allow_url_fopen&lt;/b&gt; is not enabled. This will cause issues with modules (such as Discord, Partylist) that attempt to connect to external sites</it>
+                                <file>install</file>
+                        </entry>
 		</content>
 	</table>
 </lansuite>


### PR DESCRIPTION
A few modules (Discord, Partylist) now depend on the OpenSSL module for HTTPS connections and need `allow_url_fopen` enabled to be able to retrieve information from external sites.
Mentioned in [#428](https://github.com/lansuite/lansuite/pull/428#issuecomment-460349766).
This PR adds checks for this into the environment check of the `install` module to avoid surprises later on.