### PR TITLE
Modules/Troubleticket: Fix "Cannot use [] for reading"

### DIFF
--- a/modules/troubleticket/add.php
+++ b/modules/troubleticket/add.php
@@ -53,7 +53,7 @@ switch ($_GET["step"]) {
             $t_cat_array[] = "<option value=\"0\">".t('Bitte Auswählen')."</option>";
             
             while ($row = $db->fetch_array($t_cat)) {
-                $t_cat_array[] .= "<option value=\"{$row['cat_id']}\">{$row['cat_text']}</option>";
+                $t_cat_array[] = "<option value=\"{$row['cat_id']}\">{$row['cat_text']}</option>";
             }
             
             $dsp->AddDropDownFieldRow("tticket_cat", t('Kategorie'), $t_cat_array, $error['tticket_cat']);

--- a/modules/troubleticket/cat.php
+++ b/modules/troubleticket/cat.php
@@ -25,7 +25,7 @@ switch ($_GET['step']) {
             $t_cat_array[] = "<option value=\"0\">".t('Bitte Auswählen')."</option>";
             
             while ($row = $db->fetch_array($t_cat)) {
-                $t_cat_array[] .= "<option value=\"{$row['cat_id']}\">{$row['cat_text']}</option>";
+                $t_cat_array[] = "<option value=\"{$row['cat_id']}\">{$row['cat_text']}</option>";
             }
 
             $dsp->SetForm("index.php?mod=troubleticket&action=cat&act=change&step=2");
@@ -44,16 +44,16 @@ switch ($_GET['step']) {
         $user_row = $db->qry('SELECT * FROM %prefix%user WHERE type > 1');
     
         if (isset($_POST["tticket_cat"]) && $_POST["tticket_cat"] > 0) {
-            $user_row_option[] .= "<option value=\"0\">".t('Kein zuständiger Admin')."</option>";
+            $user_row_option[] = "<option value=\"0\">".t('Kein zuständiger Admin')."</option>";
         } else {
-            $user_row_option[] .= "<option selected value=\"0\">".t('Kein zuständiger Admin')."</option>";
+            $user_row_option[] = "<option selected value=\"0\">".t('Kein zuständiger Admin')."</option>";
         }
         
         while ($user_data = $db->fetch_array($user_row)) {
             if ($user_data["userid"] == $_POST["tticket_cat"] && isset($_POST["tticket_cat"])) {
-                $user_row_option[] .= "<option selected value=\"{$user_data["userid"]}\">{$user_data["username"]}</option>";
+                $user_row_option[] = "<option selected value=\"{$user_data["userid"]}\">{$user_data["username"]}</option>";
             } else {
-                $user_row_option[] .= "<option value=\"{$user_data["userid"]}\">{$user_data["username"]}</option>";
+                $user_row_option[] = "<option value=\"{$user_data["userid"]}\">{$user_data["username"]}</option>";
             }
         }
         


### PR DESCRIPTION
PHPStan is reporting

```
  ------ ----------------------------
  Line   troubleticket/add.php
 ------ ----------------------------
  56     Cannot use [] for reading.
 ------ ----------------------------

 ------ ----------------------------
  Line   troubleticket/cat.php
 ------ ----------------------------
  28     Cannot use [] for reading.
  47     Cannot use [] for reading.
  49     Cannot use [] for reading.
  54     Cannot use [] for reading.
  56     Cannot use [] for reading.
 ------ ----------------------------
```

Array assignments are treated like string concats.