### PR TITLE
Docker Compose: Remove `platform`, because it is not existing in Docker Compose File Format Version 3 anymore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     mysql:
         image: mysql:5.6
         container_name: mysqldb
-        platform: linux/amd64
         volumes:
             - mysql_data:/var/lib/mysql
         ports:


### PR DESCRIPTION
See
- Version 2: https://docs.docker.com/compose/compose-file/compose-file-v2/#platform
- Version 3: https://docs.docker.com/compose/compose-file/compose-file-v3/