### PR TITLE
Modules/Cashmanager: Fix "Cannot use [] for reading"

### DIFF
--- a/modules/cashmgr/show.php
+++ b/modules/cashmgr/show.php
@@ -12,12 +12,12 @@ if (!$_GET['step']) {
             break;
     
         case 3:
-            $dia_quest[] .= t('Party Kalkulation')    ;
-            $dia_quest[] .= t('Fremder Kontoauszug');
-            $dia_quest[] .= t('Eigener Kontoauszug');
-            $dia_link[]     .= "index.php?mod=cashmgr&action=show&step=1";
-            $dia_link[]     .= "index.php?mod=cashmgr&action=myaccounting&act=him";
-            $dia_link[]     .= "index.php?mod=cashmgr&action=myaccounting";
+            $dia_quest[] = t('Party Kalkulation')    ;
+            $dia_quest[] = t('Fremder Kontoauszug');
+            $dia_quest[] = t('Eigener Kontoauszug');
+            $dia_link[] = "index.php?mod=cashmgr&action=show&step=1";
+            $dia_link[] = "index.php?mod=cashmgr&action=myaccounting&act=him";
+            $dia_link[] = "index.php?mod=cashmgr&action=myaccounting";
             $func->multiquestion($dia_quest, $dia_link, "");
             break;
     }


### PR DESCRIPTION
PHPStan is reporting

```
  ------ ----------------------------
  Line   cashmgr/show.php
 ------ ----------------------------
  15     Cannot use [] for reading.
  16     Cannot use [] for reading.
  17     Cannot use [] for reading.
  18     Cannot use [] for reading.
  19     Cannot use [] for reading.
  20     Cannot use [] for reading.
 ------ ----------------------------
```

Array assignments are treated like string concatenations.