### PR TITLE
GitHub Actions: Label Pull Requests if they have a merge conflict

### DIFF
--- a/.github/workflows/label-pr-conflicts.yml
+++ b/.github/workflows/label-pr-conflicts.yml
@@ -1,0 +1,21 @@
+name: Auto-label merge conflicts
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@v2.0
+        with:
+          CONFLICT_LABEL_NAME: conflicts
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Context

We can leverage Pull Request labels to indicate which Pull Request is having a merge conflict right now.
This helps with looking at the PRs and knowing "this needs some work".

## New automation

This Pull Request adds new automation to label a PR once something has merged to master automatically.