### PR TITLE
Add persistent volume to mariadb to have a statefull testing environment.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,11 @@ services:
         image: mysql:5.6
         container_name: mysqldb
         platform: linux/amd64
+        volumes:
+            - mysql_data:/var/lib/mysql
         ports:
             - "3306:3306"
         env_file:
             - docker/mysql.env
-
+volumes:
+    mysql_data: 


### PR DESCRIPTION
This pull request will add a persisent mariadb volume for developing purpose.
The issue before was that everytime you stop  docker container (docker compose) the database is deleted.
At every run you have to go through the setup again and again and manually delete the config file in beforehand.

If you want to test the install setup , my approach would be just to drop the database and remove the config for this special use case.