### PR TITLE
Fix copy and edit seat plan

### DIFF
--- a/modules/seating/copy.php
+++ b/modules/seating/copy.php
@@ -24,8 +24,8 @@ switch ($_GET['step']) {
             `rows` = %int%,
             cols = %int%,
             `name` = %string%,
-            orientation = %int%,
-            u18 = %int%,
+            orientation = %string%,
+            u18 = %string%,
             remark = %string%,
             text_tl = %string%,
             text_tc = %string%,
@@ -44,7 +44,7 @@ switch ($_GET['step']) {
             $row['cols'],
             $row['name'] .' (Kopie)',
             $row['orientation'],
-            $row['u18'],
+            empty($row['u18']) ? '0' : $row['u18'],
             $row['remark'],
             $row['text_tl'],
             $row['text_tc'],
@@ -94,7 +94,7 @@ switch ($_GET['step']) {
                   INSERT INTO %prefix%seat_sep
                   SET
                     blockid = %int%,
-                    orientation = %int%,
+                    orientation = %string%,
                     value = %int%',
                     $blockid,
                     $row['orientation'],

--- a/modules/seating/edit.php
+++ b/modules/seating/edit.php
@@ -304,6 +304,11 @@ switch ($_GET['step']) {
 
     case 3:
         // Save block settings
+
+        // u18 is not checked, then the value is '0'
+        if (empty($_POST['u18'])) {
+            $_POST['u18'] = '0';
+        }
         if ($_GET['action'] == 'add') {
             $db->qry("
               INSERT INTO %prefix%seat_block


### PR DESCRIPTION
"orientation" and "u18" in seat_block are `enum` fields and not an `int`. Therefore, single quotes are required and the field should simply be treated as %string% in lansuite database queries.

"u18" is a checkbox and no value is sent on form submit if it is unchecked. Before "u18" was treated as `int` and PHP converted an empty string to 0 which old versions of MySQL accepted. Now MySQL is not as forgiving and "u18" has to be a string, but an empty string is not accepted, therefore special handling is needed for u18.

Similar to Import.php and edit.php