### PR TITLE
Modules/Paypal: Fix "constructor invoked with 0 parameters, 2 required"

### DIFF
--- a/modules/paypal/executepayment.php
+++ b/modules/paypal/executepayment.php
@@ -30,7 +30,10 @@ if ($auth['userid'] == 0 && $cfg['paypal_donation'] == 0) {
                             break;
                         default:
                             $data = SKUtoParty($item->sku);
-                            $GuestList = new \LanSuite\Module\Guestlist\GuestList();
+                            $seating = new \LanSuite\Module\Seating\Seat2();
+                            $mail = new \LanSuite\Module\Mail\Mail();
+                            $userManager = new \LanSuite\Module\UsrMgr\UserManager($mail);
+                            $GuestList = new \LanSuite\Module\GuestList\GuestList($seating, $userManager);
                             $GuestList->SetPaid($auth['userid'], $data['party_id']);
                             break;
                     }


### PR DESCRIPTION
PHPStan is reporting

```
  ------ ----------------------------------------------------------------------------------------------------------------
  Line   paypal/executepayment.php
 ------ ----------------------------------------------------------------------------------------------------------------
  33     Class LanSuite\Module\GuestList\GuestList constructor invoked with 0 parameters, 2 required.
  33     Class LanSuite\Module\GuestList\GuestList referenced with incorrect case: LanSuite\Module\Guestlist\GuestList.
 ------ ----------------------------------------------------------------------------------------------------------------
```

This would be a PHP8 Fatal error.