### PR TITLE
Modules/PDF: Fix "Cannot use [] for reading"

### DIFF
--- a/modules/pdf/Classes/PDF.php
+++ b/modules/pdf/Classes/PDF.php
@@ -237,9 +237,9 @@ class PDF
         $data[] = [];
         foreach ($this->data_type_array[$action] as $key => $value) {
             if ($key == $selected) {
-                $data[] .= "<option selected value=\"$key\">$value</option>";
+                $data[] = "<option selected value=\"$key\">$value</option>";
             } else {
-                $data[] .= "<option value=\"$key\">$value</option>";
+                $data[] = "<option value=\"$key\">$value</option>";
             }
         }
 


### PR DESCRIPTION
PHPStan reports

```
  ------ ----------------------------
  Line   pdf/Classes/PDF.php
 ------ ----------------------------
  240    Cannot use [] for reading.
  242    Cannot use [] for reading.
 ------ ----------------------------
```

