### PR TITLE
Properly encode client ip for stats_auth table

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -331,7 +331,7 @@ class Auth
                 // Set authdata
                 $db->qry(
                     'REPLACE INTO %prefix%stats_auth
-                  SET sessid = %string%, userid = %int%, login = \'1\', ip = %string%, logtime = %string%, logintime = %string%, lasthit = %string%',
+                  SET sessid = %string%, userid = %int%, login = \'1\', ip = INET6_ATON(%string%), logtime = %string%, logintime = %string%, lasthit = %string%',
                     $this->auth["sessid"],
                     $user["userid"],
                     $this->auth["ip"],
@@ -580,7 +580,7 @@ class Auth
     {
         global $db;
         // Put all User-Data into $auth-Array
-        $user_data = $db->qry_first('SELECT 1 AS found, session.userid, session.login, session.ip, user.*
+        $user_data = $db->qry_first('SELECT 1 AS found, session.userid, session.login, INET6_NTOA(session.ip) AS ip, user.*
             FROM %prefix%stats_auth AS session
             LEFT JOIN %prefix%user AS user ON user.userid = session.userid
             WHERE session.sessid=%string% ORDER BY session.lasthit', $this->auth["sessid"]);
@@ -609,7 +609,7 @@ class Auth
             // If a session loaded no page for over one hour, this counts as a new visit
             $db->qry('UPDATE %prefix%stats_auth SET visits = visits + 1 WHERE (sessid=%string%) AND (lasthit < %int%)', $this->auth["sessid"], $visit_timeout);
             // Update user-stats and lasthit, so the timeout is resetted
-            $db->qry('UPDATE %prefix%stats_auth SET lasthit=%int%, hits = hits + 1, ip=%string%, lasthiturl= %string% WHERE sessid=%string%', $this->timestamp, $this->auth["ip"], $_SERVER['REQUEST_URI'], $this->auth["sessid"]);
+            $db->qry('UPDATE %prefix%stats_auth SET lasthit=%int%, hits = hits + 1, ip=INET6_ATON(%string%), lasthiturl= %string% WHERE sessid=%string%', $this->timestamp, $this->auth["ip"], $_SERVER['REQUEST_URI'], $this->auth["sessid"]);
         }
 
         // Heartbeat

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -331,7 +331,12 @@ class Auth
                 // Set authdata
                 $db->qry(
                     'REPLACE INTO %prefix%stats_auth
-                  SET sessid = %string%, userid = %int%, login = \'1\', ip = INET6_ATON(%string%), logtime = %string%, logintime = %string%, lasthit = %string%',
+                  SET sessid = %string%, 
+                  userid = %int%, login = \'1\', 
+                  ip = INET6_ATON(%string%), 
+                  logtime = %string%, 
+                  logintime = %string%, 
+                  lasthit = %string%',
                     $this->auth["sessid"],
                     $user["userid"],
                     $this->auth["ip"],
@@ -580,7 +585,11 @@ class Auth
     {
         global $db;
         // Put all User-Data into $auth-Array
-        $user_data = $db->qry_first('SELECT 1 AS found, session.userid, session.login, INET6_NTOA(session.ip) AS ip, user.*
+        $user_data = $db->qry_first('SELECT 1 AS found, 
+        session.userid, 
+        session.login, 
+        INET6_NTOA(session.ip) AS ip, 
+        user.*
             FROM %prefix%stats_auth AS session
             LEFT JOIN %prefix%user AS user ON user.userid = session.userid
             WHERE session.sessid=%string% ORDER BY session.lasthit', $this->auth["sessid"]);
@@ -609,7 +618,15 @@ class Auth
             // If a session loaded no page for over one hour, this counts as a new visit
             $db->qry('UPDATE %prefix%stats_auth SET visits = visits + 1 WHERE (sessid=%string%) AND (lasthit < %int%)', $this->auth["sessid"], $visit_timeout);
             // Update user-stats and lasthit, so the timeout is resetted
-            $db->qry('UPDATE %prefix%stats_auth SET lasthit=%int%, hits = hits + 1, ip=INET6_ATON(%string%), lasthiturl= %string% WHERE sessid=%string%', $this->timestamp, $this->auth["ip"], $_SERVER['REQUEST_URI'], $this->auth["sessid"]);
+            $db->qry('UPDATE %prefix%stats_auth 
+            SET lasthit=%int%, hits = hits + 1, 
+            ip=INET6_ATON(%string%), 
+            lasthiturl= %string% 
+            WHERE sessid=%string%', 
+            $this->timestamp, 
+            $this->auth["ip"], 
+            $_SERVER['REQUEST_URI'], 
+            $this->auth["sessid"]);
         }
 
         // Heartbeat

--- a/modules/install/sessions.php
+++ b/modules/install/sessions.php
@@ -27,19 +27,19 @@ switch ($_GET["step"]) {
         $ms2->AddTextSearchDropDown(t('Benutzer'), 'a.userid', $list);
 
         $list = array('' => t('Alle'));
-        $res = $db->qry('SELECT ip FROM %prefix%stats_auth GROUP BY ip ORDER BY ip');
+        $res = $db->qry('SELECT INET6_NTOA(ip) AS ip FROM %prefix%stats_auth GROUP BY ip ORDER BY ip');
         while ($row = $db->fetch_array($res)) {
             if ($row['ip']) {
                 $list[$row['ip']] = $row['ip'];
             }
         }
         $db->free_result($res);
-        $ms2->AddTextSearchDropDown(t('IP'), 'a.ip', $list);
+        $ms2->AddTextSearchDropDown(t('IP'), 'INET6_NTOA(a.ip)', $list);
 
         $ms2->AddSelect('u.userid');
         $ms2->AddResultField(t('Session-ID'), 'a.sessid');
         $ms2->AddResultField(t('Benutzername'), 'u.username', 'UserNameAndIcon');
-        $ms2->AddResultField(t('IP'), 'a.ip');
+        $ms2->AddResultField(t('IP'), 'INET6_NTOA(a.ip) AS ip');
         $ms2->AddResultField(t('Hits'), 'a.hits');
         $ms2->AddResultField(t('Visits'), 'a.visits');
         $ms2->AddResultField(t('Eingeloggt'), 'a.logintime', 'MS2GetDate');


### PR DESCRIPTION
"Recent" - for longer periods of "recent" - versions of databases are quite picky about what should fit a varbinary(16) field.
Let's properly store IP addresses (and make IPv6 visitors happy again). :wink: