### PR TITLE
Modules/Bugtracker: Wrong reference for Mail class

### DIFF
--- a/modules/bugtracker/Classes/Bugtracker.php
+++ b/modules/bugtracker/Classes/Bugtracker.php
@@ -51,7 +51,7 @@ class Bugtracker
 
         $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE state = %int% AND bugid = %int%", $state, $bugid);
         if (!$row['found']) {
-            $mail = new Lansuite\Module\Mail\Mail();
+            $mail = new \LanSuite\Module\Mail\Mail();
 
             $db->qry("UPDATE %prefix%bugtracker SET state = %int% WHERE bugid = %int%", $state, $bugid);
             $func->log_event(t('Bugreport auf Status "%1" geändert', array($this->stati[$state])), 1, '', $bugid);


### PR DESCRIPTION
The Mail class in the Bugtracker module gets referenced wrong and can't be found on file systems that are case sensitive.