### PR TITLE
Documentation: Automate deployment via GitHub Actions

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+          cache-dependency-path: 'website/package-lock.json'
 
       - name: Install dependencies
         run: make init

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -1,0 +1,42 @@
+name: "Documentation: Deploy to GitHub Pages"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: "Documentation: Deploy to GitHub Pages"
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: website
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: make init
+
+      - name: Build the documentation website
+        run: make build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/documentation-test-deploy.yml
+++ b/.github/workflows/documentation-test-deploy.yml
@@ -1,0 +1,26 @@
+name: "Documentation: Test deployment"
+
+on:
+  pull_request:
+
+jobs:
+  test-deploy:
+    name: "Documentation: Test deployment"
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: website
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: make init
+
+      - name: Test build the documentation website
+        run: make build

--- a/.github/workflows/documentation-test-deploy.yml
+++ b/.github/workflows/documentation-test-deploy.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+          cache-dependency-path: 'website/package-lock.json'
 
       - name: Install dependencies
         run: make init

--- a/website/Makefile
+++ b/website/Makefile
@@ -10,7 +10,7 @@ init: ## Installs dependencies
 
 .PHONY: run
 run: ## Starts the development server
-	npm start
+	npm run start
 
 .PHONY: clean
 clean: ## Deletes the generated content and node_modules
@@ -19,7 +19,7 @@ clean: ## Deletes the generated content and node_modules
 
 .PHONY: build
 build: ## Compiles the documentation into static content
-	npm build
+	npm run build
 
 .PHONY: deploy
 deploy: ## Renders and deploys the documentation to https://lansuite.github.io/lansuite/


### PR DESCRIPTION
## Context

In https://github.com/lansuite/lansuite/pull/613 we updated the documentation page on how to deploy the documentation manually.

This Pull Request automates the whole story:

* On each PR, the documentation gets built (to verify that everything is working)
* On each merge into `master`, the documentation gets built and deployed to the `gh-pages` branch

This way we

* have basic quality control to ensure the documentation website is working
* have always the latest documentation up to date

The GitHub actions are copied from the Docusaurus documentation: [Triggering deployment with GitHub Actions](https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions)

## Dependencies

This PR depends on https://github.com/lansuite/lansuite/pull/613
https://github.com/lansuite/lansuite/pull/613 need to be merged first.