### PR TITLE
Debug: Fix "Access to an undefined property"

### DIFF
--- a/inc/Classes/Debug.php
+++ b/inc/Classes/Debug.php
@@ -70,6 +70,16 @@ class Debug
     private bool $sql_query_running = false;
 
     /**
+     * Microtime on the start of the measurement.
+     */
+    private float $sql_query_start;
+
+    /**
+     * Query that gets measured.
+     */
+    private string $sql_query_string;
+
+    /**
      * Debug constructor.
      *
      * @param string $mode          0 = off, 1 = normal, 2 = file


### PR DESCRIPTION
PHPStan is reporting

```
------ --------------------------------------------------------------------------------------
  Line   Classes/Debug.php
 ------ --------------------------------------------------------------------------------------
  167    Access to an undefined property LanSuite\Debug::$sql_query_start.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  168    Access to an undefined property LanSuite\Debug::$sql_query_string.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  181    Access to an undefined property LanSuite\Debug::$sql_query_start.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  181    Access to an undefined property LanSuite\Debug::$sql_query_string.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ --------------------------------------------------------------------------------------
```

This will lead to errors with PHP8 as well.