### PR TITLE
Remove support for `get_magic_quotes_gpc`

### DIFF
--- a/index.php
+++ b/index.php
@@ -133,29 +133,6 @@ $_SERVER['QUERY_STRING'] = $func->NoHTML($_SERVER['QUERY_STRING'], 1);
 // TODO investigate why this is needed
 $__POST = $_POST;
 
-// Emulate MQ, if disabled
-// TODO Remove this get_magic_quotes_gpc function check, once this project had 7.4 as a minimum requirement.
-// See
-// - Setting: https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-gpc
-// - Function: https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
-if (!function_exists('get_magic_quotes_gpc') || !get_magic_quotes_gpc()) {
-    foreach ($_GET as $key => $val) {
-        if (!is_array($_GET[$key])) {
-            $_GET[$key] = addslashes($_GET[$key]);
-        }
-    }
-    foreach ($_POST as $key => $val) {
-        if (!is_array($_POST[$key])) {
-            $_POST[$key] = addslashes($_POST[$key]);
-        }
-    }
-    foreach ($_COOKIE as $key => $val) {
-        if (!is_array($_COOKIE[$key])) {
-            $_COOKIE[$key] = addslashes($_COOKIE[$key]);
-        }
-    }
-}
-
 // Include and Initialize base classes
 $lang = [];
 


### PR DESCRIPTION
The function and the PHP ini setting are deprecated since a long time and have been removed from PHP already.

### [Function: `get_magic_quotes_gpc`](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php)

> This function has been DEPRECATED as of PHP 7.4.0, and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.

### [Setting: `magic_quotes_gpc`](https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-gpc)

> This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.

