### PR TITLE
fix: skip cache for mod install

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@ if (extension_loaded('apcu')) {
 
 // Check cache for config, try to load from file otherwise
 $configCache = $cache->getItem('config');
-if (!$configCache->isHit()) {
+if (!$configCache->isHit() || $_GET['mod'] == 'install') {
     // Read Config and Definitionfiles
     // Load Basic Config
     if (file_exists('inc/base/config.php')) {


### PR DESCRIPTION
I had to skip the cache on the mod install after I tried to rerun the installer after it failed with wrong credentials from the env file. 
mod install is not only used during installation process, therefore the cache is also ignored when an logged in admin accesses that page. Which is fine imho, since I would like to see the latest values from the config.
