### PR TITLE
MasterForm: Fix "Access to an undefined property"

### DIFF
--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -144,6 +144,21 @@ class MasterForm
     private int $number = 0;
 
     /**
+     * Master form ID
+     */
+    private int $MFID;
+
+    /**
+     * Current page in pagination
+     */
+    private int $currentPage;
+
+    /**
+     * Name of a form field
+     */
+    private string $DependOnField;
+
+    /**
      * The MasterForm class deals internally with a number to handle multiple forms on one page.
      * If you are using the MasterForm class only once at the page, you can just initialize and use it.
      * If you use it multiple times, you need to increment the internal counter.


### PR DESCRIPTION
PHPStan is reporting

```
 ------ --------------------------------------------------------------------------------------
  Line   Classes/MasterForm.php
 ------ --------------------------------------------------------------------------------------
  168    Access to an undefined property LanSuite\MasterForm::$MFID.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  249    Access to an undefined property LanSuite\MasterForm::$currentPage.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  405    Access to an undefined property LanSuite\MasterForm::$MFID.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  532    Access to an undefined property LanSuite\MasterForm::$DependOnField.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  624    Access to an undefined property LanSuite\MasterForm::$DependOnField.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ --------------------------------------------------------------------------------------
```

In PHP8 this is leading to additional warnings.