### PR TITLE
fix cron2 queries

### DIFF
--- a/modules/cron2/Classes/Cron2.php
+++ b/modules/cron2/Classes/Cron2.php
@@ -16,7 +16,7 @@ class Cron2
             return false;
         }
 
-        $row = $db->qry_first("SELECT name, type, function FROM %prefix%cron WHERE jobid = %int%", $jobid);
+        $row = $db->qry_first("SELECT name, type, `function` FROM %prefix%cron WHERE jobid = %int%", $jobid);
         if ($row != false) {
             if ($row['type'] == 'sql') {
                 $sql = str_replace('%prefix%', $config['database']['prefix'], $row['function']);

--- a/modules/cron2/add.php
+++ b/modules/cron2/add.php
@@ -4,7 +4,7 @@ $dsp->NewContent(t('Cronjob hinzufügen'), '');
 $mf = new \LanSuite\MasterForm();
 
 $mf->AddField(t('Name'), 'name');
-$mf->AddField(t('Statement'), 'function');
+$mf->AddField(t('Statement'), '`function`');
 $mf->AddField(t('Aktiv'), 'active', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
 $mf->AddField(
     t('Typ'),


### PR DESCRIPTION
module cron2 uses a row named 'function', which appears to be a reserved keyword in newer MySQL versions.

This adds backticks to ensure proper recognition