### PR TITLE
MasterComment: Fix "Class LanSuite\MasterForm referenced with incorrect case"

### DIFF
--- a/inc/Classes/MasterComment.php
+++ b/inc/Classes/MasterComment.php
@@ -79,9 +79,9 @@ class MasterComment
                 $mf = new MasterForm();
                 $mf->LogID = $id;
 
-                $mf->AddField(t('Kommentar'), 'text', '', masterform::LSCODE_BIG);
+                $mf->AddField(t('Kommentar'), 'text', '', MasterForm::LSCODE_BIG);
                 if (!$auth['login']) {
-                    $mf->AddField('', 'captcha', masterform::IS_CAPTCHA);
+                    $mf->AddField('', 'captcha', MasterForm::IS_CAPTCHA);
                 }
 
                 $mf->AddFix('relatedto_item', $mod);


### PR DESCRIPTION
PHPStan reports

```
  ------ --------------------------------------------------------------------------------
  Line   Classes/MasterComment.php
 ------ --------------------------------------------------------------------------------
  82     Class LanSuite\MasterForm referenced with incorrect case: LanSuite\masterform.
  84     Class LanSuite\MasterForm referenced with incorrect case: LanSuite\masterform.
 ------ --------------------------------------------------------------------------------
```

This would lead to Fatal errors on case sensitive file systems (as not found class)