### PR TITLE
Modules/NOC: Fix "Cannot use [] for reading"

### DIFF
--- a/modules/noc/class_noc.php
+++ b/modules/noc/class_noc.php
@@ -123,9 +123,9 @@ class noc
         foreach ($walkvalue as $value) {
             if (stristr($value, ":")) {
                 $tmp = explode(":", $value);
-                $data[] .= trim($tmp[1]);
+                $data[] = trim($tmp[1]);
             } else {
-                $data[] .= trim($value);
+                $data[] = trim($value);
             }
         }
         


### PR DESCRIPTION
PHPStan reports

```
  ------ ----------------------------
  Line   noc/class_noc.php
 ------ ----------------------------
  126    Cannot use [] for reading.
  128    Cannot use [] for reading.
 ------ ----------------------------
```

These treats array assignments as string concatenations.