### PR TITLE
Rector: Raise Level set to UP_TO_PHP_56 and ignore PowToExpRector

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
 #        include:
 #        - php-versions: 8.0
 #          experimental: true
@@ -49,7 +49,7 @@ jobs:
 
   style-tests:
     name: Code Style Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # Run style checks only on one version (latest supported)
-          php-version: 7.4
+          php-version: 8.0
           extensions: gd, mysqli
 
       - name: Determine composer cache directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     # Development extensions
     && pecl install xdebug-3.2.1 \
     && docker-php-ext-enable xdebug \
-    && echo 'xdebug.mode=debug' >> /usr/local/etc/php/php.ini \
+    && echo 'xdebug.mode=debug,develop' >> /usr/local/etc/php/php.ini \
     && echo 'xdebug.discover_client_host=1' >> /usr/local/etc/php/php.ini \
     # Cleanup
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:7.2.34-fpm
+# Get composer
+FROM composer:2.5.5 as composer
+
+FROM php:8.0.28-fpm-bullseye
 
 COPY . /code
 
@@ -12,39 +15,22 @@ RUN apt-get update \
         unzip \
         libzip-dev \
     && docker-php-ext-install -j$(nproc) mysqli snmp \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd --enable-gd --prefix=/usr --with-jpeg --with-freetype \
     && docker-php-ext-install -j$(nproc) gd \
     # Development extensions
-    && pecl install xdebug-2.9.0 \
+    && pecl install xdebug-3.2.1 \
     && docker-php-ext-enable xdebug \
-    && echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini \
-    && echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini \
+    && echo 'xdebug.mode=debug' >> /usr/local/etc/php/php.ini \
+    && echo 'xdebug.discover_client_host=1' >> /usr/local/etc/php/php.ini \
     # Cleanup
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
 # Composer setup starts here. The zip extension is required for that.
-# See https://github.com/composer/docker/blob/8a2a40c3376bac96f8e3db2f129062173bff7734/1.6/Dockerfile
-# and https://github.com/composer/docker/blob/942dac53831e7b4ca4419a135304e177b9d29dbd/1.8/Dockerfile
-# or more recently https://getcomposer.org/download/
 RUN docker-php-ext-install zip
-
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 1.8.0
-
-RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/d3e09029468023aa4e9dcd165e9b6f43df0a9999/web/installer \
-    && php -r " \
-    \$signature = '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8'; \
-    \$hash = hash_file('sha384', '/tmp/installer.php'); \
-    if (!hash_equals(\$signature, \$hash)) { \
-        unlink('/tmp/installer.php'); \
-        echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
-        exit(1); \
-    }" \
-    && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
-    && composer --ansi --version --no-interaction \
-    && rm -rf /tmp/* /tmp/.htaccess
 
 WORKDIR /code
+
 RUN composer install

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "doctrine/instantiator": "~1.5.0",
         "squizlabs/php_codesniffer": "*",
         "phpstan/phpstan": "^1.9.13",
-        "phan/phan": "^5.4"
+        "phan/phan": "^5.4",
+        "rector/rector": "^0.16.0"
     },
     "minimum-stability": "stable",
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^8.0",
         "ext-gd": "*",
         "ext-mysqli": "*",
         "ext-snmp": "*",
@@ -20,17 +20,17 @@
         "ext-zlib": "*",
         "ext-ftp": "*",
 
-        "smarty/smarty": "^3.1",
+        "smarty/smarty": "^4.0",
         "geshi/geshi": "^1.0.9",
         "setasign/fpdf": "^1.8",
         "paypal/rest-api-sdk-php": "^1.13",
-        "youthweb/bbcode-parser": "^1.4",
+        "youthweb/bbcode-parser": "^1.6",
         "symfony/debug": "^4.4",
         "symfony/cache": "^v5.4.17",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1",
+        "phpunit/phpunit": "^8.5",
         "doctrine/instantiator": "~1.5.0",
         "squizlabs/php_codesniffer": "*",
         "phpstan/phpstan": "^1.9.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc0171cb6850926e0da2d72ee1f92f35",
+    "content-hash": "9d7e90f9900ef99ea7bcefa39b098b12",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -2895,6 +2895,67 @@
                 }
             ],
             "time": "2023-02-27T13:04:50+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "2125ff71ea05b079562a8f59ca48a97eb78dc07f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/2125ff71ea05b079562a8f59ca48a97eb78dc07f",
+                "reference": "2125ff71ea05b079562a8f59ca48a97eb78dc07f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.14"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.15-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-05T12:12:17+00:00"
         },
         {
             "name": "sabre/event",

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38c90416d10f6548bed0117965741596",
+    "content-hash": "bc0171cb6850926e0da2d72ee1f92f35",
     "packages": [
         {
             "name": "cache/adapter-common",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-cache/adapter-common.git",
-                "reference": "6b87c5cbdf03be42437b595dbe5de8e97cd1d497"
+                "reference": "8788309be72aa7be69b88cdc0687549c74a7d479"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/6b87c5cbdf03be42437b595dbe5de8e97cd1d497",
-                "reference": "6b87c5cbdf03be42437b595dbe5de8e97cd1d497",
+                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/8788309be72aa7be69b88cdc0687549c74a7d479",
+                "reference": "8788309be72aa7be69b88cdc0687549c74a7d479",
                 "shasum": ""
             },
             "require": {
                 "cache/tag-interop": "^1.0",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "psr/cache": "^1.0",
-                "psr/log": "^1.0",
+                "php": ">=7.4",
+                "psr/cache": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0"
             },
             "require-dev": {
-                "cache/integration-tests": "^0.16",
-                "phpunit/phpunit": "^5.7.21"
+                "cache/integration-tests": "^0.17",
+                "phpunit/phpunit": "^7.5.20 || ^9.5.10"
             },
             "type": "library",
             "extra": {
@@ -66,31 +66,31 @@
                 "tag"
             ],
             "support": {
-                "source": "https://github.com/php-cache/adapter-common/tree/1.2.0"
+                "source": "https://github.com/php-cache/adapter-common/tree/1.3.0"
             },
-            "time": "2020-12-14T12:17:39+00:00"
+            "time": "2022-01-15T15:47:19+00:00"
         },
         {
             "name": "cache/hierarchical-cache",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-cache/hierarchical-cache.git",
-                "reference": "ba3746c65461b17154fb855068403670fd7fa2d3"
+                "reference": "dedffd0a74f72c1db76e57ce29885836944e27f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/ba3746c65461b17154fb855068403670fd7fa2d3",
-                "reference": "ba3746c65461b17154fb855068403670fd7fa2d3",
+                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/dedffd0a74f72c1db76e57ce29885836944e27f3",
+                "reference": "dedffd0a74f72c1db76e57ce29885836944e27f3",
                 "shasum": ""
             },
             "require": {
                 "cache/adapter-common": "^1.0",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "psr/cache": "^1.0"
+                "php": ">=7.4",
+                "psr/cache": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.21"
+                "phpunit/phpunit": "^7.5.20 || ^9.5.10"
             },
             "type": "library",
             "extra": {
@@ -131,9 +131,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-cache/hierarchical-cache/tree/1.1.0"
+                "source": "https://github.com/php-cache/hierarchical-cache/tree/1.2.0"
             },
-            "time": "2020-12-14T12:17:39+00:00"
+            "time": "2022-01-15T15:47:19+00:00"
         },
         {
             "name": "cache/tag-interop",
@@ -196,23 +196,23 @@
         },
         {
             "name": "cache/void-adapter",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-cache/void-adapter.git",
-                "reference": "d5b51d436675f77c6e9825ffbca8b9134a036685"
+                "reference": "1f10ea9b3ccfad8422c86d326a86efc8917e2ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/void-adapter/zipball/d5b51d436675f77c6e9825ffbca8b9134a036685",
-                "reference": "d5b51d436675f77c6e9825ffbca8b9134a036685",
+                "url": "https://api.github.com/repos/php-cache/void-adapter/zipball/1f10ea9b3ccfad8422c86d326a86efc8917e2ad9",
+                "reference": "1f10ea9b3ccfad8422c86d326a86efc8917e2ad9",
                 "shasum": ""
             },
             "require": {
                 "cache/adapter-common": "^1.0",
                 "cache/hierarchical-cache": "^1.0",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "psr/cache": "^1.0",
+                "php": ">=7.4",
+                "psr/cache": "^1.0 || ^2.0",
                 "psr/simple-cache": "^1.0"
             },
             "provide": {
@@ -220,8 +220,8 @@
                 "psr/simple-cache-implementation": "^1.0"
             },
             "require-dev": {
-                "cache/integration-tests": "^0.16",
-                "phpunit/phpunit": "^5.7.21"
+                "cache/integration-tests": "^0.17",
+                "phpunit/phpunit": "^7.5.20 || ^9.5.10"
             },
             "type": "library",
             "extra": {
@@ -262,9 +262,9 @@
                 "void"
             ],
             "support": {
-                "source": "https://github.com/php-cache/void-adapter/tree/1.1.0"
+                "source": "https://github.com/php-cache/void-adapter/tree/1.2.0"
             },
-            "time": "2020-12-14T12:17:39+00:00"
+            "time": "2022-01-15T15:47:19+00:00"
         },
         {
             "name": "geshi/geshi",
@@ -457,20 +457,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -490,7 +490,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -500,9 +500,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/2.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:23:37+00:00"
         },
         {
             "name": "psr/container",
@@ -701,29 +701,29 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.47",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "a09364fe1706cb465e910eb040e592053d7effb8"
+                "reference": "e28cb0915b4e3749bf57d4ebae2984e25395cfe5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/a09364fe1706cb465e910eb040e592053d7effb8",
-                "reference": "a09364fe1706cb465e910eb040e592053d7effb8",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/e28cb0915b4e3749bf57d4ebae2984e25395cfe5",
+                "reference": "e28cb0915b4e3749bf57d4ebae2984e25395cfe5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.2 || ^7.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^6.5 || ^5.7 || ^4.8",
+                "phpunit/phpunit": "^8.5 || ^7.5",
                 "smarty/smarty-lexer": "^3.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -747,20 +747,23 @@
                 {
                     "name": "Rodney Rehm",
                     "email": "rodney.rehm@medialize.de"
+                },
+                {
+                    "name": "Simon Wisselink",
+                    "homepage": "https://www.iwink.nl/"
                 }
             ],
             "description": "Smarty - the compiling PHP template engine",
-            "homepage": "http://www.smarty.net",
+            "homepage": "https://smarty-php.github.io/smarty/",
             "keywords": [
                 "templating"
             ],
             "support": {
-                "forum": "http://www.smarty.net/forums/",
-                "irc": "irc://irc.freenode.org/smarty",
+                "forum": "https://github.com/smarty-php/smarty/discussions",
                 "issues": "https://github.com/smarty-php/smarty/issues",
-                "source": "https://github.com/smarty-php/smarty/tree/v3.1.47"
+                "source": "https://github.com/smarty-php/smarty/tree/v4.3.1"
             },
-            "time": "2022-09-14T11:29:00+00:00"
+            "time": "2023-03-28T19:47:03+00:00"
         },
         {
             "name": "symfony/cache",
@@ -1394,27 +1397,29 @@
         },
         {
             "name": "youthweb/bbcode-parser",
-            "version": "1.5.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/youthweb/bbcode-parser.git",
-                "reference": "37f37452e04f780343071d90b8bb9eb363323aa9"
+                "reference": "b1321c51ab6b50cdff2adf24a90e8779971129b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/youthweb/bbcode-parser/zipball/37f37452e04f780343071d90b8bb9eb363323aa9",
-                "reference": "37f37452e04f780343071d90b8bb9eb363323aa9",
+                "url": "https://api.github.com/repos/youthweb/bbcode-parser/zipball/b1321c51ab6b50cdff2adf24a90e8779971129b5",
+                "reference": "b1321c51ab6b50cdff2adf24a90e8779971129b5",
                 "shasum": ""
             },
             "require": {
-                "cache/void-adapter": "^1.0",
+                "cache/void-adapter": "^1.1",
                 "jakeasmith/http_build_url": "^1",
-                "jbbcode/jbbcode": "^1.3",
-                "php": "^7.2",
-                "youthweb/urllinker": "^1.2"
+                "jbbcode/jbbcode": "^1.4",
+                "php": "^7.4 || ^8.0",
+                "youthweb/urllinker": "^1.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6 || ^7 || ^8"
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "autoload": {
@@ -1443,29 +1448,31 @@
             ],
             "support": {
                 "issues": "https://github.com/youthweb/bbcode-parser/issues",
-                "source": "https://github.com/youthweb/bbcode-parser/tree/1.5.0"
+                "source": "https://github.com/youthweb/bbcode-parser/tree/1.7.1"
             },
-            "time": "2019-10-01T12:26:11+00:00"
+            "time": "2021-11-24T10:55:51+00:00"
         },
         {
             "name": "youthweb/urllinker",
-            "version": "1.3.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/youthweb/urllinker.git",
-                "reference": "b583abc45d70fee67104798bb73193de34cee5df"
+                "reference": "0a664d4f0472c63013a43a7ca7ddbd0c58ce998a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/youthweb/urllinker/zipball/b583abc45d70fee67104798bb73193de34cee5df",
-                "reference": "b583abc45d70fee67104798bb73193de34cee5df",
+                "url": "https://api.github.com/repos/youthweb/urllinker/zipball/0a664d4f0472c63013a43a7ca7ddbd0c58ce998a",
+                "reference": "0a664d4f0472c63013a43a7ca7ddbd0c58ce998a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6 || ^7 || ^8"
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "autoload": {
@@ -1492,9 +1499,9 @@
             "homepage": "https://github.com/youthweb",
             "support": {
                 "issues": "https://github.com/youthweb/urllinker/issues",
-                "source": "https://github.com/youthweb/urllinker/tree/1.3.0"
+                "source": "https://github.com/youthweb/urllinker/tree/1.5.1"
             },
-            "time": "2019-10-01T12:10:40+00:00"
+            "time": "2022-12-09T15:03:24+00:00"
         }
     ],
     "packages-dev": [
@@ -1717,6 +1724,49 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
+            "name": "doctrine/deprecations",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5|^8.5|^9.5",
+                "psr/log": "^1|^2|^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+            },
+            "time": "2022-05-02T15:47:09+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
             "source": {
@@ -1878,16 +1928,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1975,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1933,7 +1983,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2067,28 +2117,29 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2120,26 +2171,26 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2171,9 +2222,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/master"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2287,25 +2338,33 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
+                "reference": "dfc078e8af9c99210337325ff5aa152872c98714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/dfc078e8af9c99210337325ff5aa152872c98714",
+                "reference": "dfc078e8af9c99210337325ff5aa152872c98714",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.13"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
@@ -2331,76 +2390,55 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.1"
             },
-            "time": "2022-03-15T21:29:03+00:00"
+            "time": "2023-03-27T19:02:04+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "6df62b08faef4f899772bc7c3bbabb93d2b7a21c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6df62b08faef4f899772bc7c3bbabb93d2b7a21c",
+                "reference": "6df62b08faef4f899772bc7c3bbabb93d2b7a21c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.21.0"
             },
-            "time": "2020-03-05T15:02:03+00:00"
+            "time": "2023-05-17T13:13:44+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -2466,40 +2504,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.5",
+            "version": "7.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2527,31 +2565,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/6.0.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.15"
             },
-            "time": "2018-05-28T11:49:20+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-26T12:20:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2566,7 +2613,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2577,11 +2624,16 @@
                 "iterator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.5"
             },
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:42:26+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2689,29 +2741,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2736,7 +2788,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
             },
             "funding": [
                 {
@@ -2745,53 +2797,52 @@
                 }
             ],
             "abandoned": true,
-            "time": "2021-07-26T12:15:06+00:00"
+            "time": "2020-08-04T08:28:15+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.5",
+            "version": "8.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435"
+                "reference": "7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca64dba53b88aba6af32aebc6b388068db95c435",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e",
+                "reference": "7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.1",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.2",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.4",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.5",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.5",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
             },
-            "require-dev": {
-                "ext-pdo": "*"
-            },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2799,7 +2850,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -2827,70 +2878,23 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.1.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.33"
             },
-            "time": "2018-04-29T15:09:19+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/master"
-            },
-            "abandoned": true,
-            "time": "2018-05-29T13:54:20+00:00"
+            "time": "2023-02-27T13:04:50+00:00"
         },
         {
             "name": "sabre/event",
@@ -3089,16 +3093,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6296a0c086dd0117c1b78b059374d7fcbe7545ae",
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae",
                 "shasum": ""
             },
             "require": {
@@ -3143,7 +3147,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.4"
             },
             "funding": [
                 {
@@ -3151,32 +3155,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2023-05-07T05:30:20+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3203,9 +3210,15 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/master"
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
             },
-            "time": "2017-07-01T08:51:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3286,23 +3299,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -3310,7 +3326,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3335,9 +3351,15 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
             },
-            "time": "2017-04-27T15:39:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-10T06:55:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -3516,25 +3538,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3556,9 +3578,71 @@
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
             },
-            "time": "2015-07-28T20:34:47+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4356,7 +4440,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0",
+        "php": "^8.0",
         "ext-gd": "*",
         "ext-mysqli": "*",
         "ext-snmp": "*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     web:
-        image: nginx:latest
+        image: nginx:1.23.4-alpine
         ports:
             - "8080:80"
         volumes:
@@ -16,7 +16,7 @@ services:
             - .:/code
             - ./.docker/nginx-php-flags.conf:/usr/local/etc/php-fpm.d/php-flags.conf
     mysql:
-        image: mysql:5.6
+        image: mysql:5.7.42
         container_name: mysqldb
         platform: linux/amd64
         volumes:

--- a/inc/Classes/Barcode.php
+++ b/inc/Classes/Barcode.php
@@ -294,6 +294,7 @@ class Barcode
 
     public function _c93Barcode($barnumber, $scale = 1, $file = "", $checkdigit = false)
     {
+        $space = [];
         $bars=$this->_c93Encode($barnumber);
         if (empty($file)) {
             header("Content-type: image/".$this->_format);
@@ -378,6 +379,7 @@ class Barcode
 
     public function _c39Encode($barnumber, $checkdigit = false)
     {
+        $sum = null;
         $encTable=array("0" => "NNNWWNWNN",
         "1" => "WNNWNNNNW",
         "2" => "NNWWNNNNW",
@@ -483,6 +485,7 @@ class Barcode
 
     public function _c39Barcode($barnumber, $scale = 1, $file = "", $checkdigit = false)
     {
+        $space = [];
         $bars=$this->_c39Encode($barnumber, $checkdigit);
         if (empty($file)) {
             header("Content-type: image/".$this->_format);
@@ -559,6 +562,7 @@ class Barcode
     ///Start function for code128
     public function _c128Encode($barnumber, $useKeys)
     {
+        $check = null;
         $encTable=array("11011001100","11001101100","11001100110","10010011000","10010001100","10001001100","10011001000","10011000100","10001100100","11001001000","11001000100","11000100100","10110011100","10011011100","10011001110","10111001100","10011101100","10011100110","11001110010","11001011100","11001001110","11011100100","11001110100","11101101110","11101001100","11100101100","11100100110","11101100100","11100110100","11100110010","11011011000","11011000110","11000110110","10100011000","10001011000","10001000110","10110001000","10001101000","10001100010","11010001000","11000101000","11000100010","10110111000","10110001110","10001101110","10111011000","10111000110","10001110110","11101110110","11010001110","11000101110","11011101000","11011100010","11011101110","11101011000","11101000110","11100010110","11101101000","11101100010","11100011010","11101111010","11001000010","11110001010","10100110000","10100001100","10010110000","10010000110","10000101100","10000100110","10110010000","10110000100","10011010000","10011000010","10000110100","10000110010","11000010010","11001010000","11110111010","11000010100","10001111010","10100111100","10010111100","10010011110","10111100100","10011110100","10011110010","11110100100","11110010100","11110010010","11011011110","11011110110","11110110110","10101111000","10100011110","10001011110","10111101000","10111100010","11110101000","11110100010","10111011110","10111101110","11101011110","11110101110","11010000100","11010010000","11010011100","11000111010");
 
         $start=array("A"=>"11010000100","B"=>"11010010000","C"=>"11010011100");
@@ -612,6 +616,7 @@ class Barcode
 
     public function _c128Barcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $useKeys="B";
         if (preg_match("/^[0-9".chr(128).chr(129).chr(130)."]+$/", $barnumber)) {
             $useKeys='C';
@@ -752,6 +757,7 @@ class Barcode
 
     public function _codaBarcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $bars=$this->_codaEncode($barnumber);
         if (empty($file)) {
             header("Content-type: image/".$this->_format);
@@ -849,6 +855,7 @@ class Barcode
 
     public function _postEncode($barnumber)
     {
+        $check = null;
         $encTable=array("11000","00011","00101","00110","01001","01010","01100","10001","10010","10100");
 
         $sum=0;
@@ -868,6 +875,7 @@ class Barcode
 
     public function _postBarcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         if (strlen($barnumber)==5 || strlen($barnumber)==9 || strlen($barnumber)==11) {
             ;
         } else {
@@ -1008,6 +1016,7 @@ class Barcode
 
     public function _i25Barcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $bars=$this->_i25Encode($barnumber);
         if (empty($file)) {
             header("Content-type: image/".$this->_format);
@@ -1133,6 +1142,7 @@ class Barcode
 
     public function _so25Barcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $bars=$this->_so25Encode($barnumber);
         if (empty($file)) {
             header("Content-type: image/".$this->_format);
@@ -1213,6 +1223,7 @@ class Barcode
 
     public function ConvertUPCAtoUPCE($upca)
     {
+        $barnumber = null;
         $csumTotal = 0; // The checksum working variable starts at zero
         $upce ="";
         // If the source message string is less than 12 characters long, we make it 12 characters
@@ -1279,6 +1290,7 @@ class Barcode
 
     public function _upceBarcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         if (strlen($barnumber)>6) {
             $this->_ean13CheckDigit($barnumber);
             $barnumber=substr($this->_ean13CheckDigit($barnumber), 1);
@@ -1446,6 +1458,7 @@ class Barcode
 
     public function _ean8Barcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $barnumber=$this->_checkDigit($barnumber, 7);
         $bars=$this->_ean8Encode($barnumber);
         if (empty($file)) {
@@ -1626,6 +1639,7 @@ class Barcode
 
     public function _eanBarcode($barnumber, $scale = 1, $file = "")
     {
+        $space = [];
         $barnumber=$this->_ean13CheckDigit($barnumber);
 
         $bars=$this->_eanEncode($barnumber);

--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -140,6 +140,8 @@ class Func
      */
     public function unixstamp2date($func_timestamp, $func_art)
     {
+        $day = [];
+        $func_date = null;
         if ((int)$func_timestamp == 0) {
             return '---';
         } else {
@@ -717,6 +719,7 @@ class Func
      */
     public function page_split($current_page, $max_entries_per_page, $overall_entries, $working_link, $var_page_name)
     {
+        $orderby = null;
         // $current_page is passed as an string, because the source is a GET parameter
         // it seems that it can contain a string 'all' or a number.
         // In this function we add numbers to $current_page which
@@ -1120,6 +1123,9 @@ class Func
      */
     public function CreateSignonBar($guests, $paid_guests, $max_guests)
     {
+        $curuser = null;
+        $gesamtpaid = null;
+        $bar = null;
         $max_bars = 100;
 
         // Calculate signed up guests

--- a/inc/Classes/GD.php
+++ b/inc/Classes/GD.php
@@ -96,6 +96,7 @@ class GD
      */
     public function PutImage($file = null, $type = null, $destroy = true)
     {
+        $path = null;
         global $config;
 
         if ($file) {
@@ -280,6 +281,7 @@ class GD
      */
     private function OpenImage($filename)
     {
+        $img_src = null;
         if (!file_exists($filename)) {
             return 0;
         }

--- a/inc/Classes/MasterDelete.php
+++ b/inc/Classes/MasterDelete.php
@@ -106,14 +106,14 @@ class MasterDelete
             if ($func->internal_referer != 'index.php?'.$_SERVER['QUERY_STRING']) {
                 $_SESSION['md_referrer'] = $func->internal_referer;
             }
-            
+
             $refFieldsDelete = '';
             $refFieldsSet0 = '';
             $refFieldsDeny = '';
             $res = $db->qry('SELECT pri_table, pri_key, on_delete FROM %prefix%ref WHERE foreign_table = %string% AND foreign_key = %string%', $table, $idname);
             while ($row = $db->fetch_array($res)) {
                 $row2 = $db->qry_first('SELECT COUNT(*) AS cnt FROM %prefix%%plain% WHERE %plain% = %int%', $row['pri_table'], $row['pri_key'], $id);
-                
+
                 if ($row2['cnt']) {
                     if ($row['on_delete'] == 'ASK_DELETE') {
                         $refFieldsDelete .= HTML_NEWLINE. $row['pri_table'] .'.'. $row['pri_key'] .' ('. $row2['cnt'] .'x)';
@@ -151,7 +151,7 @@ class MasterDelete
             }
 
             return false;
-        
+
         // Action
         } else {
             $res = $this->DoDelete($table, $idname, $id);

--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -398,6 +398,10 @@ class MasterForm
      */
     public function SendForm($BaseURL, $table, $idname = '', $id = 0)
     {
+        $SQLFieldTypes = [];
+        $SQLFieldUnique = [];
+        $field = [];
+        $addUpdSuccess = null;
         global $dsp, $db, $config, $func, $sec, $framework, $__POST, $smarty, $cfg;
 
         // In freeze-mode there are no changes to the database allowed

--- a/inc/Functions/Debug.php
+++ b/inc/Functions/Debug.php
@@ -17,6 +17,7 @@
  */
 function d()
 {
+    $val = null;
     global $debug, $func;
 
     $arg_vars = func_get_args();

--- a/inc/Functions/MyErrorHandler.php
+++ b/inc/Functions/MyErrorHandler.php
@@ -99,7 +99,7 @@ function MyErrorHandler($errno, $errstr, $errfile, $errline)
                 type = 3,
                 description = %string%,
                 sort_tag = "PHP-Fehler"',
-            (int) $auth['userid'],
+            (int) ($auth['userid'] ?? 0),
             $err
         );
     }

--- a/inc/Functions/T.php
+++ b/inc/Functions/T.php
@@ -17,6 +17,7 @@ $translation_no_html_replace = false;
  */
 function t()
 {
+    $parameters = [];
     global $db, $translation, $func, $translation_no_html_replace;
 
     // Prepare function parameters

--- a/modules/about/Functions/GetTheLinesAndChars.php
+++ b/modules/about/Functions/GetTheLinesAndChars.php
@@ -6,6 +6,7 @@
  */
 function GetTheLinesAndChars($file)
 {
+    $data = [];
     $file_content = file($file);
     $data[0] = count($file_content);
     foreach ($file_content as $iValue) {

--- a/modules/board/Functions/GetBoardRank.php
+++ b/modules/board/Functions/GetBoardRank.php
@@ -6,6 +6,7 @@
  */
 function GetBoardRank($posts)
 {
+    $rank = null;
     global $cfg;
 
     $lines = explode("\n", $cfg['board_rank']);

--- a/modules/board/Functions/GetUserInfo.php
+++ b/modules/board/Functions/GetUserInfo.php
@@ -6,6 +6,7 @@
  */
 function GetUserInfo($userid)
 {
+    $user = [];
     global $db, $cfg, $func;
 
     $row_poster = $db->qry_first("SELECT username, type, avatar_path, signature FROM %prefix%user WHERE userid=%int%", $userid);

--- a/modules/board/Functions/NameAndDesc.php
+++ b/modules/board/Functions/NameAndDesc.php
@@ -6,6 +6,7 @@
  */
 function NameAndDesc($name)
 {
+    $group = null;
     global $line, $auth;
 
     if ($line['board_group']) {

--- a/modules/cashmgr/Classes/Accounting.php
+++ b/modules/cashmgr/Classes/Accounting.php
@@ -175,6 +175,7 @@ class Accounting
      */
     private function getGroup($fix, $posneg)
     {
+        $row = null;
         global $db;
         
         $result_list = [];

--- a/modules/downloads/show.php
+++ b/modules/downloads/show.php
@@ -66,7 +66,7 @@ if (!$cfg['download_use_ftp']) {
                 sort($FileList);
             }
         }
-          
+
         if ($FileList) {
             foreach ($FileList as $CurFile) {
                 $CreateTime = filectime($BaseDir.'/'.$CurFilePath);

--- a/modules/foodcenter/Classes/Basket.php
+++ b/modules/foodcenter/Classes/Basket.php
@@ -77,6 +77,7 @@ class Basket
      */
     public function show_basket()
     {
+        $fc_theke_delivered = [];
         global $dsp, $cfg, $func;
             
         $dsp->NewContent(t('Warenkorb'), t('Um einen Artikel zu löschen, setze ihn auf 0 und klicken anschließend auf "Neu berechnen".'));

--- a/modules/foodcenter/Classes/FoodcenterPrint.php
+++ b/modules/foodcenter/Classes/FoodcenterPrint.php
@@ -31,6 +31,7 @@ class FoodcenterPrint
 
     public function __construct()
     {
+        $temp = [];
         global $func, $auth;
 
         if (!file_exists($this->path . $_POST['file']) || $_POST['file'] == "") {
@@ -184,6 +185,8 @@ class FoodcenterPrint
      */
     private function sql()
     {
+        $config = [];
+        $row_temp = [];
         global $db;
 
         $search = '';

--- a/modules/foodcenter/Classes/Product.php
+++ b/modules/foodcenter/Classes/Product.php
@@ -386,6 +386,7 @@ class Product
      */
     public function form_add_product($step)
     {
+        $add_product_prod_opt = [];
         global $dsp, $smarty;
 
         $nextstep = $step + 1;

--- a/modules/foodcenter/Functions/PaidIconLinkFoodcenter.php
+++ b/modules/foodcenter/Functions/PaidIconLinkFoodcenter.php
@@ -8,6 +8,7 @@
  */
 function PaidIconLinkFoodcenter($paid)
 {
+    $link = null;
     global $dsp, $line, $party;
 
     // Only link, if selected party is the current party

--- a/modules/install/Classes/Import.php
+++ b/modules/install/Classes/Import.php
@@ -61,6 +61,7 @@ class Import
      */
     public function GetImportHeader($tmp_file_name)
     {
+        $import = [];
         $xml_file = fopen($tmp_file_name, "r");
         $this->xml_content = fread($xml_file, filesize($tmp_file_name));
         fclose($xml_file);
@@ -554,6 +555,8 @@ class Import
      */
     public function ImportLanSuite($del_db, $replace, $no_seat, $signon, $comment)
     {
+        $users_to_import = [];
+        $seat_blocks_to_import = [];
         global $db, $party, $cfg;
 
         // Delete User-Table

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -80,6 +80,7 @@ class Install
      */
     public function TryCreateDB($createnew = null)
     {
+        $ret_val = null;
         global $config, $db;
 
         if (!$db->connect(1)) {
@@ -620,6 +621,7 @@ class Install
      */
     public function envcheck()
     {
+        $config = [];
         global $db, $dsp, $func;
 
         $continue = 1;
@@ -961,6 +963,7 @@ class Install
      */
     public function getModConfigLine($row, $showLinks = 1)
     {
+        $language = null;
         global $smarty, $db;
 
         $smarty->assign('name', $row['name']);

--- a/modules/mail/Functions/SMTPMail.php
+++ b/modules/mail/Functions/SMTPMail.php
@@ -11,6 +11,8 @@
  */
 function SMTPMail($mail_to, $subject, $message, $headers = '')
 {
+    $cc = null;
+    $bcc = null;
     global $board_config;
 
     // Fix any bare linefeeds in the message to make it RFC821 Compliant.

--- a/modules/mail/Functions/ServerParse.php
+++ b/modules/mail/Functions/ServerParse.php
@@ -8,6 +8,7 @@
  */
 function ServerParse($socket, $response, $line = __LINE__)
 {
+    $server_response = null;
     while (substr($server_response, 3, 1) != ' ') {
         if (!($server_response = fgets($socket, 256))) {
             echo("Couldn't get mail server response codes ". HTML_NEWLINE);

--- a/modules/mastersearch2/Classes/MasterSearch2.php
+++ b/modules/mastersearch2/Classes/MasterSearch2.php
@@ -484,13 +484,13 @@ class MasterSearch2
                 } else {
                     $FirstTable = $this->query['from'];
                 }
-        
+
                 $res = $db->qry("DESCRIBE %plain%", $FirstTable);
                 while ($row = $db->fetch_array($res)) {
                     $this->SQLFieldTypes[$row['Field']] = $row['Type'];
                 }
                 $db->free_result($res);
-        
+
                 if ($this->SQLFieldTypes[$this->query['order_by']] == 'datetime'
                     || $this->SQLFieldTypes[$this->query['order_by']] == 'date'
                     || $this->SQLFieldTypes[$this->query['order_by']] == 'time'
@@ -498,7 +498,7 @@ class MasterSearch2
                     $this->query['order_by'] .= ' DESC';
                 }
             }
-      
+
         // Default order by (if non given per URL)
         } elseif ($this->query['default_order_by']) {
             $this->query['order_by'] = $this->query['default_order_by'];

--- a/modules/noc/class_noc.php
+++ b/modules/noc/class_noc.php
@@ -24,6 +24,7 @@ class noc
 {
     public function MACtoIP($SearchMAC, $IP, $ReadCommunity)
     {
+        $IP = null;
         $walk = snmprealwalk($IP, $ReadCommunity, ".1.3.6.1.2.1.3.1.1.2");
 
         if ($walk) {
@@ -59,6 +60,7 @@ class noc
     // Returns a numeric Value ( 1 for Error, 0 for No Error) <= kinda illogical...
     public function checkSNMPDevice($IP, $ReadCommunity)
     {
+        $error = null;
         unset($error);
 
         if (!(@snmpget($IP, $ReadCommunity, ".1.3.6.1.2.1.1.1.0"))) {
@@ -116,6 +118,7 @@ class noc
 
     public function getSNMPwalk($Device, $ReadCommunity, $OID)
     {
+        $data = [];
         $walkvalue = snmpwalk($Device, $ReadCommunity, $OID);
         
         foreach ($walkvalue as $value) {
@@ -132,6 +135,7 @@ class noc
     
     public function getMacAddress($Device, $ReadComunity, $device_id, $modell)
     {
+        $data = [];
         global $db;
         
         $ports = $this->getSNMPwalk($Device, $ReadComunity, ".1.3.6.1.2.1.17.4.3.1.2");

--- a/modules/noc/device_change.php
+++ b/modules/noc/device_change.php
@@ -12,32 +12,32 @@ switch ($_GET["step"]) {
 
             $_GET["step"] = 2;
         }
-        
+
         if ($_POST["device_ip"] == "") {
             $noc_error['device_ip'] = t('Bitte gib eine IP-Adresse f&uuml;r das Device ein');
-            
+
             $_GET["step"] = 2;
         } else {
             if (!($func->checkIP($_POST["device_ip"]))) {
                 $noc_error['device_ip'] = t('Bitte gib eine <em>g&uuml;ltige</em> IP-Adresse f&uuml;r das Device ein');
-            
+
                 $_GET["step"] = 2;
             }
         }
-        
-                
+
+
         if ($_POST["device_write"] == "") {
             $noc_error['device_write'] = t('Bitte gib eine Write-Community f&uuml;r das Device an.');
-                
+
             $_GET["step"] = 2;
         }
-        
+
         if ($_POST["device_read"] == "") {
             $noc_error['device_read'] = t('Bitte gib eine Read-Community f&uuml;r das Device an.');
-                            
+
             $_GET["step"] = 2;
         }
-        
+
         break;
 } // END SWITCH I
 
@@ -50,10 +50,10 @@ switch ($_GET["step"]) {
     case 1:
         include_once('modules/noc/search.inc.php');
         break;
-        
+
     case 2:
         $db->qry("SELECT * FROM %prefix%noc_devices WHERE id = %int%", $_GET["deviceid"]);
-        
+
         if ($row = $db->fetch_array()) {
             $deviceid = $row["id"];
             $device_ip = $row["ip"];
@@ -69,7 +69,7 @@ switch ($_GET["step"]) {
             $dsp->AddTextFieldRow("device_ip", t('IP-Adresse'), $device_ip, $noc_error['device_ip']);
             $dsp->AddTextFieldRow("device_read", t('Read-Community'), $device_read, $noc_error['device_read']);
             $dsp->AddTextFieldRow("device_write", t('Write-Community'), $device_write, $noc_error['device_write']);
-        
+
             $dsp->AddFormSubmitRow(t('Ändern'));
             $dsp->AddBackButton("index.php?mod=noc", "noc");
 
@@ -80,7 +80,7 @@ switch ($_GET["step"]) {
 
 
         break;
-    
+
     // --------------------------------------------------------------------------------------------------
     // Check and Update Device Data
     case 3:
@@ -97,9 +97,9 @@ switch ($_GET["step"]) {
 				      				&nbsp; &nbsp;<a href="http://de.php.net">Der Deutschen PHP Seite</a> herunter' . HTML_NEWLINE .', '));
             break;
         } // END IF
-        
+
         // ------------------------------------------------------------------------------------------
-    
+
         // U p d a t e it, not delete and reinsert it.
         $add_query = $db->qry("UPDATE %prefix%noc_devices SET
          name = %string%,
@@ -107,14 +107,14 @@ switch ($_GET["step"]) {
          readcommunity = %string%,
          writecommunity = %string%
          WHERE id = %int%", $_POST['device_caption'], $_POST['device_ip'], $_POST['device_read'], $_POST['device_write'], $_GET["deviceid"]);
-        
+
         if ($add_query == 1) {
             $func->confirmation(t('Das Device wurde erfolgreich ge&auml;ndert.'));
         } else {
             $func->error(t('Das Device konnte nicht ge&auml;ndert werden.'));
         } // END IF
-                
-    
+
+
         break;
 } // END SWITCH II
 

--- a/modules/noc/device_details.php
+++ b/modules/noc/device_details.php
@@ -16,7 +16,7 @@ if (!$row = $db->fetch_array()) {
         default:
             $device_ip = $row["ip"];
             $readcommunity  = $row["readcommunity"];
-        
+
         // DISPLAYED TEXT
             $smarty->assign('caption', t('Name'));
             $smarty->assign('ip', t('IP-Adresse'));
@@ -126,12 +126,12 @@ if (!$row = $db->fetch_array()) {
 
         //Mac-Addressen auslesen
             $noc->getMacAddress($row["ip"], $row["readcommunity"], $row["id"], $row["sysDescr"]);
-        
+
         // Get the Ports and display 'em
             $db->qry("SELECT name FROM %prefix%noc_devices WHERE id = %int%", $_GET["deviceid"]);
 
             $row = $db->fetch_array();
-        
+
         // Ports are all saved into 1 template variable
             $ports = "<tr align=\"center\">";
 
@@ -161,7 +161,7 @@ if (!$row = $db->fetch_array()) {
                     $colspan = "1";
                 }
 
-            
+
                 switch ($row["linkstatus"]) {
                     case "up(1)":
                     case "up":
@@ -181,8 +181,8 @@ if (!$row = $db->fetch_array()) {
                             }
                                 $ports .= "<td colspan=\"" . $colspan . "\"><a class=\"menu\" href=\"index.php?mod=noc&action=port_details&portid=" . $row["portid"] . "\"><img alt='' border=0 src=\"$port_pic\"/></a></td>";
                         }
-                    
-        
+
+
                         break;
 
                     case "down(2)":
@@ -222,12 +222,12 @@ if (!$row = $db->fetch_array()) {
             $changebutton = $dsp->FetchSpanButton(t('Zurück'), "index.php?mod=noc&action=show_device");
             $changebutton .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=noc&action=details_device&deviceid=". $_GET["deviceid"] ."&step=2");
             $smarty->assign('changebutton', $changebutton);
-    
+
         // DISPLAY TEMPLATE
             $dsp->AddSmartyTpl('device_details', 'noc');
             break;
-        
-        
+
+
         case 2:
             $dsp->NewContent(t('Portstatus &auml;ndern'), t('Gib bitte alle Ports an die du &auml;ndern willst'));
             $dsp->SetForm("index.php?mod=noc&action=details_device&deviceid=". $_GET["deviceid"] ."&step=3");
@@ -264,7 +264,7 @@ if (!$row = $db->fetch_array()) {
                             }
                                 $tmp_noc .= "<td colspan=\"" . $colspan . "\"><input name='noc[]' type='checkbox' value='". $row["portnr"] ."'/><img alt='' border=0 src=\"$port_pic\"/></td>\n";
                         }
-                
+
                         break;
 
                     case "down(2)":
@@ -295,11 +295,11 @@ if (!$row = $db->fetch_array()) {
                 }
                 $Portcount++;
             } // END WHILE
-        
+
             $dsp->AddSingleRow($tmp_noc . "<td>");
             $dsp->AddFormSubmitRow(t('Editieren'));
             break;
-        
+
         case 3:
             if (is_array($_POST['noc'])) {
                 foreach ($_POST['noc'] as $noc_data) {
@@ -351,7 +351,7 @@ if (!$row = $db->fetch_array()) {
 											 Pr&uuml;fen sie die Einstellung der Write-Community') . HTML_NEWLINE;
                     }
                 }
-                
+
                 if ($noc_error == 1) {
                     $func->error($text, "index.php?mod=noc&action=details_device&deviceid=". $_GET["deviceid"]);
                 } else {
@@ -391,7 +391,7 @@ if (!$row = $db->fetch_array()) {
 											 Pr&uuml;fen sie die Einstellung der Write-Community') . HTML_NEWLINE;
                     $noc_error = 1;
                 }
-            
+
                 if ($noc_error == 1) {
                     $func->error($text, "index.php?mod=noc&action=details_device&deviceid=". $_GET["deviceid"]);
                 } else {

--- a/modules/party/Classes/Party.php
+++ b/modules/party/Classes/Party.php
@@ -104,6 +104,7 @@ class Party
      */
     public function get_party_dropdown_form($show_old = 0, $link = '')
     {
+        $list_array = [];
         global $dsp, $db, $func;
 
         if ($link == '') {
@@ -252,6 +253,7 @@ class Party
      */
     public function delete_user_from_party($user_id)
     {
+        $checkin = null;
         global $db, $cfg;
 
         $timestamp = time();
@@ -277,6 +279,7 @@ class Party
      */
     public function get_user_group_dropdown($group_id = "NULL", $nogroub = 0, $select_id = 0, $javascript = false)
     {
+        $data = [];
         global $db, $dsp;
 
         if ($group_id == "NULL") {
@@ -392,6 +395,8 @@ class Party
     */
     public function getGuestQty($party_id = NULL)
     {
+        $cfg = [];
+        $db = null;
         global $cache;
         
         if (empty($party_id)) {

--- a/modules/pdf/Classes/PDF.php
+++ b/modules/pdf/Classes/PDF.php
@@ -266,6 +266,7 @@ class PDF
      */
     public function get_data_array($action, $selected = "")
     {
+        $data = [];
         $data[] = [];
         foreach ($this->data_type_array[$action] as $key => $value) {
             if ($key == $selected) {
@@ -467,6 +468,8 @@ class PDF
      */
     private function _makeUserCard($pdf_paid, $pdf_normal, $pdf_op, $pdf_orga, $pdf_guestid)
     {
+        $data = [];
+        $new_page = null;
         global $db, $func, $party;
 
         define('IMAGE_PATH', 'ext_inc/pdf_templates/');
@@ -623,6 +626,8 @@ class PDF
      */
     private function _makeSeatCard($block, $order)
     {
+        $data = [];
+        $new_page = null;
         global $db, $func, $party;
 
         define('IMAGE_PATH', 'ext_inc/pdf_templates/');
@@ -743,6 +748,8 @@ class PDF
      */
     private function _makeUserlist($pdf_paid, $pdf_normal, $pdf_op, $pdf_orga, $order)
     {
+        $data = [];
+        $new_page = null;
         global $db, $func, $party;
 
         define('IMAGE_PATH', 'ext_inc/pdf_templates/');
@@ -915,6 +922,8 @@ class PDF
      */
     private function _makeCertificate($pdf_normal, $pdf_user)
     {
+        $data = [];
+        $new_page = null;
         global $db, $func, $party;
 
         define('IMAGE_PATH', 'ext_inc/pdf_templates/');

--- a/modules/seating/Classes/Seat2.php
+++ b/modules/seating/Classes/Seat2.php
@@ -270,6 +270,7 @@ class Seat2
      */
     public function U18Block($id, $idtype)
     {
+        $blockid = null;
         global $db;
 
         if ($idtype == "b") {
@@ -307,6 +308,14 @@ class Seat2
      */
     public function DrawPlan($blockid, $mode, $linktarget = '', $selected_user = false)
     {
+        $seat_user_checkin = [];
+        $party_user = [];
+        $seat_user_checkout = [];
+        $user_info = [];
+        $YStartPlan = null;
+        $jscode = null;
+        $XStartPlan = null;
+        $YOffset = null;
         global $db, $templ, $auth, $cfg, $party, $smarty, $framework, $func;
 
         // Get Block data (side descriptions + number of rows + cols)

--- a/modules/seating/show.php
+++ b/modules/seating/show.php
@@ -255,11 +255,11 @@ switch ($_GET['step']) {
 
             $questionarray[] = t('Diesen Platz für mich vorreservieren, meinen alten Platz freigeben.');
             $linkarray[]     = "index.php?mod=seating&action=show&step=22&blockid={$_GET['blockid']}&row={$_GET['row']}&col={$_GET['col']}";
-        
+
             $questionarray[] = t('Aktion abbrechen. Zurück zum Sitzplan');
             $linkarray[]     = "index.php?mod=seating&action=show&step=2&blockid={$_GET['blockid']}";
-        
-        
+
+
             $func->multiquestion($questionarray, $linkarray, t('Solange du nicht für diese Party bezahlt hast, darfst du nur einen Sitz vormerken'), "index.php?mod=seating&action=show&step=2&blockid={$_GET['blockid']}");
 
         // Check number of marked seats of this user

--- a/modules/stats/boxes/stats.php
+++ b/modules/stats/boxes/stats.php
@@ -20,9 +20,9 @@ $avg = $db->qry_first("
   WHERE
     DATE_FORMAT(time, '%Y-%m-%d %H:00:00') = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 HOUR), '%Y-%m-%d %H:00:00')");
 $box->DotRow(t('Besucher').':');
-$box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '', '.').'<span class="infobox">'.$total['visits'].' '.t('Besucher insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['visits'] ? $avg['visits'] : '0').')<span class="infobox">'.($avg['visits'] ? $avg['visits'] : '0').' '.t('Besucher in der letzten Stunde').'</span></span>');
+$box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '', '.').'<span class="infobox">'.$total['visits'].' '.t('Besucher insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['visits'] ?: '0').')<span class="infobox">'.($avg['visits'] ?: '0').' '.t('Besucher in der letzten Stunde').'</span></span>');
 $box->DotRow(t('Aufrufe').':');
-$box->EngangedRow('<span class="infolink">'.number_format($total['hits'], 0, '', '.').'<span class="infobox">'.$total['hits'].' '.t('Seitenzugriffe insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['hits'] ? $avg['hits'] : '0').')<span class="infobox">'.($avg['hits'] ? $avg['hits'] : '0').' '.t('Seitenzugriffe in der letzten Stunde').'</span></span>');
+$box->EngangedRow('<span class="infolink">'.number_format($total['hits'], 0, '', '.').'<span class="infobox">'.$total['hits'].' '.t('Seitenzugriffe insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['hits'] ?: '0').')<span class="infobox">'.($avg['hits'] ?: '0').' '.t('Seitenzugriffe in der letzten Stunde').'</span></span>');
 
 $box->DotRow(t('Online') .': '. count($authentication->online_users), 'index.php?mod=guestlist&action=onlineuser');
 foreach ($authentication->online_users as $userid) {

--- a/modules/tournament2/Classes/TournamentFunction.php
+++ b/modules/tournament2/Classes/TournamentFunction.php
@@ -475,6 +475,8 @@ class TournamentFunction
      */
     private function GenerateNewPosition($player1, $player2)
     {
+        $team_round = [];
+        $team_pos = [];
         global $db, $round, $pos, $score, $tournamentid, $leaderid, $num_rounds, $team_anz;
 
         $team_round[$player1] = $round;
@@ -669,6 +671,7 @@ class TournamentFunction
      */
     public function SubmitResult($ttid, $gameid1, $gameid2, $score1, $score2, $comment)
     {
+        $unfinished_games = [];
         global $db, $func, $tournamentid, $round, $pos, $score, $leaderid, $num_rounds, $team_anz;
         $tournamentid = $ttid;
         $score[1] = $score1;

--- a/modules/tournament2/Classes/TournamentLeagueExport.php
+++ b/modules/tournament2/Classes/TournamentLeagueExport.php
@@ -153,6 +153,9 @@ class TournamentLeagueExport
      */
     public function ngl_export($eventid)
     {
+        $mode = null;
+        $db_teamid = [];
+        $score1 = null;
         global $db, $party;
 
         $output = '<?xml version="1.0" encoding="ISO-8859-15"?'.'>'."\r\n";
@@ -347,6 +350,9 @@ class TournamentLeagueExport
      */
     public function lgz_export($eventid)
     {
+        $mode = null;
+        $db_teamid = [];
+        $score1 = null;
         global $db, $party;
 
         $output = '<?xml version="1.0"?'.'>'."\r\n";

--- a/modules/tournament2/Functions/GetTournamentStatus.php
+++ b/modules/tournament2/Functions/GetTournamentStatus.php
@@ -6,6 +6,7 @@
  */
 function GetTournamentStatus($status)
 {
+    $status_descriptor = [];
     $status_descriptor["open"]      = t('Anmeldung offen');
     $status_descriptor["locked"]    = t('Anmeldung geschlossen');
     $status_descriptor["invisible"] = t('Unsichtbar');

--- a/modules/tournament2/Functions/WritePairs2.php
+++ b/modules/tournament2/Functions/WritePairs2.php
@@ -7,6 +7,8 @@
  */
 function write_pairs2($bracket, $max_pos)
 {
+    $score1 = null;
+    $gameid1 = null;
     global $auth, $templ, $func, $t, $x_start, $height, $height_menu, $box_height, $box_width, $db, $tournamentid, $akt_round, $max_round, $dg, $img_height, $map, $tfunc;
 
     $dg++;

--- a/modules/tournament2/Functions/WritePairs3.php
+++ b/modules/tournament2/Functions/WritePairs3.php
@@ -7,6 +7,9 @@
  */
 function write_pairs3($bracket, $max_pos)
 {
+    $score1 = null;
+    $known_game1 = null;
+    $spielerid1 = null;
     global $gd, $func, $tournament, $x_start, $height, $height_menu, $box_height, $box_width, $db, $tournamentid, $akt_round, $max_round, $color, $dg, $img_height, $map, $tfunc;
 
     $dg++;

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_54
+        LevelSetList::UP_TO_PHP_55
     ]);
 
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -22,12 +22,17 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_55
+        LevelSetList::UP_TO_PHP_56
     ]);
 
     $rectorConfig->skip([
         // Skipping LongArrayToShortArrayRector, because it transforms long multi-line
         // array to one line arrays. This would destroy readability for now.
         Rector\Php54\Rector\Array_\LongArrayToShortArrayRector::class,
+
+        // Skipping PowToExpRector, because pow is not deprecated or has any disadvantage
+        // over **
+        // See https://www.php.net/manual/en/function.pow.php
+        Rector\Php56\Rector\FuncCall\PowToExpRector::class,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        // Excluding the directories that contain external source code
+        //__DIR__ . '/ext_inc',
+        //__DIR__ . '/ext_scripts',
+
+        __DIR__ . '/inc',
+        __DIR__ . '/modules',
+        __DIR__ . '/tests',
+    ]);
+
+    // Register a single rule
+    // $rectorConfig->rule(Rector\Php70\Rector\FuncCall\RandomFunctionRector::class);
+
+    // Define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_53,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,12 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_53,
+        LevelSetList::UP_TO_PHP_54
+    ]);
+
+    $rectorConfig->skip([
+        // Skipping LongArrayToShortArrayRector, because it transforms long multi-line
+        // array to one line arrays. This would destroy readability for now.
+        Rector\Php54\Rector\Array_\LongArrayToShortArrayRector::class,
     ]);
 };


### PR DESCRIPTION
## Context

We raise the Level set of Rector to `UP_TO_PHP_56`. See https://github.com/rectorphp/rector/blob/main/config/set/level/up-to-php56.php

## Undefined variables

This PR will fix a lot of Warnings in PHP 8.
PHP 8 throws a Warning once a variable is used but not defined.

## Dependency

This PR depends on https://github.com/lansuite/lansuite/pull/582
#582 needs to be merged first.

The commit of this PR is https://github.com/lansuite/lansuite/commit/9ee877902aba4834a7a56a4a9236f11b7a67c8b9