### PR TITLE
Func: Fix "Access to an undefined property" and undefined class LanSuite\GesHi

### DIFF
--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -5,6 +5,11 @@ namespace LanSuite;
 class Func
 {
     /**
+     * HTTP referer
+     */
+    public string $internal_referer;
+
+    /**
      * @var array
      */
     public $ActiveModules = [];
@@ -496,8 +501,8 @@ class Func
                         function ($treffer) {
                             global $HighlightCode, $HighlightCount2;
                             $HighlightCount2++;
-                            $geshi = new GeSHi($HighlightCode[$HighlightCount2], 'php');
-                            $geshi->set_header_type(GESHI_HEADER_NONE);
+                            $geshi = new \GeSHi($HighlightCode[$HighlightCount2], 'php');
+                            $geshi->set_header_type(\GESHI_HEADER_NONE);
                             return '
                                 <blockquote>
                                     <div class="tbl_small">Code:</div>


### PR DESCRIPTION
PHPStan is reporting

```
 ------ --------------------------------------------------------------------------------------
  Line   Classes/Func.php
 ------ --------------------------------------------------------------------------------------
  17     Access to an undefined property LanSuite\Func::$internal_referer.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  247    Access to an undefined property LanSuite\Func::$internal_referer.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  324    Access to an undefined property LanSuite\Func::$internal_referer.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  499    Instantiated class LanSuite\GeSHi not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  690    Access to an undefined property LanSuite\Func::$internal_referer.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ --------------------------------------------------------------------------------------
```

This will lead to errors with PHP8 as well.