### PR TITLE
Raise build version, fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
   - nightly
 
 matrix:
@@ -31,5 +31,5 @@ script:
   - CHANGED_PHP_FILES=`echo "$CHANGED_FILES" | grep "\.php$"`
   - if [ -z "$CHANGED_PHP_FILES" ]; then travis_terminate 0; fi;
   - echo "$CHANGED_PHP_FILES" | xargs -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
-  - echo "$CHANGED_PHP_FILES" | xargs -n1 -P4 bin/phpcs --standard=PSR1,PSR2 --exclude=Generic.Files.LineLength,PSR1.Methods.CamelCapsMethodName.NotCamelCaps --extensions=php -s
+  - echo "$CHANGED_PHP_FILES" | xargs -n1 -P4 bin/phpcs --standard=PSR1,PSR2 --exclude=Generic.Files.LineLength,PSR1.Methods.CamelCapsMethodName --extensions=php -s
   - bin/phpunit


### PR DESCRIPTION
Raised build version to 7.2-7.4 and (hopefully) fixedTravis (wrong method name applied in PR #458)

refs #455
fixes #461