### PR TITLE
docs/docker: Add instruction to copy mysql.env file

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -56,6 +56,7 @@ $ touch ./inc/base/config.php
 $ # Add the content of the example configuration file below into ./inc/base/config.php
 $ chmod a+rw ./inc/base/config.php
 $ chmod -R a+rwX ./ext_inc/
+$ cp docker/mysql.env.dist docker/mysql.env
 $ docker-compose up
 $ docker-compose run php composer install
 ```


### PR DESCRIPTION
The mysql env file is required for the docker setup.

See https://github.com/lansuite/lansuite/blob/3c89029734499c143997fea76a3c0879d6bd91fc/docker-compose.yml#L27