### PR TITLE
Change code to allow empty birthday field

### DIFF
--- a/modules/install/wizard.php
+++ b/modules/install/wizard.php
@@ -35,7 +35,7 @@ switch ($_GET["step"]) {
             // If not found, insert
             } else {
                 $db->qry(
-                    "INSERT INTO %prefix%user SET username = 'ADMIN', firstname = 'ADMIN', name = 'ADMIN', email=%string%, password = %string%, type = '3', lastlogin = NOW(), comment = '', birthday = '0000-00-00', signature = ''",
+                    "INSERT INTO %prefix%user SET username = 'ADMIN', firstname = 'ADMIN', name = 'ADMIN', email=%string%, password = %string%, type = '3', lastlogin = NOW(), comment = '', birthday = NULL, signature = ''",
                     $_POST["email"],
                     md5($_POST["password"])
                 );

--- a/modules/stats/age.php
+++ b/modules/stats/age.php
@@ -12,10 +12,11 @@ $res = $db->qry('
   ORDER BY age');
 
 while ($row = $db->fetch_array($res)) {
-    if ($row['birthday'] == '0000-00-00') {
+    if (empty($row['birthday']) || $row['birthday'] == '0000-00-00') {
         $dsp->AddDoubleRow(t('Keine Angabe'), $row['anz']);
     } else {
         $dsp->AddDoubleRow($row['age'], $row['anz']);
     }
 }
 $db->free_result($res);
+s

--- a/modules/usrmgr/Functions/CheckBirthday.php
+++ b/modules/usrmgr/Functions/CheckBirthday.php
@@ -7,6 +7,7 @@
  *
  * @param string $date  From Inputfield like 2000-01-02
  * @return bool|string  Returns Message on error else false
+ * @todo fix this (What is that strange -80y bit? Compare against sensible date range, use checkdate() )
  */
 function check_birthday($date)
 {

--- a/modules/usrmgr/mod_settings/db.xml
+++ b/modules/usrmgr/mod_settings/db.xml
@@ -235,7 +235,7 @@
             <field>
                 <name>birthday</name>
                 <type>date</type>
-                <null></null>
+                <null>YES</null>
                 <default></default>
                 <extra></extra>
             </field>


### PR DESCRIPTION
Validated change on fresh PHP 7.4/MySQL 5.7 install.

Only incompatiblity found: Editing the user sets empty birthday field to <current date - 80 years>, but that is also behaviour as before. 

fixes #473