### PR TITLE
Modules/FAQ: Fix "Cannot use [] for reading"

### DIFF
--- a/modules/faq/add_item.php
+++ b/modules/faq/add_item.php
@@ -59,7 +59,7 @@ switch ($_GET["step"]) {
         $faq_cats[] = "<option selected value=\"0\"> ".t('Kategorie wählen')." </option>";
 
         while ($row=$db->fetch_array($get_cats)) {
-            $faq_cats[] .= "<option value=" . $row["catid"] . "> " . $row["name"] . " </option>";
+            $faq_cats[] = "<option value=" . $row["catid"] . "> " . $row["name"] . " </option>";
         }
 
         $dsp->AddTextFieldRow("question_caption", t('Frage / Überschrift'), $_POST['question_caption'], $faq_error['question_caption']);

--- a/modules/faq/change_item.php
+++ b/modules/faq/change_item.php
@@ -76,7 +76,7 @@ switch ($_GET["step"]) {
             while ($row=$db->fetch_array($get_cats)) {
                 $selected=($row["catid"] == $_POST["question_cat"]) ? "selected" : "";
 
-                $faq_cats[] .= "<option $selected value=" . $row["catid"] . "> " . $row["name"] . " </option>";
+                $faq_cats[] = "<option $selected value=" . $row["catid"] . "> " . $row["name"] . " </option>";
             }
 
             $dsp->AddTextFieldRow("question_caption", t('Frage / Überschrift'), $_POST['question_caption'], $faq_error['question_caption']);


### PR DESCRIPTION
PHPStan reports

```
  ------ ----------------------------
  Line   faq/add_item.php
 ------ ----------------------------
  62     Cannot use [] for reading.
 ------ ----------------------------

  ------ ----------------------------
  Line   faq/change_item.php
 ------ ----------------------------
  79     Cannot use [] for reading.
 ------ ----------------------------
```

Array assignments are treated like string concatenations.