### PR TITLE
Modules/Discord: Fix "Undefined variable: $disordServerId"

### DIFF
--- a/modules/discord/Classes/Discord.php
+++ b/modules/discord/Classes/Discord.php
@@ -32,7 +32,7 @@ class Discord
         } else {
             //Check if server id was passed via constructor, use configuration value otherwise
             if ($discordServerId!='') {
-                $this->discordServerId = $disordServerId;
+                $this->discordServerId = $discordServerId;
             } elseif (isset($cfg['discord_server_id'])) {
                 $this ->discordServerId =  $cfg['discord_server_id'];
             } else {


### PR DESCRIPTION
PHPStan reports

```
 ------ -------------------------------------
  Line   discord/Classes/Discord.php
 ------ -------------------------------------
  35     Undefined variable: $disordServerId
 ------ -------------------------------------
```

There is a typo in the constructor variable.