### PR TITLE
Remove dependency to apcu extension

### DIFF
--- a/docs/development-cache.md
+++ b/docs/development-cache.md
@@ -22,7 +22,7 @@ Also there is no requirement that the value is always correct, as it is just use
 ### Code
 
 There is object named `$cache` available in the global scope.
-This implements [PSR-16](https://www.php-fig.org/psr/psr-16/) and either works via APCu (if module enabled) or with files in the temporary directory.
+This implements [PSR-16](https://www.php-fig.org/psr/psr-16/) and works with files in the temporary directory.
 Code example:
 
 ```

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -28,10 +28,8 @@ class Auth
 
     /**
      * Cookie data
-     *
-     * @var array
      */
-    private $cookie_data = [];
+    private array $cookie_data = [];
 
     /**
      * Cookie name

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -250,6 +250,13 @@ class Auth
                 );
             }
 
+            if (!$user) {
+                $user = [
+                    'userid' => 0,
+                    'found' => 0,
+                ];
+            }
+
             // Needs to be a seperate query; WHERE (p.party_id IS NULL OR p.party_id=%int%) does not work when 2 parties exist
             if ($func->isModActive('party')) {
                 $party_query = $db->qry_first('SELECT p.checkin AS checkin, p.checkout AS checkout FROM %prefix%party_user AS p WHERE p.party_id=%int% AND user_id=%int%', $party->party_id, $user['userid']);
@@ -570,7 +577,7 @@ class Auth
      */
     public function get_olduserid()
     {
-        return $this->cookie_data['olduserid'];
+        return $this->cookie_data['olduserid'] ?? 0;
     }
 
     /**

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -23,10 +23,8 @@ class Auth
 
     /**
      * Time
-     *
-     * @var int
      */
-    private $timestamp;
+    private int $timestamp;
 
     /**
      * Cookie data
@@ -37,52 +35,38 @@ class Auth
 
     /**
      * Cookie name
-     *
-     * @var string
      */
-    private $cookie_name = 'LSAUTH';
+    private string $cookie_name = 'LSAUTH';
 
     /**
      * Cookie version
-     *
-     * @var string
      */
-    private $cookie_version = '1';
+    private string $cookie_version = '1';
 
     /**
      * Domain
-     *
-     * @var string
      */
-    private $cookie_domain = '';
+    private string $cookie_domain = '';
 
     /**
      * Duration in days
-     *
-     * @var string
      */
-    private $cookie_time = '30';
+    private string $cookie_time = '30';
 
     /**
      * Cookie path
-     *
-     * @var string
      */
-    private $cookie_path = '';
+    private string $cookie_path = '';
 
     /**
      * Crypt Cookie with AzDGCrypt
-     *
-     * @var bool
      */
-    private $cookie_crypt = true;
+    private bool $cookie_crypt = true;
 
     /**
      * Passphrase for AzDGCrypt
-     *
-     * @var string
      */
-    private $cookie_crypt_pw = "iD9ww32e";
+    private string $cookie_crypt_pw = "iD9ww32e";
 
     /**
      * Array containing all users, currently online

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -692,9 +692,7 @@ class Auth
         setcookie(
             $this->cookie_name,
             $this->cookiedata_pack(),
-            time()+3600*24*$this->cookie_time,
-            $this->cookie_path,
-            $this->cookie_domain
+            ['expires' => time()+3600*24*$this->cookie_time, 'path' => $this->cookie_path, 'domain' => $this->cookie_domain]
         );
     }
 
@@ -708,9 +706,7 @@ class Auth
         setcookie(
             $this->cookie_name,
             '',
-            time()+1,
-            $this->cookie_path,
-            $this->cookie_domain
+            ['expires' => time()+1, 'path' => $this->cookie_path, 'domain' => $this->cookie_domain]
         );
     }
 

--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -88,8 +88,23 @@ class Auth
     {
         global $db;
 
-        $this->auth["sessid"] = session_id();
-        $this->auth["ip"] = $_SERVER['REMOTE_ADDR'];
+        // Setting default values
+        $this->auth = [
+            'sessid' => session_id(),
+            'ip' => $_SERVER['REMOTE_ADDR'],
+
+            'login' => LS_AUTH_LOGIN_LOGGED_OUT,
+            'type' => LS_AUTH_TYPE_ANONYMOUS,
+
+            // In theory, all fields of the user database table should be present.
+            // See loadAuthBySID()
+            'userid' => 0,
+            'email' => '',
+            'username' => '',
+            'userpassword' => '',
+            'group_id' => 0,
+            'design' => 'simple' // TODO Get design from default configuration
+        ];
         $this->timestamp = time();
 
         // Update statistics
@@ -566,15 +581,24 @@ class Auth
     private function loadAuthBySID()
     {
         global $db;
+
         // Put all User-Data into $auth-Array
-        $user_data = $db->qry_first('SELECT 1 AS found, 
-        session.userid, 
-        session.login, 
-        INET6_NTOA(session.ip) AS ip, 
-        user.*
-            FROM %prefix%stats_auth AS session
-            LEFT JOIN %prefix%user AS user ON user.userid = session.userid
-            WHERE session.sessid=%string% ORDER BY session.lasthit', $this->auth["sessid"]);
+        // TODO Replace * with an expanded list of all fields of the user database table
+        // TODO Check if really all fields are required
+        $user_data = $db->qry_first('
+            SELECT
+                1 AS `found`,
+                `session`.`userid`,
+                `session`.`login`,
+                INET6_NTOA(`session`.`ip`) AS `ip`,
+                `user`.*
+            FROM
+                `%prefix%stats_auth` AS `session`
+                LEFT JOIN `%prefix%user` AS `user` ON `user`.`userid` = `session`.`userid`
+            WHERE
+                `session`.`sessid` = %string%
+            ORDER BY `session`.`lasthit`', $this->auth["sessid"]);
+
         if (is_array($user_data)) {
             foreach ($user_data as $key => $val) {
                 if (!is_numeric($key)) {
@@ -582,6 +606,7 @@ class Auth
                 }
             }
         }
+
         return $this->auth['login'];
     }
 

--- a/inc/Classes/AzDGCrypt.php
+++ b/inc/Classes/AzDGCrypt.php
@@ -59,7 +59,7 @@ class AzDGCrypt
      */
     public function crypt($t)
     {
-        mt_srand((double)microtime()*1000000);
+        mt_srand((double)microtime()*1_000_000);
         $r = md5(random_int(0, 32000));
         $c=0;
         $v = "";

--- a/inc/Classes/Barcode.php
+++ b/inc/Classes/Barcode.php
@@ -1130,7 +1130,7 @@ class Barcode
         $widebar.="0";
 
         for ($i=0; $i<strlen($barnumber); $i++) {
-            $num=(int)$barnumber{$i};
+            $num=(int)$barnumber[$i];
             $str="";
             $str=str_replace("N", "10", $encTable[$num]);
             $str=str_replace("W", $widebar, $str);
@@ -1276,7 +1276,7 @@ class Barcode
         $encTable[$checkdigit];
 
         for ($i=0; $i<strlen($barnumber); $i++) {
-            $num=(int)$barnumber{$i};
+            $num=(int)$barnumber[$i];
             $even=(substr($encTable[$checkdigit], $i, 1)=='E');
             if (!$even) {
                 $mfcStr.=$leftOdd[$num];
@@ -1404,9 +1404,9 @@ class Barcode
 
         for ($i=0; $i<strlen($barnumber); $i++) {
             if ($i % 2 == 0) {
-                $csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+                $csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
             } else {
-                $csumTotal = $csumTotal + intval($barnumber{$i});
+                $csumTotal = $csumTotal + intval($barnumber[$i]);
             }
         }
 
@@ -1445,7 +1445,7 @@ class Barcode
         $prodStr="";
 
         for ($i=0; $i<strlen($barnumber); $i++) {
-            $num=(int)$barnumber{$i};
+            $num=(int)$barnumber[$i];
             if ($i<4) {
                 $mfcStr.=$leftOdd[$num];
             } elseif ($i>=4) {
@@ -1560,9 +1560,9 @@ class Barcode
 
         for ($i=0; $i<strlen($barnumber); $i++) {
             if ($i % 2 == 0) {
-                $csumTotal = $csumTotal + intval($barnumber{$i});
+                $csumTotal = $csumTotal + intval($barnumber[$i]);
             } else {
-                $csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+                $csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
             }
         }
 
@@ -1621,7 +1621,7 @@ class Barcode
         $encbit=$barnumber[0];
 
         for ($i=1; $i<strlen($barnumber); $i++) {
-            $num=(int)$barnumber{$i};
+            $num=(int)$barnumber[$i];
             if ($i<7) {
                 $even=(substr($encTable[$encbit], $i-1, 1)==1);
                 if (!$even) {

--- a/inc/Classes/Barcode.php
+++ b/inc/Classes/Barcode.php
@@ -152,7 +152,7 @@ class Barcode
             if (strlen($barnumber)>13 || strlen($barnumber)<12) {
                 $this->_error="Barcode number must be less then 13 characters.";
                 return false;
-            } elseif (substr($barnumber, 0, 3)!="978") {
+            } elseif (!str_starts_with($barnumber, "978")) {
                 $this->_error="Not an ISBN barcode number. Must be start with 978";
                 return false;
             }
@@ -983,7 +983,7 @@ class Barcode
         $len=strlen($barnumber);
         if ($len % 2!=0) {
             $barnumber=$this->_checkDigit($barnumber, $len);
-            if ($len==strlen($barnumber) && substr($barnumber, -1)!='0') {
+            if ($len==strlen($barnumber) && !str_ends_with($barnumber, '0')) {
                 $barnumber.='0';
             }
         }
@@ -1120,7 +1120,7 @@ class Barcode
 
         $len=strlen($barnumber);
         $barnumber=$this->_checkDigit($barnumber, $len);
-        if ($len==strlen($barnumber) && substr($barnumber, -1)!='0') {
+        if ($len==strlen($barnumber) && !str_ends_with($barnumber, '0')) {
             $barnumber.='0';
         }
 
@@ -1232,7 +1232,7 @@ class Barcode
             $barnumber = str_pad($barnumber, 12, "0", STR_PAD_LEFT);
         }
 
-        if (substr($upca, 0, 1) != '0' && substr($upca, 0, 1) != '1') {
+        if (!str_starts_with($upca, '0') && !str_starts_with($upca, '1')) {
             $this->_error = 'Invalid Number System (only 0 & 1 are valid)';
             return false;
         } else {

--- a/inc/Classes/BarcodeSystem.php
+++ b/inc/Classes/BarcodeSystem.php
@@ -19,7 +19,7 @@ namespace LanSuite;
  */
 class BarcodeSystem
 {
-    private $class_barcode;
+    private \LanSuite\Barcode $class_barcode;
 
     public function __construct()
     {
@@ -44,7 +44,7 @@ class BarcodeSystem
      */
     private function gencode($userid)
     {
-        $code = 768300000000;
+        $code = 768_300_000_000;
         $code = $code + ($userid * 10000);
         $code = $code + random_int(0, 9999);
         return $code;

--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -208,6 +208,12 @@ class DB
     {
         global $func;
 
+        // Mimic the original behaviour of mysqli_fetch_array
+        // Returns an array representing the fetched row, null if there are no more rows in the result set, or false on failure.
+        if (!$query_id) {
+            return null;
+        }
+
         if ($query_id != -1) {
             $this->query_id = $query_id;
         }
@@ -233,7 +239,9 @@ class DB
             $this->query_id = $query_id;
         }
 
-        return mysqli_num_rows($this->query_id);
+        // If a SQL query does not return any rows, the query function
+        // returns false. We ensure that `num_rows` always returns an integer.
+        return $query_id ? mysqli_num_rows($this->query_id): 0;
     }
 
     /**
@@ -295,6 +303,11 @@ class DB
      */
     public function free_result($query_id = -1)
     {
+        // No op if we don't had a query result
+        if (!$query_id) {
+            return;
+        }
+
         if ($query_id != -1) {
             $this->query_id = $query_id;
         }

--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -29,10 +29,7 @@ class DB
      */
     public $count_query = 0;
 
-    /**
-     * @var string
-     */
-    private $errors = '';
+    private string $errors = '';
 
     /**
      * @var int
@@ -53,10 +50,7 @@ class DB
      */
     private $QueryArgs = [];
 
-    /**
-     * @var string
-     */
-    private $sql_error = '';
+    private string $sql_error = '';
 
     /**
      * @param string $msg

--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -4,20 +4,11 @@ namespace LanSuite;
 
 class DB
 {
-    /**
-     * @var \mysqli
-     */
-    private $link_id;
+    private \mysqli|bool|null $link_id = null;
 
-    /**
-     * @var \mysqli_result
-     */
-    private $query_id;
+    private bool|\mysqli_result|null $query_id = null;
 
-    /**
-     * @var array
-     */
-    private $record = [];
+    private array|bool|null $record = [];
 
     /**
      * @var bool
@@ -45,10 +36,7 @@ class DB
      */
     public $connectfailure = 0;
 
-    /**
-     * @var array
-     */
-    private $QueryArgs = [];
+    private array $QueryArgs = [];
 
     private string $sql_error = '';
 
@@ -175,10 +163,8 @@ class DB
 
     /**
      * If the second parameter is an array, the function uses the array as value list.
-     *
-     * @return bool|int|mysqli_result
      */
-    public function qry()
+    public function qry(): bool|int|\mysqli_result
     {
         global $config, $debug;
 
@@ -217,9 +203,8 @@ class DB
     /**
      * @param int $query_id
      * @param int $save
-     * @return array|null
      */
-    public function fetch_array($query_id = -1, $save = 1)
+    public function fetch_array($query_id = -1, $save = 1): ?array
     {
         global $func;
 
@@ -266,9 +251,8 @@ class DB
 
     /**
      * @param int $query_id
-     * @return int|string
      */
-    public function insert_id($query_id = -1)
+    public function insert_id($query_id = -1): int|string
     {
         if ($query_id != -1) {
             $this->query_id = $query_id;
@@ -320,10 +304,8 @@ class DB
 
     /**
      * If the second parameter is an array, the function uses the array as value list.
-     *
-     * @return array|bool|null
      */
-    public function qry_first()
+    public function qry_first(): array|bool|null
     {
         $this->qry($args = func_get_args());
 
@@ -340,10 +322,7 @@ class DB
         return $row;
     }
 
-    /**
-     * @return array|null
-     */
-    public function qry_first_rows()
+    public function qry_first_rows(): ?array
     {
         $this->qry($args = func_get_args());
         $row = $this->fetch_array();
@@ -363,10 +342,8 @@ class DB
 
     /**
      * Returns the version of the MySQL server
-     *
-     * @return string|bool
      */
-    public function getServerInfo()
+    public function getServerInfo(): string|bool
     {
         if ($this->link_id) {
             return mysqli_get_server_info($this->link_id);

--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -45,10 +45,8 @@ class Debug
 
     /**
      * Helpvar Timer (Outputstring)
-     *
-     * @var string
      */
-    private $timer_out = '';
+    private string $timer_out = '';
 
     /**
      * @var string
@@ -57,34 +55,25 @@ class Debug
 
     /**
      * Uservars to show
-     *
-     * @var array
      */
-    private $debugvars = [];
+    private array $debugvars = [];
 
     /**
      * Debug mode
-     *
-     * @var string
      */
-    private $mode = '';
+    private string $mode = '';
 
     /**
      * Debugpath for Filedebug
-     *
-     * @var string
      */
-    private $debug_path = '';
+    private string $debug_path = '';
 
     /**
      * @var array
      */
     private $sql_query_list = [];
 
-    /**
-     * @var bool
-     */
-    private $sql_query_running = false;
+    private bool $sql_query_running = false;
 
     /**
      * Debug constructor.

--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -48,10 +48,7 @@ class Debug
      */
     private string $timer_out = '';
 
-    /**
-     * @var string
-     */
-    private $timer_all;
+    private float|int|null $timer_all = null;
 
     /**
      * Uservars to show
@@ -68,10 +65,7 @@ class Debug
      */
     private string $debug_path = '';
 
-    /**
-     * @var array
-     */
-    private $sql_query_list = [];
+    private array $sql_query_list = [];
 
     private bool $sql_query_running = false;
 

--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -1227,29 +1227,15 @@ class Display
         $smarty->assign('name', $picname);
 
         if ($hint == '') {
-            switch ($picname) {
-                default:
-                    $hint = '';
-                    break;
-                case 'add':
-                    $hint = t('Hinzufügen');
-                    break;
-                case 'change':
-                    $hint = t('Ändern');
-                    break;
-                case 'edit':
-                    $hint = t('Editieren');
-                    break;
-                case 'delete':
-                    $hint = t('Löschen');
-                    break;
-                case 'send':
-                    $hint = t('Senden');
-                    break;
-                case 'quote':
-                    $hint = t('Zitieren');
-                    break;
-            }
+            $hint = match ($picname) {
+                'add' => t('Hinzufügen'),
+                'change' => t('Ändern'),
+                'edit' => t('Editieren'),
+                'delete' => t('Löschen'),
+                'send' => t('Senden'),
+                'quote' => t('Zitieren'),
+                default => '',
+            };
         }
         $smarty->assign('hint', $hint);
         if ($align == 'right') {

--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -18,10 +18,7 @@ class Display
      */
     public $form_open = 0;
 
-    /**
-     * @var int
-     */
-    private $formcount = 1;
+    private int $formcount = 1;
 
     /**
      * @var string
@@ -33,30 +30,18 @@ class Display
      */
     public $errortext_suffix = '';
 
-    /**
-     * @var int
-     */
-    private $FirstLine = 1;
+    private int $FirstLine = 1;
 
-    /**
-     * @var int
-     */
-    private $CurrentTab = 0;
+    private int $CurrentTab = 0;
 
     /**
      * @var string
      */
     private $TabsMainContentTmp = '';
 
-    /**
-     * @var array
-     */
-    private $TabNames = [];
+    private array $TabNames = [];
 
-    /**
-     * @var string
-     */
-    private $form_name = '';
+    private string $form_name = '';
 
     public function __construct()
     {

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -355,7 +355,7 @@ class Framework
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-ga('create', " . json_encode($cfg['google_analytics_id']) . ", 'auto');
+ga('create', " . json_encode($cfg['google_analytics_id'], JSON_THROW_ON_ERROR) . ", 'auto');
 ga('set', 'anonymizeIp', true);
 ga('send', 'pageview');
 </script>";

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -38,10 +38,8 @@ class Framework
 
     /**
      * Design
-     *
-     * @var string
      */
-    private $design = "simple";
+    private string $design = "simple";
 
     /**
      * Displaymodus (popup)
@@ -52,62 +50,45 @@ class Framework
 
     /**
      * All framework messages
-     *
-     * @var string
      */
-    private $framework_messages = '';
+    private string $framework_messages = '';
 
     /**
      * Content
-     *
-     * @var string
      */
-    private $main_content = '';
+    private string $main_content = '';
 
     /**
      * Headercode for Meta Tags
-     *
-     * @var string
      */
-    private $main_header_metatags = '';
+    private string $main_header_metatags = '';
 
     /**
      * Headercode for JS-Files
-     *
-     * @var string
      */
-    private $main_header_jsfiles = '';
+    private string $main_header_jsfiles = '';
 
     /**
      * Headercode for JS-Code
-     *
-     * @var string
      */
-    private $main_header_jscode = '';
+    private string $main_header_jscode = '';
 
     /**
      * Headercode for CSS-Files
-     *
-     * @var string
      */
-    private $main_header_cssfiles = '';
+    private string $main_header_cssfiles = '';
 
     /**
      * Headercode for CSS-Code
-     *
-     * @var string
      */
-    private $main_header_csscode = '';
+    private string $main_header_csscode = '';
 
     /**
      * @var bool
      */
     public $IsMobileBrowser = false;
 
-    /**
-     * @var string
-     */
-    private $pageTitle = '';
+    private string $pageTitle = '';
 
     public function __construct()
     {

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -226,18 +226,16 @@ class Framework
 
     /**
      * Check for errors in content and returns Zip-Mode
-     *
-     * @return int|string
      */
-    private function check_optimizer()
+    private function check_optimizer(): int|string
     {
         global $PHPErrors, $db;
 
         if (headers_sent() || connection_aborted() || $PHPErrors || (isset($db) && $db->errorsFound)) {
             return 0;
-        } elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false) {
+        } elseif (str_contains($_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip')) {
             return "x-gzip";
-        } elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip') !== false) {
+        } elseif (str_contains($_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip')) {
             return "gzip";
         }
 

--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -99,13 +99,13 @@ class Func
         $arrPattern = preg_split('~['.$strDelimiters.']~', $strPattern);
 
         // If the numbers of the two array are not the same, return false, because the cannot belong together
-        if ((is_array($arrStr) || $arrStr instanceof \Countable ? count($arrStr) : 0) !== (is_array($arrPattern) || $arrPattern instanceof \Countable ? count($arrPattern) : 0)) {
+        if ((is_countable($arrStr) ? count($arrStr) : 0) !== (is_countable($arrPattern) ? count($arrPattern) : 0)) {
             return false;
         }
 
         // Creates a new array which has the keys from the $arrPattern array and the values from the $arrStr array
         $arrTime = [];
-        for ($i = 0; $i < (is_array($arrStr) || $arrStr instanceof \Countable ? count($arrStr) : 0); $i++) {
+        for ($i = 0; $i < (is_countable($arrStr) ? count($arrStr) : 0); $i++) {
             $arrTime[$arrPattern[$i]] = $arrStr[$i];
         }
 

--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -99,7 +99,7 @@ class Func
         $arrPattern = preg_split('~['.$strDelimiters.']~', $strPattern);
 
         // If the numbers of the two array are not the same, return false, because the cannot belong together
-        if ((is_array($arrStr) || $arrStr instanceof \Countable ? count($arrStr) : 0) !== count($arrPattern)) {
+        if ((is_array($arrStr) || $arrStr instanceof \Countable ? count($arrStr) : 0) !== (is_array($arrPattern) || $arrPattern instanceof \Countable ? count($arrPattern) : 0)) {
             return false;
         }
 

--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -41,22 +41,12 @@ class Func
 
         $res = $db->qry('SELECT cfg_value, cfg_key, cfg_type FROM %prefix%config');
         while ($row = $db->fetch_array($res, 0)) {
-            switch ($row['cfg_type']) {
-                case 'integer':
-                case 'int':
-                      $cfg["{$row['cfg_key']}"] = (int)$row['cfg_value'];
-                    break;
-                case 'boolean':
-                case 'bool':
-                      $cfg["{$row['cfg_key']}"] = (bool)$row['cfg_value'];
-                    break;
-                case 'float':
-                      $cfg["{$row['cfg_key']}"] = (float)$row['cfg_value'];
-                    break;
-                default:
-                      $cfg["{$row['cfg_key']}"] = $row['cfg_value'];
-                    break;
-            }
+            $cfg["{$row['cfg_key']}"] = match ($row['cfg_type']) {
+                'integer', 'int' => (int)$row['cfg_value'],
+                'boolean', 'bool' => (bool)$row['cfg_value'],
+                'float' => (float)$row['cfg_value'],
+                default => $row['cfg_value'],
+            };
         }
         $db->free_result($res);
 
@@ -68,9 +58,8 @@ class Func
      *
      * @param string    $strStr
      * @param string    $strPattern
-     * @return bool|false|int
      */
-    public function str2time($strStr, $strPattern = 'Y-m-d H:i:s')
+    public function str2time($strStr, $strPattern = 'Y-m-d H:i:s'): bool|int
     {
         // An array of the valid date characters, see: http://php.net/date#AEN21898
         $arrCharacters = [
@@ -136,9 +125,8 @@ class Func
      *
      * @param int       $func_timestamp
      * @param string    $func_art       One of year, month, date, time, shorttime, datetime, daydatetime, daydate, or shortdaytime
-     * @return false|string
      */
-    public function unixstamp2date($func_timestamp, $func_art)
+    public function unixstamp2date($func_timestamp, $func_art): null|string
     {
         $day = [];
         $func_date = null;
@@ -786,9 +774,8 @@ class Func
      * @param string    $source_var
      * @param string    $path
      * @param string    $name
-     * @return int|string
      */
-    public function FileUpload($source_var, $path, $name = null)
+    public function FileUpload($source_var, $path, $name = null): int|string
     {
         global $config;
 
@@ -956,9 +943,8 @@ class Func
 
     /**
      * @param string $dir
-     * @return array|bool
      */
-    public function GetDirList($dir)
+    public function GetDirList($dir): array|bool
     {
         if (!is_dir($dir)) {
             return false;
@@ -967,7 +953,7 @@ class Func
         $ret = array();
         $handle = opendir($dir);
         while ($file = readdir($handle)) {
-            if ((substr($file, 0, 1)  != '.') and ($file != '.svn')) {
+            if ((!str_starts_with($file, '.')) and ($file != '.svn')) {
                 $ret[] = strtolower($file);
             }
         }

--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -928,7 +928,7 @@ class Func
             // Work out if we got a responce and time it
             [$usec, $sec] = explode(" ", microtime(true));
             $laptime = ((float)$usec + (float)$sec)-$start;
-            if (($laptime * 1000000) > ($timeout * 0.9)) {
+            if (($laptime * 1_000_000) > ($timeout * 0.9)) {
                 fclose($handle);
                 return false;
             } else {

--- a/inc/Classes/GD.php
+++ b/inc/Classes/GD.php
@@ -29,10 +29,7 @@ class GD
      */
     private $font_size;
 
-    /**
-     * @var int
-     */
-    private $free_type = 0;
+    private int $free_type = 0;
 
     /**
      * @var int

--- a/inc/Classes/MasterDelete.php
+++ b/inc/Classes/MasterDelete.php
@@ -23,9 +23,8 @@ class MasterDelete
      * @param string    $table
      * @param string    $idname
      * @param int       $id
-     * @return bool|int|mysqli_result
      */
-    private function DoDelete($table, $idname, $id)
+    private function DoDelete($table, $idname, $id): bool|int|\mysqli_result
     {
         global $func, $db, $config;
     
@@ -91,9 +90,8 @@ class MasterDelete
      * @param string    $table
      * @param string    $idname
      * @param int       $id
-     * @return bool|int|mysqli_result
      */
-    public function Delete($table, $idname, $id)
+    public function Delete($table, $idname, $id): bool|int|\mysqli_result
     {
         global $framework, $func, $db;
         

--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -49,20 +49,11 @@ class MasterForm
      */
     private $Groups = [];
 
-    /**
-     * @var array
-     */
-    private $SQLFields = [];
+    private array $SQLFields = [];
 
-    /**
-     * @var array
-     */
-    private $WYSIWYGFields = [];
+    private array $WYSIWYGFields = [];
 
-    /**
-     * @var array
-     */
-    private $DependOn = [];
+    private array $DependOn = [];
 
     /**
      * @var array
@@ -104,15 +95,9 @@ class MasterForm
      */
     public $isChange = false;
 
-    /**
-     * @var string
-     */
-    private $FormEncType = '';
+    private string $FormEncType = '';
 
-    /**
-     * @var int
-     */
-    private $PWSecID = 0;
+    private int $PWSecID = 0;
 
     /**
      * @var string
@@ -129,10 +114,7 @@ class MasterForm
      */
     public $AddChangeCondition = '';
 
-    /**
-     * @var int
-     */
-    private $NumFields = 0;
+    private int $NumFields = 0;
 
     /**
      * @var int
@@ -154,37 +136,20 @@ class MasterForm
      */
     public $SendButtonText = '';
 
-    /**
-     * @var int
-     */
-    private $OptGroupOpen = 0;
+    private int $OptGroupOpen = 0;
 
-    /**
-     * @var int
-     */
-    private $MultiLineID = 0;
+    private int $MultiLineID = 0;
 
-    /**
-     * @var array
-     */
-    private $MultiLineIDs = [];
+    private array $MultiLineIDs = [];
 
-    /**
-     * @var int
-     */
-    private $FCKeditorID = 0;
+    private int $FCKeditorID = 0;
 
-    /**
-     * @var array
-     */
-    private $Pages = [];
+    private array $Pages = [];
 
     /**
      * Master form number
-     *
-     * @var int
      */
-    private $number = 0;
+    private int $number = 0;
 
     /**
      * The MasterForm class deals internally with a number to handle multiple forms on one page.
@@ -755,13 +720,13 @@ class MasterForm
 
                                             case 'mediumtext':
                                                 if (!$maxchar) {
-                                                    $maxchar = 16777215;
+                                                    $maxchar = 16_777_215;
                                                 }
                                                 // No break statement here on purpose
 
                                             case 'longtext':
                                                 if (!$maxchar) {
-                                                    $maxchar = 4294967295;
+                                                    $maxchar = 4_294_967_295;
                                                 }
                                                 if ($field['selections'] == self::HTML_ALLOWED or $field['selections'] == self::LSCODE_ALLOWED) {
                                                     $dsp->AddTextAreaPlusRow($field['name'], $field['caption'], $_POST[$field['name']], $this->error[$field['name']], '', '', $field['optional'], $maxchar);

--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -39,15 +39,9 @@ class MasterForm
 
     public const OUTPUT_PROC = 2;
 
-    /**
-     * @var array
-     */
-    private $FormFields = [];
+    private array $FormFields = [];
 
-    /**
-     * @var array
-     */
-    private $Groups = [];
+    private array $Groups = [];
 
     private array $SQLFields = [];
 
@@ -55,10 +49,7 @@ class MasterForm
 
     private array $DependOn = [];
 
-    /**
-     * @var array
-     */
-    private $error = [];
+    private array $error = [];
 
     /**
      * @var string
@@ -396,7 +387,7 @@ class MasterForm
             $StartURL = str_replace('&mf_step=2', '', $StartURL);
             $StartURL = preg_replace('#&mf_id=[0-9]*#si', '', $StartURL);
 
-            if (strpos($StartURL, '&' . $idname . '=' . $id) == 0) {
+            if (str_starts_with($StartURL, '&' . $idname . '=' . $id)) {
                 $StartURL .= '&' . $idname . '=' . $id;
             }
         }
@@ -581,7 +572,7 @@ class MasterForm
                                                       $this->error[$field['name']] = t('Bitte fülle dieses Pflichtfeld aus.');
 
                                                 // Check Int
-                                                } elseif (strpos($SQLFieldTypes[$field['name']], 'int') !== false && $SQLFieldTypes[$field['name']] != 'tinyint(1)' && $SQLFieldTypes[$field['name']] != "enum('0','1')" && $_POST[$field['name']] and (int)$_POST[$field['name']] == 0) {
+                                                } elseif (str_contains($SQLFieldTypes[$field['name']], 'int') && $SQLFieldTypes[$field['name']] != 'tinyint(1)' && $SQLFieldTypes[$field['name']] != "enum('0','1')" && $_POST[$field['name']] and (int)$_POST[$field['name']] == 0) {
                                                       $this->error[$field['name']] = t('Bitte gib eine Zahl ein.');
 
                                                 // Check date
@@ -597,7 +588,7 @@ class MasterForm
                                                       $this->error['captcha'] = t('Captcha falsch wiedergegeben.');
 
                                                 // No \r \n \t \0 \x0B in Non-Multiline-Fields
-                                                } elseif ($field['type'] != 'text' && $field['type'] != 'mediumtext' && $field['type'] != 'longtext' && $SQLFieldTypes[$field['name']] != 'text' && $SQLFieldTypes[$field['name']] != 'mediumtext' && $SQLFieldTypes[$field['name']] != 'longtext' && !is_array($_POST[$field['name']]) && ((strpos($_POST[$field['name']], "\r") !== false) || (strpos($_POST[$field['name']], "\n") !== false) || (strpos($_POST[$field['name']], "\t") !== false) || (strpos($_POST[$field['name']], "\0") !== false) || (strpos($_POST[$field['name']], "\x0B") !== false))) {
+                                                } elseif ($field['type'] != 'text' && $field['type'] != 'mediumtext' && $field['type'] != 'longtext' && $SQLFieldTypes[$field['name']] != 'text' && $SQLFieldTypes[$field['name']] != 'mediumtext' && $SQLFieldTypes[$field['name']] != 'longtext' && !is_array($_POST[$field['name']]) && ((str_contains($_POST[$field['name']], "\r")) || (str_contains($_POST[$field['name']], "\n")) || (str_contains($_POST[$field['name']], "\t")) || (str_contains($_POST[$field['name']], "\0")) || (str_contains($_POST[$field['name']], "\x0B")))) {
                                                       $this->error[$field['name']] = t('Dieses Feld enthält nicht erlaubte Steuerungszeichen (z.B. einen Tab, oder Zeilenumbruch)');
 
                                                 // Callbacks
@@ -878,7 +869,7 @@ class MasterForm
                                                 if (is_array($field['selections'])) {
                                                     $selections = array();
                                                     foreach ($field['selections'] as $key => $val) {
-                                                        if (substr($key, 0, 10) == '-OptGroup-') {
+                                                        if (str_starts_with($key, '-OptGroup-')) {
                                                             if ($this->OptGroupOpen) {
                                                                 $selections[] = '</optgroup>';
                                                             }
@@ -1090,9 +1081,9 @@ class MasterForm
                                         $db_query .= $val .' = '. (int)$_POST[$val] .', ';
                                     } elseif ($SQLFieldTypes[$val] == 'varbinary(16)' and $val == 'ip') {
                                         $db_query .= $val .' = INET6_ATON(\''. $_POST[$val] .'\'), ';
-                                    } elseif ($_POST[$val] == '++' and strpos($SQLFieldTypes[$val], 'int') !== false) {
+                                    } elseif ($_POST[$val] == '++' and str_contains($SQLFieldTypes[$val], 'int')) {
                                         $db_query .= "$val = $val + 1, ";
-                                    } elseif ($_POST[$val] == '--' and strpos($SQLFieldTypes[$val], 'int') !== false) {
+                                    } elseif ($_POST[$val] == '--' and str_contains($SQLFieldTypes[$val], 'int')) {
                                         $db_query .= "$val = $val - 1, ";
                                     } else {
                                         $db_query .= "$val = '{$_POST[$val]}', ";

--- a/inc/Classes/Plugin.php
+++ b/inc/Classes/Plugin.php
@@ -10,30 +10,15 @@ namespace LanSuite;
 class Plugin
 {
 
-    /**
-     * @var array
-     */
-    private $modules = [];
+    private array $modules = [];
 
-    /**
-     * @var array
-     */
-    private $captions = [];
+    private array $captions = [];
 
-    /**
-     * @var array
-     */
-    private $icons = [];
+    private array $icons = [];
 
-    /**
-     * @var int
-     */
-    private $currentIndex = 0;
+    private int $currentIndex = 0;
 
-    /**
-     * @var int
-     */
-    private $count = 0;
+    private int $count = 0;
 
     /**
      * @var string

--- a/inc/Classes/Plugin.php
+++ b/inc/Classes/Plugin.php
@@ -47,9 +47,8 @@ class Plugin
      * Get the next (or specific) element
      *
      * @param int $index
-     * @return array|bool
      */
-    public function fetch($index = -1)
+    public function fetch($index = -1): array|bool
     {
         if ($index == -1) {
             $index = (int) $this->currentIndex;

--- a/inc/Classes/Security.php
+++ b/inc/Classes/Security.php
@@ -12,7 +12,7 @@ class Security
         global $db, $cfg;
 
         // Global blacklist
-        if (strpos($cfg['ip_blacklist'], (string) $_SERVER['REMOTE_ADDR']) !== false) {
+        if (str_contains($cfg['ip_blacklist'], (string) $_SERVER['REMOTE_ADDR'])) {
             return 'Deine IP wird von LanSuite geblockt. Melde dich bitte bei den Administratoren';
         }
 

--- a/inc/Classes/Security.php
+++ b/inc/Classes/Security.php
@@ -12,7 +12,7 @@ class Security
         global $db, $cfg;
 
         // Global blacklist
-        if (strpos($cfg['ip_blacklist'], $_SERVER['REMOTE_ADDR']) !== false) {
+        if (strpos($cfg['ip_blacklist'], (string) $_SERVER['REMOTE_ADDR']) !== false) {
             return 'Deine IP wird von LanSuite geblockt. Melde dich bitte bei den Administratoren';
         }
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -388,15 +388,10 @@ class Translation
      */
     private function get_trans_filename($module)
     {
-        switch ($module) {
-            case 'System':
-            case 'DB':
-                $file = 'inc/language/' . $module . '_' . $this->transfile_name;
-                break;
-
-            default:
-                $file = 'modules/' . $module . '/mod_settings/' . $this->transfile_name;
-        }
+        $file = match ($module) {
+            'System', 'DB' => 'inc/language/' . $module . '_' . $this->transfile_name,
+            default => 'modules/' . $module . '/mod_settings/' . $this->transfile_name,
+        };
 
         return $file;
     }
@@ -455,7 +450,7 @@ class Translation
 
         // Generate module name from file
         $CurrentFile = str_replace('\\', '/', $baseDir);
-        if (strpos($CurrentFile, 'modules/') !== false) {
+        if (str_contains($CurrentFile, 'modules/')) {
             $CurrentFile = substr($CurrentFile, strpos($CurrentFile, 'modules/') + 8, strlen($CurrentFile));
             $CurrentFile = substr($CurrentFile, 0, strpos($CurrentFile, '/'));
         } else {

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -16,10 +16,8 @@ class Translation
 
     /**
      * Basename of the translation file
-     *
-     * @var string
      */
-    private $transfile_name = 'translation.xml';
+    private string $transfile_name = 'translation.xml';
 
     /**
      * @var array
@@ -49,17 +47,13 @@ class Translation
 
     /**
      * Is cache for module loaded (db)
-     *
-     * @var int
      */
-    private $cachemod_loaded_db = 0;
+    private int $cachemod_loaded_db = 0;
 
     /**
      * Is cache for module loaded (xml)
-     *
-     * @var int
      */
-    private $cachemod_loaded_xml  = 0;
+    private int $cachemod_loaded_xml  = 0;
 
     public function __construct()
     {
@@ -479,7 +473,7 @@ class Translation
 
                 preg_match_all('/([^a-zA-Z0-9]+t\\(\\\')(.*?)(\\\'\\)|\\\'\\,)/', $content, $treffer1, PREG_SET_ORDER + PREG_OFFSET_CAPTURE);
                 preg_match_all('/([^a-zA-Z0-9]+t\\(\\")(.*?)(\\"\\)|\\"\\,)/', $content, $treffer2, PREG_SET_ORDER + PREG_OFFSET_CAPTURE);
-                $treffer = array_merge($treffer1, $treffer2);
+                $treffer = [...$treffer1, ...$treffer2];
 
                 foreach ($treffer as $wert) {
                     $CurrentPos = $wert[2][1];

--- a/inc/Classes/Validator/Email.php
+++ b/inc/Classes/Validator/Email.php
@@ -139,9 +139,6 @@ class Email extends Validator
 
     /**
      * Check DNS Records for MX type.
-     *
-     * @param string $host
-     * @return bool
      */
     private function checkMX(string $host): bool
     {
@@ -150,9 +147,6 @@ class Email extends Validator
 
     /**
      * Check if one of MX, A or AAAA DNS RR exists.
-     *
-     * @param string $host
-     * @return bool
      */
     private function checkHost(string $host): bool
     {

--- a/inc/Classes/Validator/Email.php
+++ b/inc/Classes/Validator/Email.php
@@ -14,7 +14,7 @@ class Email extends Validator
      */
     public const PATTERN_LOOSE = '/^.+\@\S+\.\S+$/';
 
-    private static $emailPatterns = array(
+    private static array $emailPatterns = array(
         self::VALIDATION_MODE_LOOSE => self::PATTERN_LOOSE,
         self::VALIDATION_MODE_HTML5 => self::PATTERN_HTML5,
     );

--- a/inc/Functions/CheckValidEmail.php
+++ b/inc/Functions/CheckValidEmail.php
@@ -13,16 +13,10 @@ function CheckValidEmail($email)
 {
     global $cfg,$db;
 
-    // Check which validation mode to validate
-    // an email address is configured
-    switch ($cfg['sys_email_regex_verification']) {
-        case 'loose':
-            $emailValidator = new Email(Email::VALIDATION_MODE_LOOSE);
-            break;
-        case 'html5':
-        default:
-            $emailValidator = new Email(Email::VALIDATION_MODE_HTML5);
-    }
+    $emailValidator = match ($cfg['sys_email_regex_verification']) {
+        'loose' => new Email(Email::VALIDATION_MODE_LOOSE),
+        default => new Email(Email::VALIDATION_MODE_HTML5),
+    };
 
     // Enable dns verification features based on user configuration
     switch ($cfg['sys_email_dns_verification']) {

--- a/inc/Functions/Debug.php
+++ b/inc/Functions/Debug.php
@@ -28,7 +28,7 @@ function d()
     if ($arg_vars[1]) {
         $title = $arg_vars[0];
         $val = $arg_vars[1];
-    } elseif (is_string($arg_vars[0]) && substr($arg_vars[0], 0, 1) == '$') {
+    } elseif (is_string($arg_vars[0]) && str_starts_with($arg_vars[0], '$')) {
         $title = $arg_vars[0];
         eval('global '. $arg_vars[0] .'; $val = '. $arg_vars[0] .';');
     } else {

--- a/inc/base/define.php
+++ b/inc/base/define.php
@@ -10,3 +10,13 @@ define('VALID_LS', true);
 define('HTML_NEWLINE', '<br/>');
 define('HTML_FONT_ERROR', '<font class="error">');
 define('HTML_FONT_END', '</font>');
+
+// Authentication types
+define('LS_AUTH_TYPE_ANONYMOUS', 0);
+define('LS_AUTH_TYPE_USER', 1);
+define('LS_AUTH_TYPE_ADMIN', 2);
+define('LS_AUTH_TYPE_SUPERADMIN', 3);
+
+// Authentication logged in/out
+define('LS_AUTH_LOGIN_LOGGED_OUT', 0);
+define('LS_AUTH_LOGIN_LOGGED_IN', 1);

--- a/index.php
+++ b/index.php
@@ -22,12 +22,10 @@ if (function_exists('ini_set')) {
 
 $PHPErrors = '';
 
-// Initialize Cache. Go for APCu first, filebased otherwise. DB adaptor to be used when we implement PDO.
-if (extension_loaded('apcu')) {
-    $cache = new Symfony\Component\Cache\Adapter\ApcuAdapter('lansuite', 600);
-} else {
-    $cache = new Symfony\Component\Cache\Adapter\FilesystemAdapter('lansuite', 600);
-}
+// TODO Implement DB cache adapter, once PDO is in place
+$cache = new Symfony\Component\Cache\Adapter\FilesystemAdapter('lansuite', 600);
+
+$cache->delete('config');
 
 // Check cache for config, try to load from file otherwise
 $configCache = $cache->getItem('config');

--- a/modules/about/Functions/GetTheLinesAndChars.php
+++ b/modules/about/Functions/GetTheLinesAndChars.php
@@ -8,7 +8,7 @@ function GetTheLinesAndChars($file)
 {
     $data = [];
     $file_content = file($file);
-    $data[0] = is_array($file_content) || $file_content instanceof \Countable ? count($file_content) : 0;
+    $data[0] = is_countable($file_content) ? count($file_content) : 0;
     foreach ($file_content as $iValue) {
         $data[1] += strlen($iValue);
     }

--- a/modules/beamer/Classes/Beamer.php
+++ b/modules/beamer/Classes/Beamer.php
@@ -145,9 +145,8 @@ class Beamer
 
     /**
      * @param int $bcid
-     * @return array|bool|null
      */
-    public function getContent($bcid)
+    public function getContent($bcid): array|bool|null
     {
         global $db;
 

--- a/modules/board/delete.php
+++ b/modules/board/delete.php
@@ -13,17 +13,9 @@ if ($_GET['pid']) {
 
 // Delete board
 } else {
-    switch ($_GET['step']) {
-        default:
-            include_once('modules/board/show.php');
-            break;
-
-        case 2:
-            $md->Delete('board_forums', 'fid', $_GET['fid']);
-            break;
-
-        case 10:
-            $md->MultiDelete('board_forums', 'fid');
-            break;
-    }
+    match ($_GET['step']) {
+        2 => $md->Delete('board_forums', 'fid', $_GET['fid']),
+        10 => $md->MultiDelete('board_forums', 'fid'),
+        default => include_once('modules/board/show.php'),
+    };
 }

--- a/modules/boxes/Classes/Boxes.php
+++ b/modules/boxes/Classes/Boxes.php
@@ -25,16 +25,10 @@ class Boxes
     {
         global $func;
 
-        // Set Item-Class
-        switch ($requirement) {
-            default:
-                $link_class = 'menu';
-                break;
-            case 2:
-            case 3:
-                $link_class = 'admin';
-                break;
-        }
+        $link_class = match ($requirement) {
+            2, 3 => 'admin',
+            default => 'menu',
+        };
 
         $class = '';
         switch ($level) {

--- a/modules/boxes/Classes/Menu.php
+++ b/modules/boxes/Classes/Menu.php
@@ -19,10 +19,7 @@ class Menu
      */
     public $box;
 
-    /**
-     * @var string
-     */
-    private $title = '';
+    private string $title = '';
 
     /**
      * @param $id

--- a/modules/boxes/Classes/Menu.php
+++ b/modules/boxes/Classes/Menu.php
@@ -62,8 +62,10 @@ class Menu
 
             // Scan for ID in info2 Link
             if ($_GET['mod'] == 'info2') {
-                preg_match('/(id=)(\\d{1,4})/', $item['link'], $treffer);
-                $info2_id = $treffer[2];
+                $pregMatchResult = preg_match('/(id=)(\\d{1,4})/', $item['link'], $treffer);
+                if ($pregMatchResult) {
+                    $info2_id = $treffer[2];
+                }
             }
 
             $actionParameter = $request->query->get('action');
@@ -90,7 +92,7 @@ class Menu
     {
         global $auth, $db;
 
-        if (!$_GET['menu_group']) {
+        if (!array_key_exists('menu_group', $_GET) || !$_GET['menu_group']) {
             $_GET['menu_group'] = 0;
         }
 

--- a/modules/boxes/Functions/IsWWCLT.php
+++ b/modules/boxes/Functions/IsWWCLT.php
@@ -12,7 +12,7 @@ function IsWWCLT()
     }
 
     $row = $db->qry_first("SELECT 1 AS found FROM %prefix%tournament_tournaments WHERE wwcl_gameid > 0 AND party_id = %int%", $party->party_id);
-    if ($row['found']) {
+    if ($row) {
         return 1;
     } else {
         return 0;

--- a/modules/boxes/boxes.php
+++ b/modules/boxes/boxes.php
@@ -55,7 +55,23 @@ $BoxRes = $db->qry("
 
 while ($BoxRow = $db->fetch_array($BoxRes)) {
     if (($BoxRow['module'] == '' or $func->isModActive($BoxRow['module'])) and ($BoxRow['callback'] == '' or call_user_func($BoxRow['callback'], ''))) {
+
+        // Preset $templ, if it is not defined yet
+        if (!isset($templ)) {
+            $templ = [
+                'index' => [
+                    'control' => [
+                        'boxes_letfside' => '',
+                        'boxes_rightside' => '',
+                    ]
+                ]
+            ];
+        }
+
         if ($BoxRow['source'] == 'menu') {
+            if (!isset($MenuCallbacks)) {
+                $MenuCallbacks = [];
+            }
             if (is_array($MenuCallbacks) && count($MenuCallbacks) > 0) {
                 $MenuCallbacks = array();
                 $MenuCallbacks[] = 'ShowSignon';

--- a/modules/clanmgr/Classes/Clan.php
+++ b/modules/clanmgr/Classes/Clan.php
@@ -12,9 +12,8 @@ class Clan
      * @param int $userid
      * @param string $url
      * @param string $password
-     * @return bool|int|string
      */
-    public function Add($name, $userid, $url = '', $password = '')
+    public function Add($name, $userid, $url = '', $password = ''): bool|int|string
     {
         global $db;
 
@@ -22,7 +21,7 @@ class Clan
             return false;
         }
     
-        if ($url!='' && substr($url, 0, 7) != 'http://') {
+        if ($url!='' && !str_starts_with($url, 'http://')) {
             $url = 'http://'. $url;
         }
         

--- a/modules/clanmgr/Functions/LinkToClan.php
+++ b/modules/clanmgr/Functions/LinkToClan.php
@@ -9,7 +9,7 @@ function LinkToClan($clan_url)
     if ($clan_url== '') {
         return '';
     }
-    if (substr($clan_url, 0, 7) != 'http://' and substr($clan_url, 0, 8) != 'https://') {
+    if (!str_starts_with($clan_url, 'http://') and !str_starts_with($clan_url, 'https://')) {
         $clan_url = "http://".$clan_url;
     }
     return '<a href="'. $clan_url .'" target="_blank">'. $clan_url .'</a>';

--- a/modules/downloads/show.php
+++ b/modules/downloads/show.php
@@ -166,7 +166,7 @@ if (!$cfg['download_use_ftp']) {
         if ($_GET['go_dir'] == "up") {
             array_pop($_SESSION['downloads_dir']);
         } elseif ($_GET['go_dir']) {
-            if ((is_array($_SESSION['downloads_dir']) || $_SESSION['downloads_dir'] instanceof \Countable ? count($_SESSION['downloads_dir']) : 0) > "0") {
+            if ((is_countable($_SESSION['downloads_dir']) ? count($_SESSION['downloads_dir']) : 0) > "0") {
                 foreach ($_SESSION['downloads_dir'] as $dir_entry) {
                     $set_dir .= "/" . $dir_entry;
                 }
@@ -181,7 +181,7 @@ if (!$cfg['download_use_ftp']) {
             unset($join_dir);
         }
 
-        if ((is_array($_SESSION['downloads_dir']) || $_SESSION['downloads_dir'] instanceof \Countable ? count($_SESSION['downloads_dir']) : 0) > "0") {
+        if ((is_countable($_SESSION['downloads_dir']) ? count($_SESSION['downloads_dir']) : 0) > "0") {
             foreach ($_SESSION['downloads_dir'] as $dir_entry) {
                 $set_dir .= "/" . $dir_entry;
             }
@@ -267,7 +267,7 @@ if (!$cfg['download_use_ftp']) {
         }
 
         $dsp->NewContent(t('Downloads'), t('Hier kannst du zum Download bereitgestellte Dateien downloaden. Ordner sind durch ein Ordner-Symbol gekennzeichnet und können per Klick auf dieses oder den Namen ge&ouml;ffnet werden. Bei &ouml;ffnen eines Unterverzeichnisses wird das aktuelle Verzeichnis am oberen Rand angezeigt. Ebenfalls angezeigt wird ein Symbol mit dem du zum nächst höhergelegenen Verzeichnis gelangst'));
-        if ((is_array($_SESSION['downloads_dir']) || $_SESSION['downloads_dir'] instanceof \Countable ? count($_SESSION['downloads_dir']) : 0) > "0") {
+        if ((is_countable($_SESSION['downloads_dir']) ? count($_SESSION['downloads_dir']) : 0) > "0") {
             $dsp->AddSingleRow('<a href="index.php?mod=downloads&action=show&go_dir=up"><img src="design/'. $auth['design'] .'/images/downloads_goup.gif" border="0"></a> '. $dir .'/');
         }
         $dsp->AddTableRow($table);

--- a/modules/downloads/stats.php
+++ b/modules/downloads/stats.php
@@ -77,20 +77,12 @@ if (!$_GET['file']) {
         ORDER BY DATE_FORMAT(time, %string%)", $group_by, $_GET['file'], $where, $_GET['timeframe'], $group_by, $group_by);
 
     while ($row = $db->fetch_array($res)) {
-        switch ($_GET['time']) {
-            default:
-                $out = $func->unixstamp2date($row['display_time'], 'year');
-                break;
-            case 'y':
-                $out = $func->unixstamp2date($row['display_time'], 'month');
-                break;
-            case 'm':
-                $out = $func->unixstamp2date($row['display_time'], 'daydate');
-                break;
-            case 'd':
-                $out = $func->unixstamp2date($row['display_time'], 'daydatetime');
-                break;
-        }
+        $out = match ($_GET['time']) {
+            'y' => $func->unixstamp2date($row['display_time'], 'month'),
+            'm' => $func->unixstamp2date($row['display_time'], 'daydate'),
+            'd' => $func->unixstamp2date($row['display_time'], 'daydatetime'),
+            default => $func->unixstamp2date($row['display_time'], 'year'),
+        };
         if ($link) {
             $out = '<a href="index.php?mod=downloads&action=stats&file='.$_GET['file'].'&time='. $link .'&timeframe='. $row['group_by_time'] .'">'. $out .'</a>';
         }

--- a/modules/faq/change_cat.php
+++ b/modules/faq/change_cat.php
@@ -43,7 +43,7 @@ switch ($_GET["step"]) {
             $catcaption = $get_data["name"];
         
             if ($catcaption != "") {
-                $change_it = $db->qry("UPDATE %prefix%faq_cat SET name = %string% WHERE catid = %int%", $_POST[cat_caption], $_GET["catid"]);
+                $change_it = $db->qry("UPDATE %prefix%faq_cat SET name = %string% WHERE catid = %int%", $_POST['cat_caption'], $_GET["catid"]);
                 
                 if ($change_it == true) {
                     $_SESSION["change_blocker_faq_cat"] = 1;

--- a/modules/foodcenter/Classes/Basket.php
+++ b/modules/foodcenter/Classes/Basket.php
@@ -14,10 +14,7 @@ class Basket
      */
     private $product;
 
-    /**
-     * @var Accounting
-     */
-    private $account;
+    private \LanSuite\Module\Foodcenter\Accounting $account;
 
     /**
      * @var int

--- a/modules/foodcenter/Classes/FoodcenterPrint.php
+++ b/modules/foodcenter/Classes/FoodcenterPrint.php
@@ -4,30 +4,15 @@ namespace LanSuite\Module\Foodcenter;
 
 class FoodcenterPrint
 {
-    /**
-     * @var string
-     */
-    private $output = '';
+    private string $output = '';
 
-    /**
-     * @var string
-     */
-    private $path = 'ext_inc/foodcenter_templates/';
+    private string $path = 'ext_inc/foodcenter_templates/';
 
-    /**
-     * @var string
-     */
-    private $row_file = '';
+    private string $row_file = '';
 
-    /**
-     * @var string
-     */
-    private $row_temp = '';
+    private string $row_temp = '';
 
-    /**
-     * @var array
-     */
-    private $config = [];
+    private array $config = [];
 
     public function __construct()
     {

--- a/modules/foodcenter/Classes/FoodcenterPrint.php
+++ b/modules/foodcenter/Classes/FoodcenterPrint.php
@@ -133,9 +133,8 @@ class FoodcenterPrint
 
     /**
      * @param int $userid
-     * @return array|bool|null|string
      */
-    private function GetUserdata($userid)
+    private function GetUserdata($userid): array|bool|null|string
     {
         global $db, $party;
 
@@ -152,9 +151,8 @@ class FoodcenterPrint
 
     /**
      * @param int $time
-     * @return false|string
      */
-    private function GetDate($time)
+    private function GetDate($time): false|string
     {
         global $func;
 
@@ -206,17 +204,11 @@ class FoodcenterPrint
 
             $d = 0;
             foreach ($config['search_fields'] as $col) {
-                switch ($config['search_type'][$d]) {
-                    case "exact":
-                        $search .= "($col = '$key') OR ";
-                        break;
-                    case "1337":
-                        $search .= "($col REGEXP '$key_1337') OR ";
-                        break;
-                    default:
-                        $search .= "($col LIKE '%$key%') OR ";
-                        break;
-                }
+                match ($config['search_type'][$d]) {
+                    "exact" => $search .= "($col = '$key') OR ",
+                    "1337" => $search .= "($col REGEXP '$key_1337') OR ",
+                    default => $search .= "($col LIKE '%$key%') OR ",
+                };
                 $d ++;
             }
             $search = substr($search, 0, strlen($search) - 4);

--- a/modules/foodcenter/Classes/Product.php
+++ b/modules/foodcenter/Classes/Product.php
@@ -27,17 +27,13 @@ class Product
 
     /**
      * Category
-     *
-     * @var Category
      */
-    private $cat;
+    private ?\LanSuite\Module\Foodcenter\Category $cat = null;
 
     /**
      * Supplier
-     *
-     * @var Supplier
      */
-    private $supp;
+    private ?\LanSuite\Module\Foodcenter\Supplier $supp = null;
 
     /**
      * Supplier information
@@ -55,10 +51,8 @@ class Product
 
     /**
      * Management of material
-     *
-     * @var int
      */
-    private $mat;
+    private ?int $mat = null;
 
     /**
      * Product type
@@ -91,7 +85,7 @@ class Product
      *
      * @var ProductOption[]
      */
-    private $option = [];
+    private array $option = [];
 
     /**
      * Error container
@@ -102,10 +96,8 @@ class Product
 
     /**
      * Error status
-     *
-     * @var boolean
      */
-    private $noerror = true;
+    private bool $noerror = true;
 
     /**
      * product constructor.

--- a/modules/foodcenter/Classes/Product.php
+++ b/modules/foodcenter/Classes/Product.php
@@ -89,10 +89,8 @@ class Product
 
     /**
      * Error container
-     *
-     * @var array
      */
-    private $error_food = [];
+    private array $error_food = [];
 
     /**
      * Error status

--- a/modules/foodcenter/Classes/ProductList.php
+++ b/modules/foodcenter/Classes/ProductList.php
@@ -77,10 +77,9 @@ class ProductList
      * Returns true once the product is added, false otherwise
      *
      * @param int       $id
-     * @param array|int $opt
      * @return bool
      */
-    public function add_product($id, $opt)
+    public function add_product($id, array|int $opt)
     {
         $key_array = [];
         // Product already in the list?
@@ -179,11 +178,10 @@ class ProductList
      * Write new basket once something changed
      *
      * @param int       $listid
-     * @param array|int $opt
      * @param int $value
      * @return mixed
      */
-    public function chanche_ordered($listid, $opt, $value)
+    public function chanche_ordered($listid, array|int $opt, $value)
     {
         if (!is_null($opt)) {
             return $this->product[$listid]->order_option($opt, $value);

--- a/modules/foodcenter/Classes/ProductList.php
+++ b/modules/foodcenter/Classes/ProductList.php
@@ -11,17 +11,15 @@ class ProductList
 {
     /**
      * List of product numbers
-     *
-     * @var array
      */
-    private $product_list = [];
+    private array $product_list = [];
 
     /**
      * List of products
      *
      * @var Product[]
      */
-    private $product = [];
+    private array $product = [];
 
     /**
      * Load all products from a category

--- a/modules/foodcenter/Classes/ProductList.php
+++ b/modules/foodcenter/Classes/ProductList.php
@@ -108,7 +108,11 @@ class ProductList
 
                 // If it is not the same product, get the last key
                 end($this->product);
-                $key_array = each($this->product);
+                $key_array[1] = current($this->product);
+                $key_array['value'] = current($this->product);
+                $key_array[0] = key($this->product);
+                $key_array['key'] = key($this->product);
+                next($this->product);
                 if (count($this->product) == 0) {
                     $key = 0;
                 } else {
@@ -142,7 +146,11 @@ class ProductList
             $ret = true;
 
             end($this->product);
-            $key_array = each($this->product);
+            $key_array[1] = current($this->product);
+            $key_array['value'] = current($this->product);
+            $key_array[0] = key($this->product);
+            $key_array['key'] = key($this->product);
+            next($this->product);
             if (count($this->product) == 0) {
                 $key = 0;
             } else {

--- a/modules/foodcenter/Classes/ProductList.php
+++ b/modules/foodcenter/Classes/ProductList.php
@@ -84,6 +84,7 @@ class ProductList
      */
     public function add_product($id, $opt)
     {
+        $key_array = [];
         // Product already in the list?
         if (in_array($id, $this->product_list)) {
             if (is_array($opt)) {

--- a/modules/foodcenter/Classes/Supplier.php
+++ b/modules/foodcenter/Classes/Supplier.php
@@ -32,10 +32,8 @@ class Supplier
 
     /**
      * Error container
-     *
-     * @var array
      */
-    private $error = [];
+    private array $error = [];
 
     /**
      * supp constructor.

--- a/modules/foodcenter/Classes/Supplier.php
+++ b/modules/foodcenter/Classes/Supplier.php
@@ -53,9 +53,8 @@ class Supplier
      *
      * @param int       $select_id
      * @param boolean   $new
-     * @return array|bool
      */
-    private function get_supp_array($select_id, $new = null)
+    private function get_supp_array($select_id, $new = null): array|bool
     {
         global $db;
 

--- a/modules/foodcenter/findproduct.php
+++ b/modules/foodcenter/findproduct.php
@@ -21,30 +21,13 @@ $ms2->AddTextSearchField('Produktsuche', array('p.caption' => 'like', 'p.p_desc'
 $ms2->AddSelect('p.cat_id');
 $ms2->AddResultField('Titel', 'p.id', 'GetTitelName');
 
-switch ($_POST['search_dd_input'][0]) {
-    case 1:
-        $ms2->NoItemsText = t('Keine aktuellen Bestellungen vorhanden.');
-        break;
-
-    case 2:
-        $ms2->NoItemsText = t('Es müssen keine Produkte bestellt werden.');
-        break;
-
-    case 3:
-        $ms2->NoItemsText = t('Es wird auf keine Lieferung gewartet.');
-        break;
-
-    case 4:
-        $ms2->NoItemsText = t('Derzeit gibt es keine fertiggestellten Gerichte aus der Küche.');
-        break;
-        
-    case 5:
-        $ms2->NoItemsText = t('Du hast alle Produkte abgeholt.');
-        break;
-        
-    default:
-        $ms2->NoItemsText = t('Keine aktuellen Bestellungen vorhanden.');
-        break;
-}
+$ms2->NoItemsText = match ($_POST['search_dd_input'][0]) {
+    1 => t('Keine aktuellen Bestellungen vorhanden.'),
+    2 => t('Es müssen keine Produkte bestellt werden.'),
+    3 => t('Es wird auf keine Lieferung gewartet.'),
+    4 => t('Derzeit gibt es keine fertiggestellten Gerichte aus der Küche.'),
+    5 => t('Du hast alle Produkte abgeholt.'),
+    default => t('Keine aktuellen Bestellungen vorhanden.'),
+};
 
 $ms2->PrintSearch('index.php?mod=foodcenter&action=findproduct', 'p.id');

--- a/modules/foodcenter/ordered.php
+++ b/modules/foodcenter/ordered.php
@@ -38,30 +38,13 @@ $ms2->AddResultField('Letzte änderung', 'a.lastchange', 'MS2GetDate');
 $ms2->AddResultField('Geliefert', 'a.supplytime', 'MS2GetDate');
 $ms2->AddResultField('Status', 's.statusname');
 
-switch ($_POST['search_dd_input'][0]) {
-    case 1:
-        $ms2->NoItemsText = t('Keine aktuellen Bestellungen vorhanden.');
-        break;
-
-    case 2:
-        $ms2->NoItemsText = t('Es müssen keine Produkte bestellt werden.');
-        break;
-
-    case 3:
-        $ms2->NoItemsText = t('Es wird auf keine Lieferung gewartet.');
-        break;
-
-    case 4:
-        $ms2->NoItemsText = t('Derzeit gibt es keine fertiggestellten Gerichte aus der Küche.');
-        break;
-        
-    case 5:
-        $ms2->NoItemsText = t('Du hast alle Produkte abgeholt.');
-        break;
-        
-    default:
-        $ms2->NoItemsText = t('Keine aktuellen Bestellungen vorhanden.');
-        break;
-}
+$ms2->NoItemsText = match ($_POST['search_dd_input'][0]) {
+    1 => t('Keine aktuellen Bestellungen vorhanden.'),
+    2 => t('Es müssen keine Produkte bestellt werden.'),
+    3 => t('Es wird auf keine Lieferung gewartet.'),
+    4 => t('Derzeit gibt es keine fertiggestellten Gerichte aus der Küche.'),
+    5 => t('Du hast alle Produkte abgeholt.'),
+    default => t('Keine aktuellen Bestellungen vorhanden.'),
+};
 
 $ms2->PrintSearch('index.php?mod=foodcenter&action=ordered', 'a.id');

--- a/modules/foodcenter/statchange.php
+++ b/modules/foodcenter/statchange.php
@@ -152,7 +152,7 @@ switch ($_GET['step']) {
         $handle = opendir("ext_inc/foodcenter_templates");
         while ($file = readdir($handle)) {
             if (($file != ".") and ($file != "..") and ($file != ".svn") and (!is_dir($file))) {
-                if (((substr($file, -3, 3) == "htm") && (substr($file, -7, 7) != "row.htm")) || ((substr($file, -4, 4) == "html") && (substr($file, -8, 8) != "row.html"))) {
+                if (((str_ends_with($file, "htm")) && (!str_ends_with($file, "row.htm"))) || ((str_ends_with($file, "html")) && (!str_ends_with($file, "row.html")))) {
                     $file_array[] = "<option value=\"$file\">$file</option>";
                 }
             }

--- a/modules/games/hangman.php
+++ b/modules/games/hangman.php
@@ -58,7 +58,7 @@ if (!$_GET["sieg"]) {
 
             $pos = 0;
             $found = 0;
-            while (!(strpos($_SESSION["losungswort"], $_POST["buchstabe"], $pos) === false)) {
+            while (!(!str_contains($_SESSION["losungswort"], $_POST["buchstabe"]))) {
                 $pos = strpos($_SESSION["losungswort"], $_POST["buchstabe"], $pos) + 1;
                 $_GET["ratewort"] = substr_replace($_GET["ratewort"], $_POST["buchstabe"], $pos - 1, 1);
                 $found = 1;

--- a/modules/guestlist/Classes/GuestList.php
+++ b/modules/guestlist/Classes/GuestList.php
@@ -8,15 +8,9 @@ use LanSuite\Module\Seating\Seat2;
 class GuestList
 {
 
-    /**
-     * @var Seat2
-     */
-    private $seating;
+    private \LanSuite\Module\Seating\Seat2 $seating;
 
-    /**
-     * @var \LanSuite\Module\UsrMgr\UserManager
-     */
-    private $userManager;
+    private \LanSuite\Module\UsrMgr\UserManager $userManager;
 
     public function __construct(Seat2 $seating, \LanSuite\Module\UsrMgr\UserManager $userManager)
     {

--- a/modules/guestlist/Functions/ClanURLLink.php
+++ b/modules/guestlist/Functions/ClanURLLink.php
@@ -13,7 +13,7 @@ function ClanURLLink($clan_name)
     } elseif ($func->isModActive('clanmgr')) {
         return '<a href="index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $line['clanid'] .'">'. $clan_name .'</a>';
     } elseif ($clan_name != '' and $line['clanurl'] != '' and $line['clanurl'] != 'http://') {
-        if (substr($line['clanurl'], 0, 7) != 'http://') {
+        if (!str_starts_with($line['clanurl'], 'http://')) {
             $line['clanurl'] = 'http://'. $line['clanurl'];
         }
         return '<a href="'. $line['clanurl'] .'" target="_blank">'. $clan_name .'</a>';

--- a/modules/guestlist/Functions/GetTimeDiff.php
+++ b/modules/guestlist/Functions/GetTimeDiff.php
@@ -2,9 +2,8 @@
 
 /**
  * @param int $last
- * @return false|string
  */
-function getTimeDiff($last)
+function getTimeDiff($last): false|string
 {
     return date("i:s", time()-$last);
 }

--- a/modules/guestlist/usermap.php
+++ b/modules/guestlist/usermap.php
@@ -25,35 +25,17 @@ if ($cfg['guestlist_guestmap'] == 2) {
         $aggregated_text='';
         while ($row = $db->fetch_array($res)) {
             ($row['country'])? $country = $row['country'] : $country = $cfg['sys_country'];
-            switch ($country) {
-                case 'de':
-                    $GCountry = 'Germany';
-                    break;
-                case 'at':
-                    $GCountry = 'Austria';
-                    break;
-                case 'ch':
-                    $GCountry = 'Swiss';
-                    break;
-                case 'en':
-                    $GCountry = 'England';
-                    break;
-                case 'nl':
-                    $GCountry = 'Netherlands';
-                    break;
-                case 'es':
-                    $GCountry = 'Spain';
-                    break;
-                case 'it':
-                    $GCountry = 'Italy';
-                    break;
-                case 'fr':
-                    $GCountry = 'France';
-                    break;
-                default:
-                    $GCountry = 'Germany';
-                    break;
-            }
+            $GCountry = match ($country) {
+                'de' => 'Germany',
+                'at' => 'Austria',
+                'ch' => 'Swiss',
+                'en' => 'England',
+                'nl' => 'Netherlands',
+                'es' => 'Spain',
+                'it' => 'Italy',
+                'fr' => 'France',
+                default => 'Germany',
+            };
 
             // Show detailed map to admins only, otherwise stick to user settings
             if ($row['show_me_in_map'] == 1 || $auth['type'] >= 2) {

--- a/modules/hardware/edit.php
+++ b/modules/hardware/edit.php
@@ -17,7 +17,7 @@ if ($auth['type'] >= 2 or ($_GET['userid'] == $auth['userid'] and $cfg['user_sel
     $mf->AddField('Monitor', 'monitor', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddField('Betriebssystem', 'os', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddField('Computername', 'name', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
-    $mf->AddField('Sonstiges', 'sonstiges', text, '', \LanSuite\MasterForm::FIELD_OPTIONAL);
+    $mf->AddField('Sonstiges', 'sonstiges', 'text', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddFix('userid', $_GET['userid']);
     $mf->SendForm('index.php?mod=hardware&action=edit&userid='.$_GET['userid'], 'hardware', 'hardwareid', $_GET['hardwareid']);
 } else {

--- a/modules/home/show.php
+++ b/modules/home/show.php
@@ -23,7 +23,8 @@ switch ($home_page) {
             if ($caption == 'install') {
                 $caption = 'comments';
             }
-            if ($cfg['home_item_cnt_'.$caption]
+            $cfgArrayKey = 'home_item_cnt_' . $caption;
+            if ((array_key_exists($cfgArrayKey, $cfg) && $cfg[$cfgArrayKey])
                 || ($caption == 'party' && $party->count > 0)
                 || ($caption == 'troubleticket' && $auth['type'] >= 2)
                 || ($caption == 'rent' && $auth['type'] >= 2)

--- a/modules/install/Classes/Export.php
+++ b/modules/install/Classes/Export.php
@@ -6,25 +6,16 @@ use LanSuite\Module\Seating\Seat2;
 
 class Export
 {
-    /**
-     * @var string
-     */
-    private $output;
+    private ?string $output = null;
 
-    /**
-     * @var string
-     */
-    private $filename;
+    private ?string $filename = null;
 
     /**
      * @var string
      */
     public $lansuite;
 
-    /**
-     * @var \LanSuite\XML
-     */
-    private $xml;
+    private \LanSuite\XML $xml;
 
     public function __construct(\LanSuite\XML $xml)
     {

--- a/modules/install/Classes/Export.php
+++ b/modules/install/Classes/Export.php
@@ -507,7 +507,7 @@ class Export
         header("Content-Disposition: attachment; filename=\"$filename\"");
         $zip->download_file();
     
-        if ((is_array($zip->errors) || $zip->errors instanceof \Countable ? count($zip->errors) : 0) > 0) {
+        if ((is_countable($zip->errors) ? count($zip->errors) : 0) > 0) {
             return false;
         }
 

--- a/modules/install/Classes/Import.php
+++ b/modules/install/Classes/Import.php
@@ -24,10 +24,7 @@ class Import
      */
     public $installed_tables = [];
 
-    /**
-     * @var \LanSuite\XML
-     */
-    private $xml;
+    private \LanSuite\XML $xml;
 
     public function __construct(\LanSuite\XML $xml)
     {

--- a/modules/install/Classes/Import.php
+++ b/modules/install/Classes/Import.php
@@ -4,20 +4,14 @@ namespace LanSuite\Module\Install;
 
 class Import
 {
-    /**
-     * @var string
-     */
-    private $xml_content;
+    private string|bool|null $xml_content = null;
 
     /**
      * @var string
      */
     public $xml_content_lansuite;
 
-    /**
-     * @var array
-     */
-    private $table_state = [];
+    private array $table_state = [];
 
     /**
      * @var array
@@ -44,9 +38,8 @@ class Import
 
     /**
      * @param string $usr_file_name
-     * @return bool|string
      */
-    public function GetUploadFileType($usr_file_name)
+    public function GetUploadFileType($usr_file_name): bool|string
     {
         $file_type = substr($usr_file_name, strrpos($usr_file_name, ".") + 1, strlen($usr_file_name));
         return $file_type;
@@ -169,9 +162,9 @@ class Import
 
                         // Set default value to 0 or '', if NOT NULL and not autoincrement
                         if ($null == 'NOT NULL' and $extra == '') {
-                            if (substr($type, 0, 3) == 'int' or substr($type, 0, 7) == 'tinyint' or substr($type, 0, 9) == 'mediumint'
-                            or substr($type, 0, 8) == 'smallint' or substr($type, 0, 6) == 'bigint'
-                            or substr($type, 0, 7) == 'decimal' or substr($type, 0, 5) == 'float' or substr($type, 0, 6) == 'double') {
+                            if (str_starts_with($type, 'int') or str_starts_with($type, 'tinyint') or str_starts_with($type, 'mediumint')
+                            or str_starts_with($type, 'smallint') or str_starts_with($type, 'bigint')
+                            or str_starts_with($type, 'decimal') or str_starts_with($type, 'float') or str_starts_with($type, 'double')) {
                                     $default = 'default '. (int)$default_xml;
                             } elseif ($type == 'timestamp') {
                                 $default = 'default CURRENT_TIMESTAMP';
@@ -219,7 +212,7 @@ class Import
 
                                         // Handle special type changes
                                         // Changing int() to datetime
-                                        if ($type == 'datetime' and substr($db_field["Type"], 0, 3) == 'int') {
+                                        if ($type == 'datetime' and str_starts_with($db_field["Type"], 'int')) {
                                             $db->qry("ALTER TABLE %prefix%$table_name CHANGE %plain% %plain%_lstmp INT", $name, $name);
                                             $db->qry("ALTER TABLE %prefix%%plain% ADD %plain% DATETIME", $table_name, $name);
                                             $db->qry("UPDATE %prefix%%plain% SET %plain% = FROM_UNIXTIME(%plain%_lstmp)", $table_name, $name, $name);

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -810,14 +810,6 @@ class Install
         }
         $dsp->AddDoubleRow("FTP Library", $ftp_check);
         
-        // APCu-Lib
-        if (extension_loaded('apcu')) {
-            $apcu_check = $ok;
-        } else {
-            $apcu_check = $optimize . t('Auf deinem System konnte das PHP-Modul <b>APCu</b> nicht gefunden werden. Dies wird verwendet, um verschiedenste Daten für schnellen Zugriff zwischenzuspeichern. Eine Aktivierung ist bei vielen Seitenzugriffen angeraten. Als Fallback werden die Daten im Dateisystem vorgehalten');
-        }
-        $dsp->AddDoubleRow("APCu", $apcu_check);
-        
         // OpenSSL
         if (extension_loaded('openssl')) {
             $openssl_check = $ok;

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -6,10 +6,7 @@ use LanSuite\XML;
 
 class Install
 {
-    /**
-     * @var Import
-     */
-    private $import;
+    private \LanSuite\Module\Install\Import $import;
 
     public function __construct(Import $import)
     {

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -38,10 +38,8 @@ class Install
 
     /**
      * Write $config into file /inc/base/config.php
-     *
-     * @return bool|int
      */
-    public function WriteConfig()
+    public function WriteConfig(): bool|int
     {
         global $config;
 
@@ -662,7 +660,7 @@ class Install
         $currentMysqlVersion = $db->getServerInfo();
         if (!$currentMysqlVersion) {
             $mysqlVersionCheck = $not_possible . t('Konnte MySQL-Version nicht überprüfen, da keine Verbindung mit den Standarddaten (root@localhost) möglich war. <br/>Dies ist kein direkter Fehler, bedeutetet aber, dass einige Setup-Schritte per Hand durchgeführt werden müssen. <br/>Bitte Stelle sicher, dass du MySQL mindestens in Version %1 benutzt.', $minMysqlVersion);
-        } elseif (strpos($currentMysqlVersion, 'MariaDB') !== false) {
+        } elseif (str_contains($currentMysqlVersion, 'MariaDB')) {
             $currentMariaDBVersion = substr($currentMysqlVersion, strpos($currentMysqlVersion, '-')+1);
             if (version_compare($currentMariaDBVersion, $minMariaDBVersion) >= 0) {
                 $mysqlVersionCheck = $optimize . t('MariaDB Version %1 gefunden. <br/>Bitte beachte, das LanSuite primär für MySQL entwickelt wurde und es daher zu unerwarteten Problemen mit MariaDB kommen kann!', $currentMariaDBVersion);

--- a/modules/install/Functions/WriteMenuEntries.php
+++ b/modules/install/Functions/WriteMenuEntries.php
@@ -40,26 +40,14 @@ function WriteMenuEntries()
             $requirement = "";
             for ($i = 0; $i <= 5; $i++) {
                 ($i == $row["requirement"])? $selected = " selected" : $selected = "";
-                switch ($i) {
-                    default:
-                        $out = t('Jeder');
-                        break;
-                    case 1:
-                        $out = t('Nur Eingeloggte');
-                        break;
-                    case 2:
-                        $out = t('Nur Admins');
-                        break;
-                    case 3:
-                        $out = t('Nur Superadminen');
-                        break;
-                    case 4:
-                        $out = t('Keine Admins');
-                        break;
-                    case 5:
-                        $out = t('Nur Ausgeloggte');
-                        break;
-                }
+                $out = match ($i) {
+                    1 => t('Nur Eingeloggte'),
+                    2 => t('Nur Admins'),
+                    3 => t('Nur Superadminen'),
+                    4 => t('Keine Admins'),
+                    5 => t('Nur Ausgeloggte'),
+                    default => t('Jeder'),
+                };
                 $requirement .= "<option value=\"$i\"$selected>$out</option>";
             }
             $smarty->assign('requirement', $requirement);

--- a/modules/install/boxes/language.php
+++ b/modules/install/boxes/language.php
@@ -1,5 +1,5 @@
 <?php
-$cur_url = @parse_url($_SERVER['REQUEST_URI']);
+$cur_url = parse_url($_SERVER['REQUEST_URI']);
 
 // Delete old 'language=' from URL
 if (isset($_GET['language'])) {
@@ -10,6 +10,9 @@ if (isset($_GET['language'])) {
     $_SERVER['REQUEST_URI'] = substr($_SERVER['REQUEST_URI'], 0, $tmpPos) . substr($_SERVER['REQUEST_URI'], $tmpPos + strlen('language=xx') + 1) ;
 }
 
+if (!array_key_exists('query', $cur_url)) {
+    $cur_url['query'] = '';
+}
 $cur_url['query'] = preg_replace('#language=(.*)&#sUi', '', $cur_url['query']);
 $cur_url['query'] = preg_replace('#&language=(.*)$#sUi', '', $cur_url['query']);
 

--- a/modules/install/boxes/login.php
+++ b/modules/install/boxes/login.php
@@ -13,6 +13,8 @@ $smarty->assign('buttons_login', '<input type="submit" class="Button" name="logi
 // 62.67.200.4 = Proxy IP of https://sslsites.de/lansuite.orgapage.de
 if ($cfg['sys_partyurl_ssl'] && ($_SERVER['HTTPS'] != 'on' && getenv('REMOTE_ADDR') != "62.67.200.4")) {
     $smarty->assign('ssl_link', $cfg['sys_partyurl_ssl']);
+} else {
+    $smarty->assign('ssl_link', '');
 }
 
 $box->AddTemplate($smarty->fetch('modules/boxes/templates/box_login_content.htm'));

--- a/modules/install/mod_cfg.php
+++ b/modules/install/mod_cfg.php
@@ -251,20 +251,11 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
                         }
                             $res = $db->qry('SELECT pri_table, pri_key, foreign_table, foreign_key, on_delete FROM %prefix%ref WHERE (0 = 1) %plain%', $where);
                         while ($row = $db->fetch_array($res)) {
-                            switch ($row['on_delete']) {
-                                case 'ASK_SET0':
-                                case 'SET0':
-                                case 'ASK_DELETE':
-                                case 'DELETE':
-                                    $color = '#ff0000';
-                                    break;
-                                case 'DENY':
-                                    $color = '#008800';
-                                    break;
-                                default:
-                                    $color = '#000000';
-                                    break;
-                            }
+                            $color = match ($row['on_delete']) {
+                                'ASK_SET0', 'SET0', 'ASK_DELETE', 'DELETE' => '#ff0000',
+                                'DENY' => '#008800',
+                                default => '#000000',
+                            };
                             $dsp->AddDoubleRow('<font color="'. $color .'">'. $row['pri_table'] .'.'. $row['pri_key'] .'</font>', $row['foreign_table'] .'.'. $row['foreign_key']);
                         }
                         $dsp->AddSingleRow('<font color="#ff0000">'. t('Rot: Wenn rechts ein Eintrag gelöscht wird, wenden links die passenden mit gelöscht') .'</font>');
@@ -278,20 +269,11 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
                         }
                         $res = $db->qry('SELECT pri_table, pri_key, foreign_table, foreign_key, on_delete FROM %prefix%ref WHERE (0 = 1) %plain%', $where);
                         while ($row = $db->fetch_array($res)) {
-                            switch ($row['on_delete']) {
-                                case 'ASK_SET0':
-                                case 'SET0':
-                                case 'ASK_DELETE':
-                                case 'DELETE':
-                                    $color = '#ff0000';
-                                    break;
-                                case 'DENY':
-                                    $color = '#008800';
-                                    break;
-                                default:
-                                    $color = '#000000';
-                                    break;
-                            }
+                            $color = match ($row['on_delete']) {
+                                'ASK_SET0', 'SET0', 'ASK_DELETE', 'DELETE' => '#ff0000',
+                                'DENY' => '#008800',
+                                default => '#000000',
+                            };
                             $dsp->AddDoubleRow('<font color="'. $color .'">'. $row['pri_table'] .'.'. $row['pri_key'] .'</font>', $row['foreign_table'] .'.'. $row['foreign_key']);
                         }
                         $dsp->AddSingleRow('<font color="#ff0000">'. t('Rot: Wenn rechts ein Eintrag gelöscht wird, wenden links die passenden mit gelöscht') .'</font>');

--- a/modules/install/plugins/home.php
+++ b/modules/install/plugins/home.php
@@ -3,6 +3,7 @@
 $smarty->assign('caption', t('Sonstige neue Kommentare'));
 $content = "";
 
+$exclude = '';
 if (!$func->isModActive('faq')) {
     $exclude .= ' AND relatedto_item != \'faq\'';
 }

--- a/modules/mail/Classes/Mail.php
+++ b/modules/mail/Classes/Mail.php
@@ -4,10 +4,7 @@ namespace LanSuite\Module\Mail;
 
 class Mail
 {
-    /**
-     * @var string
-     */
-    private $inet_headers;
+    private ?string $inet_headers = null;
 
     /**
      * @var string

--- a/modules/mail/newmail.php
+++ b/modules/mail/newmail.php
@@ -26,7 +26,7 @@ if ($_GET['replyto']) {
     $reply_message = $row['mailID'];
     if (!$_POST['toUserID'] and $_GET['replyto']) {
         $_POST['Subject'] = 'WG: '.$row['Subject'];
-    } elseif (substr($row['Subject'], 0, 4) == 'Re: ') {
+    } elseif (str_starts_with($row['Subject'], 'Re: ')) {
         $_POST['Subject'] = $row['Subject'];
     } else {
         $_POST['Subject'] = 'Re: '.$row['Subject'];

--- a/modules/mastersearch2/Classes/MasterSearch2.php
+++ b/modules/mastersearch2/Classes/MasterSearch2.php
@@ -49,15 +49,9 @@ class MasterSearch2
 
     private array $SQLFieldTypes = [];
 
-    /**
-     * @var array
-     */
-    private $HiddenGetFields = [];
+    private array $HiddenGetFields = [];
 
-    /**
-     * @var int
-     */
-    private $ms_number = 0;
+    private int|float $ms_number = 0;
 
     private string $TargetPageField = '';
 
@@ -377,7 +371,7 @@ class MasterSearch2
                             // Negation, greater than, less than
                             $pre_eq = '';
                             $value = $func->AllowHTML($value); # Converts &lt; back to <
-                            if (substr($value, 0, 1) == '!' or substr($value, 0, 1) == '<' or substr($value, 0, 1) == '>') {
+                            if (str_starts_with($value, '!') or str_starts_with($value, '<') or str_starts_with($value, '>')) {
                                 $pre_eq = substr($value, 0, 1);
                                 $value = substr($value, 1, strlen($value) - 1);
                             }
@@ -393,7 +387,7 @@ class MasterSearch2
                         }
 
                         // If COUNT function is used in select, write this variable in the having statement, otherwise in the where statement
-                        if (strpos($current_field_list['sql_field'], 'OUNT(') == 0) {
+                        if (str_starts_with($current_field_list['sql_field'], 'OUNT(')) {
                             $this->query['where'] .= " AND ($sql_one_search_field)";
                         } else {
                             $this->query['having'] .= "($sql_one_search_field) AND ";
@@ -831,7 +825,7 @@ class MasterSearch2
                     $arr = array();
 
                     if (!$current_field['callback'] or call_user_func($current_field['callback'], $line[$select_id_field])) {
-                        if (substr($current_field['link'], 0, 11) == 'javascript:') {
+                        if (str_starts_with($current_field['link'], 'javascript:')) {
                             $arr['link'] = '#" onclick="'. $current_field['link'];
                         } else {
                             $arr['link'] = $current_field['link'];

--- a/modules/mastersearch2/Classes/MasterSearch2.php
+++ b/modules/mastersearch2/Classes/MasterSearch2.php
@@ -21,60 +21,33 @@ class MasterSearch2
         'order_by_end' => ''
     ];
 
-    /**
-     * @var array
-     */
-    private $result_field = [];
+    private array $result_field = [];
 
-    /**
-     * @var array
-     */
-    private $search_fields = [];
+    private array $search_fields = [];
 
-    /**
-     * @var array
-     */
-    private $search_dropdown = [];
+    private array $search_dropdown = [];
 
-    /**
-     * @var array
-     */
-    private $icon_field = [];
+    private array $icon_field = [];
 
-    /**
-     * @var array
-     */
-    private $multi_select_action = [];
+    private array $multi_select_action = [];
 
     /**
      * @var array
      */
     public $config = [];
 
-    /**
-     * @var array
-     */
-    private $bgcolors = [];
+    private array $bgcolors = [];
 
-    /**
-     * @var string
-     */
-    private $bgcolor_attr = '';
+    private string $bgcolor_attr = '';
 
-    /**
-     * @var bool
-     */
-    private $orderByFieldFound = false;
+    private bool $orderByFieldFound = false;
 
     /**
      * @var string
      */
     public $NoItemsText = '';
 
-    /**
-     * @var array
-     */
-    private $SQLFieldTypes = [];
+    private array $SQLFieldTypes = [];
 
     /**
      * @var array
@@ -86,15 +59,9 @@ class MasterSearch2
      */
     private $ms_number = 0;
 
-    /**
-     * @var string
-     */
-    private $TargetPageField = '';
+    private string $TargetPageField = '';
 
-    /**
-     * @var int
-     */
-    private $TargetPageCount = 0;
+    private int $TargetPageCount = 0;
 
     /**
      * @var array

--- a/modules/mastersearch2/Functions/MS2GetTime.php
+++ b/modules/mastersearch2/Functions/MS2GetTime.php
@@ -4,9 +4,8 @@
  * Used as a callback function for MasterSearch2 class.
  *
  * @param int $time
- * @return false|string
  */
-function MS2GetTime($time)
+function MS2GetTime($time): false|string
 {
     global $dsp;
 

--- a/modules/msgsys/add.php
+++ b/modules/msgsys/add.php
@@ -89,7 +89,7 @@ switch ($_GET['step']) {
 
             // Confirmations / Errors
             // Successful
-            if ((is_array($sux) || $sux instanceof \Countable ? count($sux) : 0) > "0" && (is_array($err) || $err instanceof \Countable ? count($err) : 0) == "0") {
+            if ((is_countable($sux) ? count($sux) : 0) > "0" && (is_countable($err) ? count($err) : 0) == "0") {
                 foreach ($sux as $item) {
                     if ($names1 != "") {
                         $names1 .= ", ";
@@ -100,7 +100,7 @@ switch ($_GET['step']) {
                                            <b>%NAMES1%</b> ' . HTML_NEWLINE . ' Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf sichtbar.')));
 
             // Partly Successful
-            } elseif ((is_array($sux) || $sux instanceof \Countable ? count($sux) : 0) > "0" && (is_array($err) || $err instanceof \Countable ? count($err) : 0) > "0") {
+            } elseif ((is_countable($sux) ? count($sux) : 0) > "0" && (is_countable($err) ? count($err) : 0) > "0") {
                 foreach ($sux as $item) {
                     if ($names1 != "") {
                         $names1 .= ", ";
@@ -124,7 +124,7 @@ switch ($_GET['step']) {
                                            - Du versuchst dich selbst in die Buddy-Liste hinzuzuf&uuml;gen ' . HTML_NEWLINE . '
                                            Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf sichtbar.'))), "");
                 // Not successful
-            } elseif ((is_array($sux) || $sux instanceof \Countable ? count($sux) : 0) == "0" && (is_array($err) || $err instanceof \Countable ? count($err) : 0) > "0") {
+            } elseif ((is_countable($sux) ? count($sux) : 0) == "0" && (is_countable($err) ? count($err) : 0) > "0") {
                 $func->error(t('Es konnten keine Benutzer in die Buddy-Liste hinzugef&uuml;gt werden. ' . HTML_NEWLINE . '
                       Dies kann folgende Ursachen haben: ' . HTML_NEWLINE . '
                       - Der Benutzer ist bereits in deiner Buddy-Liste ' . HTML_NEWLINE . '

--- a/modules/msgsys/query_messages.php
+++ b/modules/msgsys/query_messages.php
@@ -26,7 +26,7 @@ $query = $db->qry("
     )
   ORDER BY timestamp", $auth['userid'], $_GET['queryid'], $_GET['queryid'], $auth['userid']);
 
-$row2 = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $_GET[queryid]);
+$row2 = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $_GET['queryid']);
 
 while ($row = $db->fetch_array($query)) {
     $senderid   = $row["senderid"];

--- a/modules/msgsys/remove.php
+++ b/modules/msgsys/remove.php
@@ -1,25 +1,25 @@
 <?php
 
-if ($_GET[queryid]) {
-    switch ($_GET[step]) {
+if ($_GET['queryid']) {
+    switch ($_GET['step']) {
         default:
             $rowcheck = $db->qry("
               SELECT id
               FROM %prefix%buddys
               WHERE userid = %int%
-              AND buddyid = %int%", $auth['userid'], $_GET[queryid]);
+              AND buddyid = %int%", $auth['userid'], $_GET['queryid']);
 
             // User in buddylist ?
             if ($db->num_rows() != '0') {
                 $row = $db->qry_first("
                   SELECT username, name, firstname
                   FROM %prefix%user
-                  WHERE userid = %int%", $_GET[queryid]);
+                  WHERE userid = %int%", $_GET['queryid']);
 
                 if ($cfg['sys_internet'] == 0) {
-                    $func->question(t('Willst du den Benutzer <b>%1 (%2 %3)</b> wirklich aus deiner Buddy-Liste entfernen?', $row[name], $row[firstname], $row[username]), "index.php?mod=msgsys&action=removebuddy&queryid=$_GET[queryid]&step=2", "index.php");
+                    $func->question(t('Willst du den Benutzer <b>%1 (%2 %3)</b> wirklich aus deiner Buddy-Liste entfernen?', $row['name'], $row['firstname'], $row['username']), 'index.php?mod=msgsys&action=removebuddy&queryid=' . $_GET['queryid'] . '&step=2', "index.php");
                 } else {
-                    $func->question(t('Willst du den Benutzer <b>%1</b> wirklich aus deiner Buddy-Liste entfernen?', $row[username]), "index.php?mod=msgsys&action=removebuddy&queryid=$_GET[queryid]&step=2", "index.php");
+                    $func->question(t('Willst du den Benutzer <b>%1</b> wirklich aus deiner Buddy-Liste entfernen?', $row['username']), 'index.php?mod=msgsys&action=removebuddy&queryid=' . $_GET['queryid'] . '&step=2', "index.php");
                 }
             } else {
                 $func->error(t('Dieser Benutzer befindet sich nicht in deiner Buddy-Liste'));
@@ -31,19 +31,19 @@ if ($_GET[queryid]) {
             $row1 = $db->qry_first("
                SELECT username, name, firstname
                FROM %prefix%user
-               WHERE userid = %int%", $_GET[queryid]);
+               WHERE userid = %int%", $_GET['queryid']);
 
             $row2 = $db->qry("
                DELETE FROM %prefix%buddys
                WHERE buddyid = %int%
-               AND userid = %int%", $_GET[queryid], $auth['userid']);
+               AND userid = %int%", $_GET['queryid'], $auth['userid']);
 
             // Confirmation
             if ($row2 == true) {
                 if ($cfg['sys_internet'] == 1) {
-                    $func->confirmation(t('Der Benutzer <b>%1</b> wurde aus deiner Buddy-Liste entfernt. Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf wirksam.', $row1[username]), "");
+                    $func->confirmation(t('Der Benutzer <b>%1</b> wurde aus deiner Buddy-Liste entfernt. Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf wirksam.', $row1['username']), "");
                 } else {
-                    $func->confirmation(t('Der Benutzer <b>%1 (%2 %3)</b> wurde aus deiner Buddy-Liste entfernt. Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf wirksam.', $row1[name], $row1[firstname], $row1[username]), "");
+                    $func->confirmation(t('Der Benutzer <b>%1 (%2 %3)</b> wurde aus deiner Buddy-Liste entfernt. Die &Auml;nderung wird beim n&auml;chsten Seitenaufruf wirksam.', $row1['name'], $row1['firstname'], $row1['username']), "");
                 }
             }
             break;

--- a/modules/noc/class_noc.php
+++ b/modules/noc/class_noc.php
@@ -147,7 +147,7 @@ class noc
             }
         }
         // Array mit Ports und Adressen zusammenfügen
-        for ($i = 0; $i < (is_array($ports) || $ports instanceof \Countable ? count($ports) : 0); $i++) {
+        for ($i = 0; $i < (is_countable($ports) ? count($ports) : 0); $i++) {
             if ($data[$ports[$i]] == "") {
                 $data[$ports[$i]] = $Addresses[$i];
             } else {

--- a/modules/noc/device_add.php
+++ b/modules/noc/device_add.php
@@ -91,7 +91,7 @@ switch ($_GET["step"]) {
         $sysLocation    = $noc->getSNMPValue($_POST["device_ip"], $_POST["device_read"], ".1.3.6.1.2.1.1.6.0");
         $sysName    = $noc->getSNMPValue($_POST["device_ip"], $_POST["device_read"], ".1.3.6.1.2.1.1.5.0");
         $ports    = $noc->getSNMPwalk($_POST["device_ip"], $_POST["device_read"], ".1.3.6.1.2.1.2.2.1.1");
-        $numport = is_array($ports) || $ports instanceof \Countable ? count($ports) : 0;
+        $numport = is_countable($ports) ? count($ports) : 0;
         
         // Store the device into a SQL table
         $add_query = $db->qry("INSERT INTO %prefix%noc_devices SET
@@ -112,7 +112,7 @@ switch ($_GET["step"]) {
 
         $row = $db->fetch_array();
 
-        for ($ActualPort=0; $ActualPort < (is_array($ports) || $ports instanceof \Countable ? count($ports) : 0); $ActualPort++) {
+        for ($ActualPort=0; $ActualPort < (is_countable($ports) ? count($ports) : 0); $ActualPort++) {
             $Port[$ActualPort]["deviceid"] = $row["id"];
 
             $Port[$ActualPort]["PortNr"] =

--- a/modules/noc/statistics.php
+++ b/modules/noc/statistics.php
@@ -64,7 +64,7 @@ while ($row = $db->fetch_array()) {
 }
 
 // We need more than 10 Values to continue...
-if ((is_array($value) || $value instanceof \Countable ? count($value) : 0) < 10) {
+if ((is_countable($value) ? count($value) : 0) < 10) {
     if (!is_array($value)) {
         $msg = "Es sind keine Daten vorhanden.";
     } else {

--- a/modules/party/Classes/Party.php
+++ b/modules/party/Classes/Party.php
@@ -67,19 +67,21 @@ class Party
             $this->count = $db->num_rows($res);
             $db->free_result($res);
 
-            $_SESSION['party_info'] = array();
+            $_SESSION['party_info'] = [];
             if ($this->count > 0) {
                 $row = $db->qry_first("SELECT name, ort, plz, UNIX_TIMESTAMP(enddate) AS enddate, UNIX_TIMESTAMP(sstartdate) AS sstartdate, UNIX_TIMESTAMP(senddate) AS senddate, UNIX_TIMESTAMP(startdate) AS startdate, max_guest FROM %prefix%partys WHERE party_id=%int%", $this->party_id);
                 $this->data = $row;
 
-                $_SESSION['party_info']['name']            = $row['name'];
-                $_SESSION['party_info']['partyort']        = $row['ort'];
-                $_SESSION['party_info']['partyplz']        = $row['plz'];
-                $_SESSION['party_info']['partybegin']    = $row['startdate'];
-                $_SESSION['party_info']['partyend']    = $row['enddate'];
-                $_SESSION['party_info']['s_startdate']    = $row['sstartdate'];
-                $_SESSION['party_info']['s_enddate']    = $row['senddate'];
-                $_SESSION['party_info']['max_guest']    = $row['max_guest'];
+                $_SESSION['party_info'] = [
+                    'name' => $row['name'],
+                    'partyort' => $row['ort'],
+                    'partyplz' => $row['plz'],
+                    'partybegin' => $row['startdate'],
+                    'partyend' => $row['enddate'],
+                    's_startdate' => $row['sstartdate'],
+                    's_enddate' => $row['senddate'],
+                    'max_guest' => $row['max_guest'],
+                ];
             }
         }
     }

--- a/modules/party/Functions/CheckEndDate.php
+++ b/modules/party/Functions/CheckEndDate.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $enddate
- * @return bool|string
  */
-function CheckEndDate($enddate)
+function CheckEndDate($enddate): bool|string
 {
     global $func;
 

--- a/modules/party/Functions/CheckSignonEndDate.php
+++ b/modules/party/Functions/CheckSignonEndDate.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $senddate
- * @return bool|string
  */
-function CheckSignonEndDate($senddate)
+function CheckSignonEndDate($senddate): bool|string
 {
     global $func;
     if ($func->str2time($senddate) < $func->str2time($_POST['sstartdate'])) {

--- a/modules/party/Functions/CheckSignonStartDate.php
+++ b/modules/party/Functions/CheckSignonStartDate.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $sstartdate
- * @return bool|string
  */
-function CheckSignonStartDate($sstartdate)
+function CheckSignonStartDate($sstartdate): bool|string
 {
     global $func;
 

--- a/modules/party/boxes/signonstatus.php
+++ b/modules/party/boxes/signonstatus.php
@@ -3,6 +3,8 @@
  * Generate Signonstatus. Show Counter and Bar.
  */
 
+// TODO Even if no party is planned, this box is shown
+
 // Number with or without orga team
 if ($cfg["guestlist_showorga"] == 0) {
     $querytype = "type = 1";
@@ -23,7 +25,7 @@ $get_cur = $db->qry_first('SELECT COUNT(userid) as n FROM %prefix%user AS user L
 $paid = $get_cur["n"];
 
 // Max. attenteed
-$max = $_SESSION['party_info']['max_guest'];
+$max = $_SESSION['party_info']['max_guest'] ?? 0;
 
 if ($paid > $cur) {
     $paid = $cur;
@@ -60,6 +62,7 @@ $pixelcuruser = $curuser - $gesamtpaid;
 $pixelpaid = $gesamtpaid;
 
 // Create bar
+$bar = '';
 if ($pixelpaid > 0) {
     $bar = '<ul class="BarOccupied infolink" style="width:'. $pixelpaid .'px;">&nbsp;<span class="infobox">'. t('Angemeldet und Bezahlt') .': '. $paid .'</span></ul>';
 }
@@ -84,12 +87,15 @@ if ($cfg['sys_internet']) {
         }
         $box->ItemRow('data', '<form action=""><select name="set_party_id" class="form" >'. $options .'</select><br /><input type="submit" class="Button" value="Party wechseln" /></form>');
     } else {
-        $box->ItemRow("data", '<b>'. $_SESSION['party_info']['name'] .'</b>');
+        $partyName = $_SESSION['party_info']['name'] ?? '';
+        $box->ItemRow("data", '<b>'. $partyName .'</b>');
     }
     $db->free_result($res);
   
     date_default_timezone_set($cfg['sys_timezone']);
-    $box->EngangedRow(date("d.m.y", $_SESSION['party_info']['partybegin']) .' - '. date("d.m.y", $_SESSION['party_info']['partyend']));
+    $partyBegin = $_SESSION['party_info']['partybegin'] ?? time();
+    $partyEnd = $_SESSION['party_info']['partyend'] ?? time();
+    $box->EngangedRow(date("d.m.y", $partyBegin) .' - '. date("d.m.y", $partyEnd));
 }
 
 $box->EngangedRow($bar);
@@ -126,7 +132,8 @@ if ($cfg['sys_internet']) {
     $box->EmptyRow();
     $box->ItemRow("data", '<b>'. t('Counter') .'</b>');
   
-    if ($_SESSION['party_info']['partyend'] < time()) {
+    $partyEnd = $_SESSION['party_info']['partyend'] ?? 0;
+    if ($partyEnd < time()) {
         $box->EngangedRow(t('Diese Party ist bereits vorüber'));
     } else {
         $count = ceil(($_SESSION['party_info']['partybegin'] - time()) / 60);

--- a/modules/party/plugins/home.php
+++ b/modules/party/plugins/home.php
@@ -43,6 +43,6 @@ if ($party->count > 0) {
         $content .= t('Gäste bezahlt / eingecheckt / ausgecheckt') .': '. $user_paid['n'] .' / '. $user_checkin['n'] .' / '. $user_checkout['n'] . HTML_NEWLINE;
 
         $visits = $db->qry_first("SELECT SUM(visits) AS visits, SUM(hits) AS hits FROM %prefix%stats_usage");
-        $content .= t('Besucher gesamt / Gerade eingeloggt') .": ". $visits['visits'] .' / '. (is_array($authentication->online_users) || $authentication->online_users instanceof \Countable ? count($authentication->online_users) : 0) . HTML_NEWLINE;
+        $content .= t('Besucher gesamt / Gerade eingeloggt') .": ". $visits['visits'] .' / '. (is_countable($authentication->online_users) ? count($authentication->online_users) : 0) . HTML_NEWLINE;
     }
 }

--- a/modules/party/price_del.php
+++ b/modules/party/price_del.php
@@ -1,6 +1,6 @@
 <?php
 
-foreach ($_POST[action] as $key => $val) {
+foreach ($_POST['action'] as $key => $val) {
     $db->qry("DELETE FROM %prefix%party_prices WHERE price_id = %string%", $key);
 }
 $func->confirmation('Erfolgreich gelöscht', 'index.php?mod=party');

--- a/modules/partylist/Functions/AddSignonStatus.php
+++ b/modules/partylist/Functions/AddSignonStatus.php
@@ -12,7 +12,7 @@ function AddSignonStatus($lsurl, $show_history = 0)
     if (substr($lsurl, strlen($lsurl) - 1, 1) != '/') {
         $lsurl .= '/';
     }
-    if (substr($lsurl, 0, 7) != 'http://' && substr($lsurl, 0, 8) != 'https://') {
+    if (!str_starts_with($lsurl, 'http://') && !str_starts_with($lsurl, 'https://')) {
         $lsurl = 'http://'. $lsurl;
     }
     $lsurl .= 'ext_inc/party_infos/infos.xml';
@@ -20,7 +20,7 @@ function AddSignonStatus($lsurl, $show_history = 0)
 
     if (!$content) {
         $content_error = '';
-        if (!extension_loaded('openssl') && strpos($lsurl, 'https://')!==false) {
+        if (!extension_loaded('openssl') && str_contains($lsurl, 'https://')) {
             $content_error .= HTML_NEWLINE.t('Konfigurationsproblem: OpenSSL-Modul nicht geladen');
         }
         if (!ini_get('allow_url_fopen')) {

--- a/modules/partylist/Functions/GetSite.php
+++ b/modules/partylist/Functions/GetSite.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $url
- * @return bool|string
  */
-function GetSite($url)
+function GetSite($url): bool|string
 {
     return @file_get_contents($url, false, stream_context_create(array('http' => array('timeout' => 10))));
 }

--- a/modules/partylist/show.php
+++ b/modules/partylist/show.php
@@ -8,7 +8,7 @@ switch ($_GET['step']) {
         if (substr($row['ls_url'], strlen($row['ls_url']) - 1, 1) != '/') {
             $row['ls_url'] .= '/';
         }
-        if (substr($row['ls_url'], 0, 7) != 'http://' && substr($row['ls_url'], 0, 8) != 'https://') {
+        if (!str_starts_with($row['ls_url'], 'http://') && !str_starts_with($row['ls_url'], 'https://')) {
             $row['ls_url'] = 'http://'. $row['ls_url'];
         }
         header('Location: '. $row['ls_url'] . 'index.php?mod=signon');
@@ -62,7 +62,7 @@ if (!$_GET['partyid']) {
         p.partyid = %int%", $_GET['partyid']);
     $framework->AddToPageTitle($row["name"]);
 
-    if (substr($row['url'], 0, 7) != 'http://' && substr($row['url'], 0, 8) != 'https://') {
+    if (!str_starts_with($row['url'], 'http://') && !str_starts_with($row['url'], 'https://')) {
         $row['url'] = 'http://'. $row['url'];
     }
 

--- a/modules/paypal/Classes/PayPal.php
+++ b/modules/paypal/Classes/PayPal.php
@@ -14,10 +14,7 @@ class PayPal
 
     private array $config = [];
 
-    /**
-     * @var array
-     */
-    private $items = [];
+    private array $items = [];
 
     private ?\PayPal\Api\Payment $payment = null;
 
@@ -47,7 +44,6 @@ class PayPal
     }
 
     /**
-     * @param PayPalItem $item
      * @return void
      */
     public function addItem(PayPalItem $item)
@@ -76,10 +72,7 @@ class PayPal
         return $items;
     }
 
-    /**
-     * @return float|int
-     */
-    public function calcItemsTotal()
+    public function calcItemsTotal(): float|int
     {
         $total = 0;
         foreach ($this->items as $item) {
@@ -169,7 +162,7 @@ class PayPal
 
                 $approval_link = $this->payment->getApprovalLink();
                 return $approval_link;
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $func->error(t('Fehler bei der Übermittlung an PayPal'));
             }
         } else {

--- a/modules/paypal/Classes/PayPal.php
+++ b/modules/paypal/Classes/PayPal.php
@@ -10,30 +10,18 @@ use \PayPal\Api\Payer;
 class PayPal
 {
 
-    /**
-     * @var OAuthTokenCredential
-     */
-    private $authTokenCredential;
+    private \PayPal\Auth\OAuthTokenCredential $authTokenCredential;
 
-    /**
-     * @var array
-     */
-    private $config = [];
+    private array $config = [];
 
     /**
      * @var array
      */
     private $items = [];
 
-    /**
-     * @var Payment
-     */
-    private $payment;
+    private ?\PayPal\Api\Payment $payment = null;
 
-    /**
-     * @var ApiContext
-     */
-    private $apiContext;
+    private \PayPal\Rest\ApiContext $apiContext;
     
     public function __construct()
     {

--- a/modules/paypal/Functions/GetPriceDetails.php
+++ b/modules/paypal/Functions/GetPriceDetails.php
@@ -2,9 +2,8 @@
 
 /**
  * @param int $priceID
- * @return array|bool|null
  */
-function GetPriceDetails($priceID)
+function GetPriceDetails($priceID): array|bool|null
 {
     global $db, $auth;
 

--- a/modules/paypal/Functions/SKUtoParty.php
+++ b/modules/paypal/Functions/SKUtoParty.php
@@ -5,9 +5,8 @@
  * so we need to extract it from the string again
  *
  * @param $SKU
- * @return array|bool
  */
-function SKUtoParty(string $SKU)
+function SKUtoParty(string $SKU): array|bool
 {
     $SKUarray = explode('-', $SKU);
     if ($SKUarray[0] == 'PARTY') {

--- a/modules/paypal/executepayment.php
+++ b/modules/paypal/executepayment.php
@@ -39,7 +39,7 @@ if ($auth['userid'] == 0 && $cfg['paypal_donation'] == 0) {
                 $dsp->NewContent(t('Zahlung fehlgeschlagen'), t('Leider war die Zahlung nicht erfolgreich!'));
                 $func->error(t('Die PayPal-Zahlung wurde abgebrochen'));
             }
-        } catch (PayPal\Exception\PayPalConnectionException $e) {
+        } catch (PayPal\Exception\PayPalConnectionException) {
             $dsp->NewContent(t('Zahlung fehlgeschlagen'), t('Leider war die Zahlung nicht erfolgreich!'));
             $func->error(t('Die PayPal-Zahlung wurde abgebrochen'));
         }

--- a/modules/pdf/Classes/PDF.php
+++ b/modules/pdf/Classes/PDF.php
@@ -178,27 +178,13 @@ class PDF
     {
         global $func;
 
-        switch ($action) {
-            case 'guestcards':
-                $this->_menuUsercards($action);
-                break;
-
-            case 'seatcards':
-                $this->_menuSeatcards($action);
-                break;
-
-            case 'userlist':
-                $this->_menuUserlist($action);
-                break;
-
-            case 'certificate':
-                $this->_menuCertificate($action);
-                break;
-
-            default:
-                $func->error(t('Die von dir gew&uuml;nschte Funktion konnte nicht ausgef&uuml;rt werden'), "index.php?mod=pdf&action=" . $action);
-                break;
-        }
+        match ($action) {
+            'guestcards' => $this->_menuUsercards($action),
+            'seatcards' => $this->_menuSeatcards($action),
+            'userlist' => $this->_menuUserlist($action),
+            'certificate' => $this->_menuCertificate($action),
+            default => $func->error(t('Die von dir gew&uuml;nschte Funktion konnte nicht ausgef&uuml;rt werden'), "index.php?mod=pdf&action=" . $action),
+        };
     }
 
     /**

--- a/modules/pdf/Classes/PDF.php
+++ b/modules/pdf/Classes/PDF.php
@@ -18,29 +18,20 @@ class PDF
 
     /**
      * Data array
-     *
-     * @var array
      */
-    private $data_type_array = [];
+    private array $data_type_array = [];
 
-    /**
-     * @var \FPDF
-     */
-    private $pdf;
+    private ?\FPDF $pdf = null;
 
     /**
      * Current position on the x axis
-     *
-     * @var int
      */
-    private $x = 0;
+    private int $x = 0;
 
     /**
      * Current position on the y axis
-     *
-     * @var int
      */
-    private $y = 0;
+    private int $y = 0;
 
     /**
      * Start position on the x axis
@@ -86,17 +77,13 @@ class PDF
 
     /**
      * Corrent column
-     *
-     * @var int
      */
-    private $col = 1;
+    private int $col = 1;
 
     /**
      * Current row
-     *
-     * @var int
      */
-    private $row = 1;
+    private int $row = 1;
 
     /**
      * Maximum number of possible columns
@@ -119,15 +106,9 @@ class PDF
      */
     private $templ_id;
 
-    /**
-     * @var BarcodeSystem
-     */
-    private $barcodeSystem = null;
+    private ?\LanSuite\BarcodeSystem $barcodeSystem = null;
 
-    /**
-     * @var Seat2
-     */
-    private $seating = null;
+    private ?\LanSuite\Module\Seating\Seat2 $seating = null;
 
     /**
      * @param int $templ_id

--- a/modules/picgallery/show.php
+++ b/modules/picgallery/show.php
@@ -88,10 +88,10 @@ if (!$gd->available) {
     }
     if ($handle) {
         while ($file = readdir($handle)) {
-            if ($file != "." and $file != ".." and $file != ".svn" and substr($file, 0, 1) != '.') {
+            if ($file != "." and $file != ".." and $file != ".svn" and !str_starts_with($file, '.')) {
                 if (is_dir($root_dir . $file)) {
                     $dir_list[] = $file;
-                } elseif (substr($file, 0, 8) != "lsthumb_") {
+                } elseif (!str_starts_with($file, "lsthumb_")) {
                     $extension =  strtolower(substr($file, strrpos($file, ".") + 1, 4));
                     if (IsSupportedType($extension)) {
                         $dir_size += filesize($root_dir . $file);
@@ -260,20 +260,12 @@ if (!$gd->available) {
                 and $z <= $cfg["picgallery_rows"] * $cfg["picgallery_items_per_row"] * ($_GET["page"] + 1)) {
                     $extension =  strtolower(substr($package, strrpos($package, ".") + 1, 4));
 
-                    switch ($extension) {
-                        case "ace":
-                            $icon = "ace.jpg";
-                            break;
-                        case "rar":
-                            $icon = "rar.jpg";
-                            break;
-                        case "zip":
-                            $icon = "zip.jpg";
-                            break;
-                        default:
-                            $icon = "zip.jpg";
-                            break;
-                    }
+                    $icon = match ($extension) {
+                        "ace" => "ace.jpg",
+                        "rar" => "rar.jpg",
+                        "zip" => "zip.jpg",
+                        default => "zip.jpg",
+                    };
 
                     $thumb_path = $icon_dir . $icon;
                     if (file_exists($thumb_path)) {
@@ -414,7 +406,7 @@ if (!$gd->available) {
                 $handle = opendir($root_dir);
             }
             while ($file = readdir($handle)) {
-                if (($file != ".") and ($file != "..") and ($file != ".svn") and (!is_dir($root_dir . $file) and substr($file, 0, 8) != "lsthumb_")) {
+                if (($file != ".") and ($file != "..") and ($file != ".svn") and (!is_dir($root_dir . $file) and !str_starts_with($file, "lsthumb_"))) {
                     $extension =  strtolower(substr($file, strrpos($file, ".") + 1, 4));
                     if (IsSupportedType($extension)) {
                         $file_list[] = $file;

--- a/modules/seating/Classes/Seat2.php
+++ b/modules/seating/Classes/Seat2.php
@@ -59,9 +59,8 @@ class Seat2
      * @param int $userid
      * @param int $MaxBlockLength
      * @param int $LinkIt
-     * @return bool|string
      */
-    public function SeatOfUser($userid, $MaxBlockLength = 0, $LinkIt = 0)
+    public function SeatOfUser($userid, $MaxBlockLength = 0, $LinkIt = 0): bool|string
     {
         global $db, $party;
 
@@ -102,9 +101,8 @@ class Seat2
 
     /**
      * @param int $userid
-     * @return array|bool
      */
-    public function SeatOfUserArray($userid)
+    public function SeatOfUserArray($userid): array|bool
     {
         global $db, $party;
 
@@ -155,9 +153,8 @@ class Seat2
      * @param int $MaxBlockLength
      * @param int $LinkIt
      * @param int $userid
-     * @return bool|string
      */
-    private function CoordinateToBlockAndName($x, $y, $blockid, $MaxBlockLength = 0, $LinkIt = 0, $userid = 0)
+    private function CoordinateToBlockAndName($x, $y, $blockid, $MaxBlockLength = 0, $LinkIt = 0, $userid = 0): bool|string
     {
         global $db;
     
@@ -191,9 +188,8 @@ class Seat2
      * @param int $x
      * @param int $y
      * @param boolean $orientation
-     * @return int|string
      */
-    public function CoordinateToName($x, $y, $orientation)
+    public function CoordinateToName($x, $y, $orientation): int|string
     {
         $out = '';
         if ($orientation) {
@@ -245,9 +241,8 @@ class Seat2
     /**
      * @param int $y
      * @param boolean $orientation
-     * @return int|string
      */
-    public function CoordinateToNameRow($y, $orientation)
+    public function CoordinateToNameRow($y, $orientation): int|string
     {
         $out = '';
         if ($orientation) {

--- a/modules/server/Functions/CheckIP.php
+++ b/modules/server/Functions/CheckIP.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $ip
- * @return bool|string
  */
-function CheckIP($ip)
+function CheckIP($ip): bool|string
 {
     global $cfg;
 

--- a/modules/server/Functions/CheckMAC.php
+++ b/modules/server/Functions/CheckMAC.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $mac
- * @return bool|string
  */
-function CheckMAC($mac)
+function CheckMAC($mac): bool|string
 {
     if ($mac) {
         $explode = explode('-', $mac);

--- a/modules/server/Functions/CheckPort.php
+++ b/modules/server/Functions/CheckPort.php
@@ -2,9 +2,8 @@
 
 /**
  * @param int $port
- * @return bool|string
  */
-function CheckPort($port)
+function CheckPort($port): bool|string
 {
     if ($port < 1 or $port > 65535) {
         return t('Der Port muss zwischen 1 und 65535 liegen');

--- a/modules/server/Functions/PingServer.php
+++ b/modules/server/Functions/PingServer.php
@@ -52,32 +52,32 @@ function PingServer($host, $port)
 
                 $res = fread($fp, 1000);
 
-                if ((strpos($res, "logged in") != 0) && (strpos($res, "230") != 0)) {
+                if ((!str_starts_with($res, "logged in")) && (!str_starts_with($res, "230"))) {
                     $special_info .= "<div class=\"tbl_green\">".t('Login als Anonymous erfolgreich')."</div>";
                 } else {
                     $special_info .= "<div class=\"tbl_error\">".t('Login als Anonymous fehlgeschlagen')."</div>";
                 }
-                if ((strpos($res, "Ratio") != 0) && (strpos($res, "426") != 0)) {
+                if ((!str_starts_with($res, "Ratio")) && (!str_starts_with($res, "426"))) {
                     $special_info .= "<div class=\"tbl_error\">".t('Ratio-FTP (Es muss zuerst etwas hochgeladen werden)')."</div>";
                 }
-                if ((strpos($res, "Quota") != 0) && (strpos($res, "426") != 0)) {
+                if ((!str_starts_with($res, "Quota")) && (!str_starts_with($res, "426"))) {
                     $special_info .= "<div class=\"tbl_error\">".t('Quota-FTP (Es darf nur eine gewisse Menge gezogen werden)')."</div>";
                 }
-                if ((strpos($res, "Too many") != 0) && (strpos($res, "21") != 0)) {
+                if ((!str_starts_with($res, "Too many")) && (!str_starts_with($res, "21"))) {
                     $special_info .= "<div class=\"tbl_error\">".t('<u>Hinweis</u>: Zu viele User momentan')."</div>";
                 }
-                if ((strpos($res, "home directory") != 0) && (strpos($res, "530") != 0)) {
+                if ((!str_starts_with($res, "home directory")) && (!str_starts_with($res, "530"))) {
                     $special_info .= "<div class=\"tbl_error\">".t('<u>Fehler</u>: Server hat kein Home-Directory gesetzt')."</div>";
                 }
-                if ((strpos($res, "220") === 0)) {
+                if ((str_starts_with($res, "220"))) {
                     $special_info .= "<div class=\"tbl_black\">: ".substr($res, 4, strpos($res, "\r\n")-2)."</div>";
                 }
-                if ((strpos($res, "215") != 0)) {
+                if ((!str_starts_with($res, "215"))) {
                     $special_info .= "<div class=\"tbl_black\">".t('System').": ".substr(substr($res, strpos($res, "215"), 99), 4, strpos(substr($res, strpos($res, "215"), 99), "\r\n")-2)  ."</div>";
                 }
                 $error_stri=$res;
                 for ($error_stri_num=0; $error_stri_num<10; $error_stri_num++) {
-                    if (strpos($error_stri, "530 ") != 0) {
+                    if (!str_starts_with($error_stri, "530 ")) {
                         if ($error_stri_num == 0) {
                             $special_info .= HTML_NEWLINE . "<div class=\"tbl_black\"><u>".t('Fehlermeldungen').":</u></div>";
                         }
@@ -110,7 +110,7 @@ function PingServer($host, $port)
                 $special_info .= "<div class=\"tbl_black\"><u>".t('Channels').":</u></div>";
                 $channel=$res;
                 for ($channel_num=0; $channel_num<10; $channel_num++) {
-                    if (strpos($channel, "322 ") != 0) {
+                    if (!str_starts_with($channel, "322 ")) {
                         $channel=substr($channel, strpos($channel, "322 ")+5, 9999);
                         $special_info .= "<div class=\"tbl_black\">". substr($channel, 0, strpos($channel, ":")-1) ."</div>";
                     }

--- a/modules/server/Functions/ServerType.php
+++ b/modules/server/Functions/ServerType.php
@@ -6,27 +6,13 @@
  */
 function ServerType($type)
 {
-    switch ($type) {
-        default:
-            return "???";
-            break;
-        case "gameserver":
-            return "Game";
-            break;
-        case "ftp":
-            return "FTP";
-            break;
-        case "irc":
-            return "IRC";
-            break;
-        case "web":
-            return "Web";
-            break;
-        case "proxy":
-            return "Proxy";
-            break;
-        case "misc":
-            return "Misc";
-            break;
-    }
+    return match ($type) {
+        "gameserver" => "Game",
+        "ftp" => "FTP",
+        "irc" => "IRC",
+        "web" => "Web",
+        "proxy" => "Proxy",
+        "misc" => "Misc",
+        default => "???",
+    };
 }

--- a/modules/shoutbox/shoutqueries.php
+++ b/modules/shoutbox/shoutqueries.php
@@ -67,4 +67,4 @@ header("Cache-Control: no-store, no-cache, must-revalidate");
 header("Cache-Control: post-check=0, pre-check=0", false);
 header("Pragma: no-cache");
 
-echo json_encode($data);
+echo json_encode($data, JSON_THROW_ON_ERROR);

--- a/modules/sponsor/Functions/RewriteFields.php
+++ b/modules/sponsor/Functions/RewriteFields.php
@@ -5,15 +5,15 @@
  */
 function RewriteFields()
 {
-    if (substr($_POST['pic_path'], 0, 12) == 'html-code://') {
+    if (str_starts_with($_POST['pic_path'], 'html-code://')) {
         $_POST['pic_code'] = substr($_POST['pic_path'], 12, strlen($_POST['pic_path']) - 12);
         $_POST['pic_path'] = '';
     }
-    if (substr($_POST['pic_path_banner'], 0, 12) == 'html-code://') {
+    if (str_starts_with($_POST['pic_path_banner'], 'html-code://')) {
         $_POST['pic_code_banner'] = substr($_POST['pic_path_banner'], 12, strlen($_POST['pic_path_banner']) - 12);
         $_POST['pic_path_banner'] = '';
     }
-    if (substr($_POST['pic_path_button'], 0, 12) == 'html-code://') {
+    if (str_starts_with($_POST['pic_path_button'], 'html-code://')) {
         $_POST['pic_code_button'] = substr($_POST['pic_path_button'], 12, strlen($_POST['pic_path_button']) - 12);
         $_POST['pic_path_button'] = '';
     }

--- a/modules/sponsor/Functions/UploadFiles.php
+++ b/modules/sponsor/Functions/UploadFiles.php
@@ -17,7 +17,7 @@ function UploadFiles()
         // 3) Was a code submitted?
     } elseif ($_POST['pic_code'] != '') {
         $_POST['pic_path'] = $_POST['pic_code'];
-        if (substr($_POST['pic_path'], 0, 12) != 'html-code://') {
+        if (!str_starts_with($_POST['pic_path'], 'html-code://')) {
             $_POST['pic_path'] = 'html-code://'. $_POST['pic_path'];
         }
     }
@@ -32,7 +32,7 @@ function UploadFiles()
         // 3) Was a code submitted?
     } elseif ($_POST['pic_code_banner'] != '') {
         $_POST['pic_path_banner'] = $_POST['pic_code_banner'];
-        if (substr($_POST['pic_path_banner'], 0, 12) != 'html-code://') {
+        if (!str_starts_with($_POST['pic_path_banner'], 'html-code://')) {
             $_POST['pic_path_banner'] = 'html-code://'. $_POST['pic_path_banner'];
         }
 
@@ -52,7 +52,7 @@ function UploadFiles()
         // 3) Was a code submitted?
     } elseif ($_POST['pic_code_button'] != '') {
         $_POST['pic_path_button'] = $_POST['pic_code_button'];
-        if (substr($_POST['pic_path_button'], 0, 12) != 'html-code://') {
+        if (!str_starts_with($_POST['pic_path_button'], 'html-code://')) {
             $_POST['pic_path_button'] = 'html-code://'. $_POST['pic_path_button'];
         }
 

--- a/modules/sponsor/banner.php
+++ b/modules/sponsor/banner.php
@@ -34,7 +34,7 @@ if ($banner['pic_path_banner'] == '' and file_exists($old_file_name)) {
 }
 
 // If entry is HTML-Code
-if (substr($file_name, 0, 12) == 'html-code://') {
+if (str_starts_with($file_name, 'html-code://')) {
     $smarty->assign('MainBanner', $func->AllowHTML(substr($file_name, 12, strlen($file_name) - 12)));
 } else {
   // If no Banner-Thumb was found, use LanSuite default banner

--- a/modules/sponsor/boxes/sponsor.php
+++ b/modules/sponsor/boxes/sponsor.php
@@ -19,7 +19,7 @@ while ($sponsor = $db->fetch_array($sponsoren)) {
     $out = '';
 
     // If entry is HTML-Code
-    if (substr($sponsor['pic_path_button'], 0, 12) == 'html-code://') {
+    if (str_starts_with($sponsor['pic_path_button'], 'html-code://')) {
         $out = $func->AllowHTML(substr($sponsor["pic_path_button"], 12, strlen($sponsor["pic_path_button"]) - 12));
 
     // Else add Image-Tag

--- a/modules/sponsor/show.php
+++ b/modules/sponsor/show.php
@@ -13,7 +13,7 @@ $out = "<table>";
 while ($sponsor = $db->fetch_array($sponsoren)) {
     $col1 = "";
     // If entry is HTML-Code
-    if (substr($sponsor["pic_path"], 0, 12) == 'html-code://') {
+    if (str_starts_with($sponsor["pic_path"], 'html-code://')) {
         $col1 = $func->AllowHTML(substr($sponsor["pic_path"], 12, strlen($sponsor["pic_path"]) - 12));
 
     // Else add Image-Tag

--- a/modules/stats/Classes/Stats.php
+++ b/modules/stats/Classes/Stats.php
@@ -22,13 +22,14 @@ class Stats
         //   Mozilla/5.0 (compatible; Exabot/3.0; +http://www.e...
         //   Mozilla/5.0 (compatible; Googlebot/2.1; +http://ww...
         // see also http://www.user-agents.org/
-        if (strpos(strtolower($httpUserAgent), 'bot') === false
-            && strpos(strtolower($httpUserAgent), 'spider') === false
-            && strpos(strtolower($httpUserAgent), 'crawl') === false
-            && strpos(strtolower($httpUserAgent), 'search') === false
-            && strpos(strtolower($httpUserAgent), 'google') === false
-            && strpos(strtolower($httpUserAgent), 'find') === false) {
-            if (array_key_exists('log_browser_stats', $cfg) && $cfg['log_browser_stats']) {
+
+        if (!str_contains(strtolower($httpUserAgent), 'bot')
+            && !str_contains(strtolower($httpUserAgent), 'spider')
+            && !str_contains(strtolower($httpUserAgent), 'crawl')
+            && !str_contains(strtolower($httpUserAgent), 'search')
+            && !str_contains(strtolower($httpUserAgent), 'google')
+            && !str_contains(strtolower($httpUserAgent), 'find')) {
+                if (array_key_exists('log_browser_stats', $cfg) && $cfg['log_browser_stats']) {
                 $db->qry(
                     '
                   INSERT INTO %prefix%stats_browser

--- a/modules/stats/boxes/stats.php
+++ b/modules/stats/boxes/stats.php
@@ -24,13 +24,13 @@ $box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '
 $box->DotRow(t('Aufrufe').':');
 $box->EngangedRow('<span class="infolink">'.number_format($total['hits'], 0, '', '.').'<span class="infobox">'.$total['hits'].' '.t('Seitenzugriffe insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['hits'] ?: '0').')<span class="infobox">'.($avg['hits'] ?: '0').' '.t('Seitenzugriffe in der letzten Stunde').'</span></span>');
 
-$box->DotRow(t('Online') .': '. (is_array($authentication->online_users) || $authentication->online_users instanceof \Countable ? count($authentication->online_users) : 0), 'index.php?mod=guestlist&action=onlineuser');
+$box->DotRow(t('Online') .': '. (is_countable($authentication->online_users) ? count($authentication->online_users) : 0), 'index.php?mod=guestlist&action=onlineuser');
 foreach ($authentication->online_users as $userid) {
     $row = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $userid);
     $box->EngangedRow($dsp->FetchUserIcon($userid, $row["username"]));
 }
 
-$box->DotRow(t('Untätig') .': '. (is_array($authentication->away_users) || $authentication->away_users instanceof \Countable ? count($authentication->away_users) : 0), 'index.php?mod=guestlist&action=onlineuser');
+$box->DotRow(t('Untätig') .': '. (is_countable($authentication->away_users) ? count($authentication->away_users) : 0), 'index.php?mod=guestlist&action=onlineuser');
 foreach ($authentication->away_users as $userid) {
     $row = $db->qry_first("SELECT username FROM %prefix%user WHERE userid = %int%", $userid);
     $box->EngangedRow($dsp->FetchUserIcon($userid, $row["username"]));

--- a/modules/stats/boxes/stats.php
+++ b/modules/stats/boxes/stats.php
@@ -18,7 +18,16 @@ $avg = $db->qry_first("
     hits
   FROM %prefix%stats_usage
   WHERE
-    DATE_FORMAT(time, '%Y-%m-%d %H:00:00') = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 1 HOUR), '%Y-%m-%d %H:00:00')");
+    DATE_FORMAT(time, '%Y-%m-%d %H:00:00') = DATE_FORMAT(DATE_SUB(NOW(), INTERVAL 2 HOUR), '%Y-%m-%d %H:00:00')");
+
+// If there are no visits + hits in the last hour
+// preset it  to 0
+if (!$avg) {
+  $avg = [
+    'visits' => 0,
+    'hits' => 0,
+  ];
+}
 $box->DotRow(t('Besucher').':');
 $box->EngangedRow('<span class="infolink">'.number_format($total['visits'], 0, '', '.').'<span class="infobox">'.$total['visits'].' '.t('Besucher insgesamt').'</span></span>&nbsp;<span class="infolink">('.($avg['visits'] ?: '0').')<span class="infobox">'.($avg['visits'] ?: '0').' '.t('Besucher in der letzten Stunde').'</span></span>');
 $box->DotRow(t('Aufrufe').':');

--- a/modules/stats/sysinfo.php
+++ b/modules/stats/sysinfo.php
@@ -1,8 +1,8 @@
 <?php
 
 $sysinfo_ramusage = 48;
-$sysinfo_ramtotal = 2146357248;
-$sysinfo_ramfree = 1101516800;
-$sysinfo_virtualtotal = 2147352576;
-$sysinfo_virtualfree = 2108493824;
+$sysinfo_ramtotal = 2_146_357_248;
+$sysinfo_ramfree = 1_101_516_800;
+$sysinfo_virtualtotal = 2_147_352_576;
+$sysinfo_virtualfree = 2_108_493_824;
 $sysinfo_cpuusage = 36;

--- a/modules/stats/usage.php
+++ b/modules/stats/usage.php
@@ -52,20 +52,12 @@ $res = $db->qry("
   GROUP BY DATE_FORMAT(time, %string%)
   ORDER BY DATE_FORMAT(time, %string%)", $group_by, $where, $_GET['timeframe'], $group_by, $group_by);
 while ($row = $db->fetch_array($res)) {
-    switch ($_GET['time']) {
-        default:
-            $out = $func->unixstamp2date($row['display_time'], 'year');
-            break;
-        case 'y':
-            $out = $func->unixstamp2date($row['display_time'], 'month');
-            break;
-        case 'm':
-            $out = $func->unixstamp2date($row['display_time'], 'daydate');
-            break;
-        case 'd':
-            $out = $func->unixstamp2date($row['display_time'], 'daydatetime');
-            break;
-    }
+    $out = match ($_GET['time']) {
+        'y' => $func->unixstamp2date($row['display_time'], 'month'),
+        'm' => $func->unixstamp2date($row['display_time'], 'daydate'),
+        'd' => $func->unixstamp2date($row['display_time'], 'daydatetime'),
+        default => $func->unixstamp2date($row['display_time'], 'year'),
+    };
     if ($link) {
         $out = '<a href="index.php?mod=stats&action=usage&time='. $link .'&timeframe='. $row['group_by_time'] .'">'. $out .'</a>';
     }

--- a/modules/tournament2/Classes/LanSuiteTree.php
+++ b/modules/tournament2/Classes/LanSuiteTree.php
@@ -73,7 +73,7 @@ class LanSuiteTree extends TourneyTree
 
         // Determine winner of each match
         foreach ($this->wb_teams as $round => $teams) {
-            for ($i=0; $i<(is_array($teams) || $teams instanceof \Countable ? count($teams) : 0); $i++) {
+            for ($i=0; $i<(is_countable($teams) ? count($teams) : 0); $i++) {
                 $t1 = $this->wb_teams[$round][$i];
                 $i++;
                 $t2 = $this->wb_teams[$round][$i];
@@ -122,7 +122,7 @@ class LanSuiteTree extends TourneyTree
         array_push($this->wb_teams, $fix, $fix);
 
         foreach ($this->lb_teams as $round => $teams) {
-            for ($i=0; $i<(is_array($teams) || $teams instanceof \Countable ? count($teams) : 0); $i++) {
+            for ($i=0; $i<(is_countable($teams) ? count($teams) : 0); $i++) {
                 $t1 = $this->lb_teams[$round][$i];
                 $i++;
                 $t2 = $this->lb_teams[$round][$i];

--- a/modules/tournament2/Classes/LanSuiteTree.php
+++ b/modules/tournament2/Classes/LanSuiteTree.php
@@ -4,30 +4,18 @@ namespace LanSuite\Module\Tournament2;
 
 class LanSuiteTree extends TourneyTree
 {
-    /**
-     * @var array
-     */
-    private $wb_teams = [];
+    private array $wb_teams = [];
 
-    /**
-     * @var array
-     */
-    private $lb_teams = [];
+    private array $lb_teams = [];
 
     /**
      * @var int
      */
     private $size = null;
 
-    /**
-     * @var string
-     */
-    private $st = null;
+    private ?string $st = null;
 
-    /**
-     * @var TourneyTree
-     */
-    private $tree = null;
+    private ?\LanSuite\Module\Tournament2\TourneyTree $tree = null;
 
     /**
      * @var \LanSuite\DB

--- a/modules/tournament2/Classes/Team.php
+++ b/modules/tournament2/Classes/Team.php
@@ -5,15 +5,9 @@ namespace LanSuite\Module\Tournament2;
 class Team
 {
 
-    /**
-     * @var \LanSuite\Module\Mail\Mail
-     */
-    private $mail = null;
+    private ?\LanSuite\Module\Mail\Mail $mail = null;
 
-    /**
-     * @var \LanSuite\Module\Seating\Seat2
-     */
-    private $seating = null;
+    private ?\LanSuite\Module\Seating\Seat2 $seating = null;
 
     public function __construct(\LanSuite\Module\Mail\Mail $mail, \LanSuite\Module\Seating\Seat2 $seating)
     {

--- a/modules/tournament2/Classes/TournamentFunction.php
+++ b/modules/tournament2/Classes/TournamentFunction.php
@@ -52,9 +52,8 @@ class TournamentFunction
      * @param int $tid
      * @param string $mode
      * @param int $group
-     * @return float|int
      */
-    public function GetTeamAnz($tid, $mode, $group = 0)
+    public function GetTeamAnz($tid, $mode, $group = 0): float|int
     {
         global $db;
 
@@ -99,9 +98,8 @@ class TournamentFunction
      * @param array $tournament
      * @param int $round
      * @param int $group_nr
-     * @return float|int
      */
-    public function GetGameStart($tournament, $round, $group_nr = 0)
+    public function GetGameStart($tournament, $round, $group_nr = 0): float|int
     {
         global $db;
         
@@ -151,9 +149,8 @@ class TournamentFunction
      * @param array $tournament
      * @param int $round
      * @param int $group_nr
-     * @return float|int
      */
-    public function GetGameEnd($tournament, $round, $group_nr = 0)
+    public function GetGameEnd($tournament, $round, $group_nr = 0): float|int
     {
         global $db;
         

--- a/modules/tournament2/Classes/TournamentFunction.php
+++ b/modules/tournament2/Classes/TournamentFunction.php
@@ -5,15 +5,9 @@ namespace LanSuite\Module\Tournament2;
 class TournamentFunction
 {
 
-    /**
-     * @var \LanSuite\Module\Mail\Mail
-     */
-    private $mail = null;
+    private ?\LanSuite\Module\Mail\Mail $mail = null;
 
-    /**
-     * @var \LanSuite\Module\Seating\Seat2
-     */
-    private $seating = null;
+    private ?\LanSuite\Module\Seating\Seat2 $seating = null;
 
     public function __construct(\LanSuite\Module\Mail\Mail $mail, \LanSuite\Module\Seating\Seat2 $seating)
     {

--- a/modules/tournament2/Classes/TournamentLeagueExport.php
+++ b/modules/tournament2/Classes/TournamentLeagueExport.php
@@ -5,15 +5,9 @@ namespace LanSuite\Module\Tournament2;
 class TournamentLeagueExport
 {
 
-    /**
-     * @var \LanSuite\XML
-     */
-    private $xml = null;
+    private ?\LanSuite\XML $xml = null;
 
-    /**
-     * @var \LanSuite\Module\Tournament2\TournamentFunction
-     */
-    private $tournamentFunc = null;
+    private ?\LanSuite\Module\Tournament2\TournamentFunction $tournamentFunc = null;
 
     public function __construct(\LanSuite\XML $xml, \LanSuite\Module\Tournament2\TournamentFunction $tournamentFunc)
     {

--- a/modules/tournament2/Classes/TourneyTree.php
+++ b/modules/tournament2/Classes/TourneyTree.php
@@ -297,7 +297,7 @@ class TourneyTree
                 $row = $y+1;
 
                 if ($x == 0) {
-                    if (((is_array($this->wb_teams[$x]) || $this->wb_teams[$x] instanceof \Countable ? count($this->wb_teams[$x]) : 0) % 2) == 1) {
+                    if (((is_countable($this->wb_teams[$x]) ? count($this->wb_teams[$x]) : 0) % 2) == 1) {
                         $this->generateBar($x+1, $y, $this->wb_tbl);
                         $this->generateBar($x+1, $y-1, $this->wb_tbl);
                     }
@@ -312,7 +312,7 @@ class TourneyTree
                 // $x / 2 is the actual round!
                 // $round-2 is the actual previous round
                 if ($x > 0 && $x < $this->wb_num_cols && ($x % 2) == 0) {
-                    if (((is_array($this->wb_teams[$x/2]) || $this->wb_teams[$x/2] instanceof \Countable ? count($this->wb_teams[$x/2]) : 0) % 2) == 1) {
+                    if (((is_countable($this->wb_teams[$x/2]) ? count($this->wb_teams[$x/2]) : 0) % 2) == 1) {
                         $this->generateBar($x+1, $y, $this->wb_tbl);
                         $this->generateBar($x+1, $y-1, $this->wb_tbl);
                     }
@@ -351,11 +351,11 @@ class TourneyTree
 
                 // first round
                 if ($x == 0) {
-                    if (((is_array($this->lb_teams[$x]) || $this->lb_teams[$x] instanceof \Countable ? count($this->lb_teams[$x]) : 0) % 2) == 1) {
+                    if (((is_countable($this->lb_teams[$x]) ? count($this->lb_teams[$x]) : 0) % 2) == 1) {
                         $this->generateBar($x+1, $y, $this->lb_tbl);
                         $this->generateBar($x+1, $y-1, $this->lb_tbl);
                     }
-                    if (($row % 2) == 1 && (is_array($this->lb_teams[$x]) || $this->lb_teams[$x] instanceof \Countable ? count($this->lb_teams[$x]) : 0) > 0) {
+                    if (($row % 2) == 1 && (is_countable($this->lb_teams[$x]) ? count($this->lb_teams[$x]) : 0) > 0) {
                         $this->lb_tbl[$x][$y] = array_shift($this->lb_teams[$x]);        // insert team
                         $this->lb_indexes[$round][] = [$x, $y];
                         // we need them for the positions of the following round
@@ -370,14 +370,14 @@ class TourneyTree
 
                 // rounds > 1
                 if ($x > 0 && $x < ($this->lb_num_cols-2) && ($x % 2) == 0) {
-                    if (((is_array($this->lb_teams[$x/2]) || $this->lb_teams[$x/2] instanceof \Countable ? count($this->lb_teams[$x/2]) : 0) % 2) == 1) {
+                    if (((is_countable($this->lb_teams[$x/2]) ? count($this->lb_teams[$x/2]) : 0) % 2) == 1) {
                         $this->generateBar($x+1, $y, $this->lb_tbl);
                         $this->generateBar($x+1, $y-1, $this->lb_tbl);
                     }
 
                     $tmp = $this->getPrevCoords($round, $this->lb_indexes);
                     if ($this->calcMW($tmp[0][1], $tmp[1][1]) == $y) {
-                        if ((is_array($this->lb_teams[($x/2)]) || $this->lb_teams[($x/2)] instanceof \Countable ? count($this->lb_teams[($x/2)]) : 0) > 0) {
+                        if ((is_countable($this->lb_teams[($x/2)]) ? count($this->lb_teams[($x/2)]) : 0) > 0) {
                             $this->lb_tbl[$x][$y] = array_shift($this->lb_teams[($x/2)]);
                         }        // insert team
                         array_shift($this->lb_indexes[$round-2]);
@@ -387,7 +387,7 @@ class TourneyTree
                         }
                         $this->lb_indexes[$round][] = [$x, $y];
 
-                        if ((is_array($this->lb_teams[($x/2)]) || $this->lb_teams[($x/2)] instanceof \Countable ? count($this->lb_teams[($x/2)]) : 0) <= 0) {
+                        if ((is_countable($this->lb_teams[($x/2)]) ? count($this->lb_teams[($x/2)]) : 0) <= 0) {
                             $tmp = $this->getPrevCoords($round, $this->lb_indexes, 0);
                             $delta = $tmp[1][1] - $tmp[0][1] ;
                             if ($delta > 0) {

--- a/modules/tournament2/Classes/TourneyTree.php
+++ b/modules/tournament2/Classes/TourneyTree.php
@@ -42,10 +42,7 @@ class TourneyTree
      */
     private $wb_num_cols;
 
-    /**
-     * @var array
-     */
-    private $wb_tbl = [];
+    private array $wb_tbl = [];
 
     /**
      * @var array
@@ -67,10 +64,7 @@ class TourneyTree
      */
     private $lb_num_cols;
 
-    /**
-     * @var array
-     */
-    private $lb_tbl = [];
+    private array $lb_tbl = [];
 
     /**
      * @var array

--- a/modules/tournament2/Classes/TourneyTree.php
+++ b/modules/tournament2/Classes/TourneyTree.php
@@ -27,49 +27,34 @@ class TourneyTree
      */
     private $size;
 
-    /**
-     * @var float|int
-     */
-    private $wb_rounds;
+    private float|int $wb_rounds;
 
-    /**
-     * @var float|int
-     */
-    private $wb_num_rows;
+    private int|float $wb_num_rows;
 
-    /**
-     * @var float|int
-     */
-    private $wb_num_cols;
+    private float|int $wb_num_cols;
 
     private array $wb_tbl = [];
 
-    /**
-     * @var array
-     */
-    private $wb_indexes = [];
+    private array $wb_indexes = [];
 
     /**
      * @var float|int
      */
-    private $lb_rounds;
+    private float|int|null $lb_rounds = null;
 
     /**
      * @var float|int
      */
-    private $lb_num_rows;
+    private int|float|null $lb_num_rows = null;
 
     /**
      * @var float|int
      */
-    private $lb_num_cols;
+    private float|int|null $lb_num_cols = null;
 
     private array $lb_tbl = [];
 
-    /**
-     * @var array
-     */
-    private $lb_indexes = [];
+    private array $lb_indexes = [];
 
     public function __construct($size, $wb_teams, $lb_teams = false)
     {

--- a/modules/tournament2/Functions/CheckDateInFuture.php
+++ b/modules/tournament2/Functions/CheckDateInFuture.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $date
- * @return bool|string
  */
-function CheckDateInFuture($date)
+function CheckDateInFuture($date): bool|string
 {
     global $func, $mf;
 

--- a/modules/tournament2/Functions/CheckModeChangeAllowed.php
+++ b/modules/tournament2/Functions/CheckModeChangeAllowed.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $mode
- * @return bool|string
  */
-function CheckModeChangeAllowed($mode)
+function CheckModeChangeAllowed($mode): bool|string
 {
     global $mf, $db;
 

--- a/modules/tournament2/Functions/CheckModeForLeague.php
+++ b/modules/tournament2/Functions/CheckModeForLeague.php
@@ -2,9 +2,8 @@
 
 /**
  * @param boolean $league
- * @return bool|string
  */
-function CheckModeForLeague($league)
+function CheckModeForLeague($league): bool|string
 {
     if ($league and $_POST['mode'] != 'single' and $_POST['mode'] != 'double') {
         return t('Diese Liga ist nur im SE und DE Modus möglich');

--- a/modules/tournament2/Functions/CheckModeForWWCLLeague.php
+++ b/modules/tournament2/Functions/CheckModeForWWCLLeague.php
@@ -2,9 +2,8 @@
 
 /**
  * @param boolean $league
- * @return bool|string
  */
-function CheckModeForWWCLLeague($league)
+function CheckModeForWWCLLeague($league): bool|string
 {
     if ($league and $_POST['mode'] != 'single' and $_POST['mode'] != 'double' and $_POST['mode'] != 'groups') {
         return t('WWCL-Turniere müssen im SE, DE oder Gruppenspiele Modus ausgetragen werden');

--- a/modules/tournament2/Functions/CheckStateChangeAllowed.php
+++ b/modules/tournament2/Functions/CheckStateChangeAllowed.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $state
- * @return bool|string
  */
-function CheckStateChangeAllowed($state)
+function CheckStateChangeAllowed($state): bool|string
 {
     if ($state == 'process') {
         return t('Dieser Status kann nicht manuell gesetzt werden. Zum setzen, bitte "Generieren" verwenden');

--- a/modules/tournament2/Functions/WritePairs2.php
+++ b/modules/tournament2/Functions/WritePairs2.php
@@ -1,11 +1,10 @@
 <?php
 
 /**
- * @param mixed $bracket
  * @param int $max_pos
  * @return void
  */
-function write_pairs2($bracket, $max_pos)
+function write_pairs2(mixed $bracket, $max_pos)
 {
     $score1 = null;
     $gameid1 = null;

--- a/modules/tournament2/Functions/WritePairs3.php
+++ b/modules/tournament2/Functions/WritePairs3.php
@@ -1,11 +1,10 @@
 <?php
 
 /**
- * @param mixed $bracket
  * @param int $max_pos
  * @return void
  */
-function write_pairs3($bracket, $max_pos)
+function write_pairs3(mixed $bracket, $max_pos)
 {
     $score1 = null;
     $known_game1 = null;

--- a/modules/tournament2/join.php
+++ b/modules/tournament2/join.php
@@ -74,7 +74,7 @@ if ($tteam->SignonCheck($tournamentid)) {
                 $sec->lock("t_join");
             }
 
-            if ((is_array($error) || $error instanceof \Countable ? count($error) : 0) > 0) {
+            if ((is_countable($error) ? count($error) : 0) > 0) {
                 $_GET['step']--;
             }
             break;

--- a/modules/tournament2/join.php
+++ b/modules/tournament2/join.php
@@ -113,7 +113,7 @@ if ($tteam->SignonCheck($tournamentid)) {
             }
 
             $dsp->AddTextAreaPlusRow("team_comment", t('Bemerkung'), $_POST["team_comment"], "", "", "", 1);
-            $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1000000, 1);
+            $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1_000_000, 1);
 
             if ($tournament['wwcl_gameid'] > 0) {
                 $dsp->AddTextFieldRow("wwclid", t('WWCL ID'), $user['wwclid'], "");

--- a/modules/tournament2/teammgr.php
+++ b/modules/tournament2/teammgr.php
@@ -91,7 +91,7 @@ switch ($_GET['step']) {
         if ($team["banner"]) {
             $dsp->AddSingleRow("<img src=\"ext_inc/team_banners/{$team['banner']}\" alt=\"{$team['banner']}\">");
         }
-        $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1000000, 1);
+        $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1_000_000, 1);
 
         if ($tournament['wwcl_gameid'] > 0) {
             $dsp->AddTextFieldRow("wwclid", t('WWCL ID'), $team['wwclid'], "");

--- a/modules/tournament2/teammgr_admin.php
+++ b/modules/tournament2/teammgr_admin.php
@@ -76,7 +76,7 @@ switch ($_GET["step"]) {
             $dsp->AddPasswordRow("set_password", t('Team-Passwort festlegen'), $_POST["set_password"], $error["set_password"]);
             $dsp->AddPasswordRow("set_password2", t('Team-Passwort wiederholen'), $_POST["set_password2"], $error["set_password2"]);
             $dsp->AddTextAreaPlusRow("team_comment", t('Bemerkung'), $team_comment, "", "", "", 1);
-            $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1000000, 1);
+            $dsp->AddFileSelectRow("team_banner", t('Team-Logo (max. 1MB)'), "", "", 1_000_000, 1);
             $dsp->AddFormSubmitRow(t('Hinzufügen'));
             $dsp->AddBackButton("index.php?mod=tournament2&action=teammgr_admin", "");
         }

--- a/modules/tournament2/timetable.php
+++ b/modules/tournament2/timetable.php
@@ -43,7 +43,7 @@ if ($maxtime > $mintime + 60 * 60 * 24 * 4) {
     $maxtime = $mintime + 60 * 60 * 24 * 4;
 }
 
-$head .= "<td><b>".t('Turnier')."</b></td>";
+$head = "<td><b>".t('Turnier')."</b></td>";
 for ($z = $mintime; $z <= $maxtime; $z+= (60 * 60 * 2)) {
     $head .= "<td colspan = 4>". $func->unixstamp2date($z, "time")."</td>";
 }

--- a/modules/tournament2/timetable.php
+++ b/modules/tournament2/timetable.php
@@ -8,7 +8,7 @@ $tfunc = new \LanSuite\Module\Tournament2\TournamentFunction($mail, $seat2);
 $dsp->NewContent(t('Turnier-Zeitplan'), t('Hier siehst du, welches Turnier zu welcher Zeit stattfindet.'));
 
 // Generate Table-head
-$mintime = 9999999999;
+$mintime = 9_999_999_999;
 $maxtime = 0;
 $tournaments = $db->qry("
   SELECT *,

--- a/modules/tournament2/tournaments_del.php
+++ b/modules/tournament2/tournaments_del.php
@@ -6,16 +6,8 @@ $md->References['t2_teams'] = '';
 $md->References['t2_teammembers'] = '';
 $md->References['t2_games'] = '';
 
-switch ($_GET['step']) {
-    default:
-        include_once('modules/tournament2/search.inc.php');
-        break;
-
-    case 2:
-        $md->Delete('tournament_tournaments', 'tournamentid', $_GET['tournamentid']);
-        break;
-  
-    case 10:
-        $md->MultiDelete('tournament_tournaments', 'tournamentid');
-        break;
-}
+match ($_GET['step']) {
+    2 => $md->Delete('tournament_tournaments', 'tournamentid', $_GET['tournamentid']),
+    10 => $md->MultiDelete('tournament_tournaments', 'tournamentid'),
+    default => include_once('modules/tournament2/search.inc.php'),
+};

--- a/modules/troubleticket/Functions/TTStatus.php
+++ b/modules/troubleticket/Functions/TTStatus.php
@@ -6,24 +6,12 @@
  */
 function TTStatus($status)
 {
-    switch ($status) {
-        default:
-            return t('Überprüft am/um');
-            break;
-        case 1:
-            return t('Neu / Ungeprüft');
-            break;
-        case 2:
-            return t('Überprüft / Akzeptiert');
-            break;
-        case 3:
-            return t('In Arbeit');
-            break;
-        case 4:
-            return t('Abgeschlossen');
-            break;
-        case 5:
-            return t('Abgelehnt');
-            break;
-    }
+    return match ($status) {
+        1 => t('Neu / Ungeprüft'),
+        2 => t('Überprüft / Akzeptiert'),
+        3 => t('In Arbeit'),
+        4 => t('Abgeschlossen'),
+        5 => t('Abgelehnt'),
+        default => t('Überprüft am/um'),
+    };
 }

--- a/modules/troubleticket/change.php
+++ b/modules/troubleticket/change.php
@@ -52,21 +52,12 @@ switch ($_GET["step"]) {
             $dsp->AddDoubleRow(t('Eingetragen am/um'), $func->unixstamp2date($row["created"], "daydatetime"));
             $dsp->AddDoubleRow(t('Von Benutzer'), $get_originuser["username"]);
 
-            // priorität zahl -> text
-            switch ($row["priority"]) {
-                default:
-                    $priority = t('Niedrig');
-                    break;
-                case 20:
-                    $priority = t('Normal');
-                    break;
-                case 30:
-                    $priority = t('Hoch');
-                    break;
-                case 40:
-                    $priority = t('Kritisch');
-                    break;
-            }
+            $priority = match ($row["priority"]) {
+                20 => t('Normal'),
+                30 => t('Hoch'),
+                40 => t('Kritisch'),
+                default => t('Niedrig'),
+            };
             $dsp->AddDoubleRow(t('Priorität'), $priority);
 
             // entsprechend des ticketstatuses passende zeilen ausgeben

--- a/modules/troubleticket/show.php
+++ b/modules/troubleticket/show.php
@@ -33,21 +33,12 @@ switch ($_GET["step"]) {
             $dsp->AddDoubleRow(t('Eingetragen am/um'), $func->unixstamp2date($row["created"], "daydatetime"));
             $dsp->AddDoubleRow(t('Von Benutzer'), $dsp->FetchUserIcon($get_originuser["userid"], $get_originuser["username"]));
 
-            // priorität zahl -> text
-            switch ($row["priority"]) {
-                default:
-                    $priority = t('Niedrig');
-                    break;
-                case 20:
-                    $priority = t('Normal');
-                    break;
-                case 30:
-                    $priority = t('Hoch');
-                    break;
-                case 40:
-                    $priority = t('Kritisch');
-                    break;
-            }
+            $priority = match ($row["priority"]) {
+                20 => t('Normal'),
+                30 => t('Hoch'),
+                40 => t('Kritisch'),
+                default => t('Niedrig'),
+            };
             $dsp->AddDoubleRow(t('Priorität'), $priority);
 
             // entsprechend des ticketstatuses passende zeilen ausgeben

--- a/modules/usrmgr/Classes/UserManager.php
+++ b/modules/usrmgr/Classes/UserManager.php
@@ -29,7 +29,7 @@ class UserManager
         if (!empty($cfg['sys_partyurl_ssl'])) {
             $verification_link = $cfg['sys_partyurl_ssl'];
             //make sure that it ends with a slash
-            if (substr($cfg['sys_partyurl_ssl'], -1, 1) != '/') {
+            if (!str_ends_with($cfg['sys_partyurl_ssl'], '/')) {
                 $verification_link .= '/';
             }
             $verification_link .= "index.php?mod=usrmgr&action=verify_email&verification_code=$verification_code";

--- a/modules/usrmgr/Classes/UserManager.php
+++ b/modules/usrmgr/Classes/UserManager.php
@@ -4,10 +4,7 @@ namespace LanSuite\Module\UsrMgr;
 class UserManager
 {
 
-    /**
-     * @var \LanSuite\Module\Mail\Mail
-     */
-    private $mail = null;
+    private ?\LanSuite\Module\Mail\Mail $mail = null;
 
     public function __construct(\LanSuite\Module\Mail\Mail $mail)
     {

--- a/modules/usrmgr/Functions/Addr1Input.php
+++ b/modules/usrmgr/Functions/Addr1Input.php
@@ -4,9 +4,8 @@
  * @param string $field
  * @param int $mode
  * @param string $error
- * @return bool|string
  */
-function Addr1Input($field, $mode, $error = '')
+function Addr1Input($field, $mode, $error = ''): bool|string
 {
     global $dsp;
 

--- a/modules/usrmgr/Functions/Addr2Input.php
+++ b/modules/usrmgr/Functions/Addr2Input.php
@@ -4,9 +4,8 @@
  * @param string $field
  * @param int $mode
  * @param string $error
- * @return bool|string
  */
-function Addr2Input($field, $mode, $error = '')
+function Addr2Input($field, $mode, $error = ''): bool|string
 {
     global $dsp;
 

--- a/modules/usrmgr/Functions/ChangeAllowed.php
+++ b/modules/usrmgr/Functions/ChangeAllowed.php
@@ -2,9 +2,8 @@
 
 /**
  * @param int $id
- * @return bool|string
  */
-function ChangeAllowed($id)
+function ChangeAllowed($id): bool|string
 {
     global $db, $row, $func, $auth, $seat2;
 

--- a/modules/usrmgr/Functions/CheckAndResizeUploadPic.php
+++ b/modules/usrmgr/Functions/CheckAndResizeUploadPic.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $AvatarName
- * @return bool|string
  */
-function CheckAndResizeUploadPic($AvatarName)
+function CheckAndResizeUploadPic($AvatarName): bool|string
 {
     global $gd;
 

--- a/modules/usrmgr/Functions/CheckBirthday.php
+++ b/modules/usrmgr/Functions/CheckBirthday.php
@@ -9,7 +9,7 @@
  * @return bool|string  Returns Message on error else false
  * @todo fix this (What is that strange -80y bit? Compare against sensible date range, use checkdate() )
  */
-function check_birthday($date)
+function check_birthday($date): bool|string
 {
     global $cfg;
 

--- a/modules/usrmgr/Functions/CheckClanNotExists.php
+++ b/modules/usrmgr/Functions/CheckClanNotExists.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $ClanName
- * @return bool|string
  */
-function CheckClanNotExists($ClanName)
+function CheckClanNotExists($ClanName): bool|string
 {
     global $db;
 

--- a/modules/usrmgr/Functions/CheckClanPWUsrMgr.php
+++ b/modules/usrmgr/Functions/CheckClanPWUsrMgr.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $clanpw
- * @return bool|string
  */
-function CheckClanPWUsrMgr($clanpw)
+function CheckClanPWUsrMgr($clanpw): bool|string
 {
     global $db, $auth;
 

--- a/modules/usrmgr/Functions/CheckNoSpace.php
+++ b/modules/usrmgr/Functions/CheckNoSpace.php
@@ -2,11 +2,10 @@
 
 /**
  * @param string $val
- * @return bool|string
  */
-function check_no_space($val)
+function check_no_space($val): bool|string
 {
-    if (strpos($val, ' ') !== false) {
+    if (str_contains($val, ' ')) {
         return t('Der Feldname darf kein Leerzeichen enthalten');
     } else {
         return false;

--- a/modules/usrmgr/Functions/CheckOldPW.php
+++ b/modules/usrmgr/Functions/CheckOldPW.php
@@ -2,9 +2,8 @@
 
 /**
  * @param string $old_password
- * @return bool|string
  */
-function CheckOldPW($old_password)
+function CheckOldPW($old_password): bool|string
 {
     global $db, $auth;
 

--- a/modules/usrmgr/Functions/CheckOptGender.php
+++ b/modules/usrmgr/Functions/CheckOptGender.php
@@ -6,7 +6,7 @@
  * @param int $gender   From Inputfield 0=None, 1=Male, 2=Female
  * @return bool|string  Returns Message on error else false
  */
-function check_opt_gender($gender)
+function check_opt_gender($gender): bool|string
 {
     global $cfg;
 

--- a/modules/usrmgr/Functions/ClanURLLinkUsrMgrSearch.php
+++ b/modules/usrmgr/Functions/ClanURLLinkUsrMgrSearch.php
@@ -9,7 +9,7 @@ function ClanURLLinkUsrMgrSearch($clan_name)
     global $line;
 
     if ($clan_name != '' and $line['clanurl'] != '' and $line['clanurl'] != 'http://') {
-        if (substr($line['clanurl'], 0, 7) != 'http://') {
+        if (!str_starts_with($line['clanurl'], 'http://')) {
             $line['clanurl'] = 'http://'. $line['clanurl'];
         }
         return '<a href="'. $line['clanurl'] .'" target="_blank">'. $clan_name .'</a>';

--- a/modules/usrmgr/Functions/ClanURLLinkUsrMgrSearchInc.php
+++ b/modules/usrmgr/Functions/ClanURLLinkUsrMgrSearchInc.php
@@ -13,7 +13,7 @@ function ClanURLLinkUsrMgrSearchInc($clan_name)
     } elseif ($func->isModActive('clanmgr')) {
         return '<a href="index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $line['clanid'] .'">'. $clan_name .'</a>';
     } elseif ($clan_name != '' and $line['clanurl'] != '' and $line['clanurl'] != 'http://') {
-        if (substr($line['clanurl'], 0, 7) != 'http://') {
+        if (!str_starts_with($line['clanurl'], 'http://')) {
             $line['clanurl'] = 'http://'. $line['clanurl'];
         }
         return '<a href="'. $line['clanurl'] .'" target="_blank">'. $clan_name .'</a>';

--- a/modules/usrmgr/Functions/GetTypeDescription.php
+++ b/modules/usrmgr/Functions/GetTypeDescription.php
@@ -6,24 +6,12 @@
  */
 function GetTypeDescription($type)
 {
-    switch ($type) {
-        case -2:
-            return t('Organisator (gesperrt)');
-            break;
-        case -1:
-            return t('Gast (gesperrt)');
-            break;
-        default:
-            return t('Gast (deaktiviert)');
-            break;
-        case 1:
-            return t('Gast');
-            break;
-        case 2:
-            return t('Organisator');
-            break;
-        case 3:
-            return t('Superadmin');
-            break;
-    }
+    return match ($type) {
+        -2 => t('Organisator (gesperrt)'),
+        -1 => t('Gast (gesperrt)'),
+        1 => t('Gast'),
+        2 => t('Organisator'),
+        3 => t('Superadmin'),
+        default => t('Gast (deaktiviert)'),
+    };
 }

--- a/modules/usrmgr/Functions/PersoInput.php
+++ b/modules/usrmgr/Functions/PersoInput.php
@@ -4,11 +4,10 @@
  * @param string $field
  * @param int $mode
  * @param string $error
- * @return bool|string
  * @throws Exception
  * @throws SmartyException
  */
-function PersoInput($field, $mode, $error = '')
+function PersoInput($field, $mode, $error = ''): bool|string
 {
     global $dsp, $usrmgr, $smarty;
 

--- a/modules/usrmgr/details.php
+++ b/modules/usrmgr/details.php
@@ -103,7 +103,7 @@ if (!$user_data['userid']) {
     if ($cfg['signon_show_clan']) {
         $clan = '<table width="100%" cellspacing="0" cellpadding="0"><tr><td>';
         $clan .= '<a href="index.php?mod=clanmgr&step=2&clanid='.$user_data["clanid"].'">'.$user_data["clan"].'</a>';
-        if ($user_data['clanurl']!='' && substr($user_data['clanurl'], 0, 7) != 'http://') {
+        if ($user_data['clanurl']!='' && !str_starts_with($user_data['clanurl'], 'http://')) {
             $user_data['clanurl'] = 'http://'. $user_data['clanurl'];
         }
         if ($user_data['clanurl']) {

--- a/modules/usrmgr/map.php
+++ b/modules/usrmgr/map.php
@@ -5,35 +5,17 @@ $dsp->NewContent(t('Benutzerkarte'), t('Auf dieser Karte findest du alle Benutze
 if (!$cfg['google_maps_api_key']) {
     $func->information(t('Du musst dich zuerst unter http://www.google.com/apis/maps/signup.html einen Google-Maps API Key erzeugen und diesen auf der %1 eingeben.', '<a href="index.php?mod=install&action=modules&step=10&module=install">'. t('AdminSeite in den Allgemeinen Einstellungen').'</a>'));
 } else {
-    switch ($cfg['country']) {
-        case 'de':
-            $GCountry = 'Germany';
-            break;
-        case 'at':
-            $GCountry = 'Austria';
-            break;
-        case 'ch':
-            $GCountry = 'Swiss';
-            break;
-        case 'en':
-            $GCountry = 'England';
-            break;
-        case 'nl':
-            $GCountry = 'Netherlands';
-            break;
-        case 'es':
-            $GCountry = 'Spain';
-            break;
-        case 'it':
-            $GCountry = 'Italy';
-            break;
-        case 'fr':
-            $GCountry = 'France';
-            break;
-        default:
-            $GCountry = 'Germany';
-            break;
-    }
+    $GCountry = match ($cfg['country']) {
+        'de' => 'Germany',
+        'at' => 'Austria',
+        'ch' => 'Swiss',
+        'en' => 'England',
+        'nl' => 'Netherlands',
+        'es' => 'Spain',
+        'it' => 'Italy',
+        'fr' => 'France',
+        default => 'Germany',
+    };
 
     $res = $db->qry("
       SELECT

--- a/modules/usrmgr/remind.php
+++ b/modules/usrmgr/remind.php
@@ -25,7 +25,7 @@ if (!$cfg['sys_internet']) {
                 //Try HTTPS first...
                 if (!empty($cfg['sys_partyurl_ssl'])) {
                     $verification_link = $cfg['sys_partyurl_ssl'];
-                    if (substr($cfg['sys_partyurl_ssl'], -1, 1) != '/') {
+                    if (!str_ends_with($cfg['sys_partyurl_ssl'], '/')) {
                         $verification_link .= '/';
                     } //make sure that it ends with a slash
                     $verification_link .= "index.php?mod=usrmgr&action=pwrecover&step=3&fcode=$fcode";

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_71
+        LevelSetList::UP_TO_PHP_72
     ]);
 
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_73
+        LevelSetList::UP_TO_PHP_74
     ]);
 
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_72
+        LevelSetList::UP_TO_PHP_73
     ]);
 
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74
+        LevelSetList::UP_TO_PHP_80
     ]);
 
     $rectorConfig->skip([
@@ -34,5 +34,12 @@ return static function (RectorConfig $rectorConfig): void {
         // over **
         // See https://www.php.net/manual/en/function.pow.php
         Rector\Php56\Rector\FuncCall\PowToExpRector::class,
+
+        // Skipping Constructor Promotion right now, because it is a great feature and syntactic sugar.
+        // However, to keep the changeset small, we might introduce this at a later stage.
+        // More info:
+        //  - https://wiki.php.net/rfc/constructor_promotion
+        //  - https://github.com/php/php-src/pull/5291
+        Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
     ]);
 };


### PR DESCRIPTION
## Context

LanSuite suggests to install the apcu PHP extension ([APC User Cache](https://www.php.net/manual/de/book.apcu.php#book.apcu)).

This PR is removing the dependency on apcu for the following reasons:

1. We don't use a single `apcu_` function to make use on the user cache
2. It adds complexity to the server setup for the people who want to run LanSuite
3. We don't have any performance issue right now, which would be a compelling reason to add `apcu_` functions
4. Only the configuration cache has used the apcu cache - However, in my setups, I never used apcu and never observed that the system is slow - especially in times of SSDs, Ramdisks, etc.

I suggest to make the setup and maintenance of LanSuite easier by removing it.

Furthermore, this is not a breaking change.

## Dependencies

This PR depends on https://github.com/lansuite/lansuite/pull/604.
https://github.com/lansuite/lansuite/pull/604 need to be merged before.

The single commit in this PR is https://github.com/lansuite/lansuite/commit/30f46ed8fce575daf1364b6a314beb85883abbdf