### PR TITLE
Database/MySQL: Add new class with first class Prepared Statement support

### DIFF
--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -2,6 +2,14 @@
 
 namespace LanSuite;
 
+/**
+ * Old Database implementation.
+ *
+ * Please use the new database implementation Database()
+ * See Database.php
+ *
+ * @deprecated
+ */
 class DB
 {
     private \mysqli|bool|null $link_id = null;

--- a/inc/Classes/Database.php
+++ b/inc/Classes/Database.php
@@ -134,30 +134,18 @@ class Database
      * 
      * $query => The SQL statement.
      * 
-     * $parameterTypes => Parameter types:
-     *      i	corresponding variable has type int
-     *      d	corresponding variable has type float
-     *      s	corresponding variable has type string
-     *      b	corresponding variable is a blob and will be sent in packets
-     *      See https://www.php.net/manual/en/mysqli-stmt.bind-param
-     * 
      * $parameterValues => The values for the query.
-     *      Attention: Need to be in the same order as $parameterTypes.
      * 
      * TODO: Implement debug time measurement (with query_start and query_stop)
      */
-    public function query(string $query, string $parameterTypes = '', array $parameterValues = []): \mysqli_stmt
+    public function query(string $query, array $parameterValues = []): \mysqli_stmt
     {
         // Replace table prefix
         $query = str_replace('%prefix%', $this->tablePrefix, $query);
 
         $statement = $this->database->prepare($query);
-        if (count($parameterValues) > 0) {
-            $statement->bind_param($parameterTypes, ...$parameterValues);
-        }
-
         // Will throw an exception in the case of failure.
-        $statement->execute();
+        $statement->execute($parameterValues);
 
         return $statement;
     }
@@ -168,9 +156,9 @@ class Database
      * 
      * In case of an empty result, an empty array is returned.
      */
-    public function queryWithFullResult(string $query, string $parameterTypes = '', array $parameterValues = []): array
+    public function queryWithFullResult(string $query, array $parameterValues = []): array
     {
-        $statement = $this->query($query, $parameterTypes, $parameterValues);
+        $statement = $this->query($query, $parameterValues);
         $queryResult = $this->getStatementResult($statement);
 
         if (!$queryResult) {
@@ -195,9 +183,9 @@ class Database
      * 
      * In case of an empty result, an empty array is returned.
      */
-    public function queryWithOnlyFirstRow(string $query, string $parameterTypes = '', array $parameterValues = []): array
+    public function queryWithOnlyFirstRow(string $query, array $parameterValues = []): array
     {
-        $statement = $this->query($query, $parameterTypes, $parameterValues);
+        $statement = $this->query($query, $parameterValues);
         $queryResult = $this->getStatementResult($statement);
 
         if (!$queryResult) {

--- a/inc/Classes/Database.php
+++ b/inc/Classes/Database.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace LanSuite;
+
+/**
+ * Database connection implementation.
+ * Uses prepared statements by default via the MySQLi engine.
+ */
+class Database
+{
+    /**
+     * Database hostname
+     */
+    private string $host = '';
+
+    /**
+     * Database port
+     */
+    private int $port = 3306;
+
+    /**
+     * Username of the database user
+     */
+    private string $username = '';
+
+    /**
+     * Password of the database user.
+     * See $this->$username.
+     */
+    private string $password = '';
+
+    /**
+     * Name of the database we will connect to
+     */
+    private string $databaseName = '';
+
+    /**
+     * Charset we set for the connection
+     */
+    private string $charset = '';
+
+    /**
+     * Database object
+     */
+    private ?\mysqli $database = null;
+
+    /**
+     * Database table prefix
+     */
+    private string $tablePrefix = '';
+
+    public function __construct($host, $port, $username, $password, $databaseName, $charset) {
+        $this->host = $host;
+        $this->port = $port;
+        $this->username = $username;
+        $this->password = $password;
+        $this->databaseName = $databaseName;
+        $this->charset = $charset;
+    }
+
+    /**
+     * Connects to the database
+     */
+    public function connect(): bool
+    {
+        // Set MySQL to throw exceptions.
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+        $this->database = new \mysqli($this->host, $this->username, $this->password, $this->databaseName, $this->port);
+
+        // We don't need to check if the connection was successful.
+        // If it is _not_ successful, an exception will be thrown.
+    
+        $this->setCharset($this->charset);
+
+        return true;
+    }
+
+    /**
+     * Sets the table prefix.
+     */
+    public function setTablePrefix(string $tablePrefix): void
+    {
+        $this->tablePrefix = $tablePrefix;
+    }
+
+    /**
+     * Sets the database charset.
+     * 
+     * See https://www.php.net/manual/en/mysqli.set-charset.php
+     * See https://www.php.net/manual/en/mysqlinfo.concepts.charset.php
+     */
+    public function setCharset($charset): void
+    {
+        if ($charset) {
+            $this->database->set_charset($charset);
+        }
+    }
+
+    /**
+     * Returns a string representing the type of connection used
+     */
+    public function getHostInfo(): string
+    {
+        return $this->database->host_info;
+    }
+
+    /**
+     * Closes a previously opened database connection
+     */
+    public function disconnect(): bool
+    {
+        return $this->database->close();
+    }
+
+    /**
+     * Get MySQL client info
+     */
+    public function getClientInfo(): string
+    {
+        return $this->database->client_info;
+    }
+
+    /**
+     * Returns the version of the MySQL server
+     */
+    public function getServerInfo(): string
+    {
+        return $this->database->server_info;
+    }
+
+    /**
+     * Executes a query (in a prepared statement style).
+     * 
+     * $query => The SQL statement.
+     * 
+     * $parameterTypes => Parameter types:
+     *      i	corresponding variable has type int
+     *      d	corresponding variable has type float
+     *      s	corresponding variable has type string
+     *      b	corresponding variable is a blob and will be sent in packets
+     *      See https://www.php.net/manual/en/mysqli-stmt.bind-param
+     * 
+     * $parameterValues => The values for the query.
+     *      Attention: Need to be in the same order as $parameterTypes.
+     * 
+     * TODO: Implement debug time measurement (with query_start and query_stop)
+     */
+    public function query(string $query, string $parameterTypes = '', array $parameterValues = []): \mysqli_stmt
+    {
+        // Replace table prefix
+        $query = str_replace('%prefix%', $this->tablePrefix, $query);
+
+        $statement = $this->database->prepare($query);
+        if (count($parameterValues) > 0) {
+            $statement->bind_param($parameterTypes, ...$parameterValues);
+        }
+
+        // Will throw an exception in the case of failure.
+        $statement->execute();
+
+        return $statement;
+    }
+
+    /**
+     * Executes $query as prepared statement and returns
+     * the full result as an array.
+     * 
+     * In case of an empty result, an empty array is returned.
+     */
+    public function queryWithFullResult(string $query, string $parameterTypes = '', array $parameterValues = []): array
+    {
+        $statement = $this->query($query, $parameterTypes, $parameterValues);
+        $queryResult = $this->getStatementResult($statement);
+
+        if (!$queryResult) {
+            return [];
+        }
+
+        $data = [];
+        while ($row = $queryResult->fetch_assoc()) {
+            $data[] = $row;
+        }
+
+        // Cleanup
+        $this->freeResult($queryResult);
+        $this->closeStatement($statement);
+
+        return $data;
+    }
+
+    /**
+     * Executes $query as prepared statement and returns
+     * only the first row.
+     * 
+     * In case of an empty result, an empty array is returned.
+     */
+    public function queryWithOnlyFirstRow(string $query, string $parameterTypes = '', array $parameterValues = []): array
+    {
+        $statement = $this->query($query, $parameterTypes, $parameterValues);
+        $queryResult = $this->getStatementResult($statement);
+
+        if (!$queryResult) {
+            return [];
+        }
+
+        $row = $queryResult->fetch_assoc();
+
+        // Cleanup
+        $this->freeResult($queryResult);
+        $this->closeStatement($statement);
+
+        return $row;
+    }
+
+    /**
+     * Returns the total number of rows changed, deleted, inserted, or matched by the last statement executed
+     */
+    public function getStatementAffectedRows(\mysqli_stmt $statement): int|string
+    {
+        return $statement->affected_rows;
+    }
+
+    /**
+     * Get the ID generated from the previous INSERT operation
+     */
+    public function getStatementInsertID(\mysqli_stmt $statement): int|string
+    {
+        return $statement->insert_id;
+    }
+
+    /**
+     * Gets a result set from a prepared statement as a mysqli_result object
+     */
+    public function getStatementResult(\mysqli_stmt $statement): \mysqli_result|bool
+    {
+        return $statement->get_result();
+    }
+
+    /**
+     * Closes a prepared statement
+     */
+    public function closeStatement(\mysqli_stmt $statement): bool
+    {
+        return $statement->close();
+    }
+
+    /**
+     * Gets the number of rows in the result set
+     */
+    public function getResultNumRows(\mysqli_result $result): int|string
+    {
+        return $result->num_rows;
+    }
+
+    /**
+     * Frees the memory associated with a result
+     */
+    public function freeResult(\mysqli_result $result): void
+    {
+        $result->free();
+    }
+}

--- a/index.php
+++ b/index.php
@@ -41,11 +41,12 @@ if (!$configCache->isHit() || $request->query->get('mod') == 'install') {
         $config['lansuite']['debugmode'] = '0';
 
         $config['database']['server'] = 'localhost';
+        $config['database']['dbport'] = 3306;
         $config['database']['user'] = 'root';
         $config['database']['passwd'] = '';
         $config['database']['database'] = 'lansuite';
         $config['database']['prefix'] = 'ls_';
-        $config['database']['charset'] = 'utf8';
+        $config['database']['charset'] = 'utf8mb4';
 
         $config['environment']['configured'] = 0;
     }

--- a/index.php
+++ b/index.php
@@ -200,8 +200,27 @@ $ms_number = 0;
 // Display Functions (to load the lansuite-templates)
 $dsp = new \LanSuite\Display();
 
-// DB Functions (to work with the databse)
+// DB Functions (to work with the database)
+// TODO Remove the "old" database class, once everything is migrated to the new one (see below)
 $db = new \LanSuite\DB();
+
+// Loading the new database class with standard support for prepared statements.
+$database = new \LanSuite\Database(
+    $config['database']['server'],
+    $config['database']['dbport'] ?? 3306,
+    $config['database']['user'],
+    $config['database']['passwd'],
+    $config['database']['database'],
+    $config['database']['charset'] ?? 'utf8mb4'
+);
+try {
+    $database->connect();
+    $database->setTablePrefix($config['database']['prefix']);
+} catch(\mysqli_sql_exception $e) {
+    $databaseError = $e->getMessage() . ' (' . $e->getCode() . ')';
+    echo HTML_FONT_ERROR . t('Die Verbindung zur Datenbank ist fehlgeschlagen. LanSuite wird abgebrochen. Zurückgegebener MySQL-Fehler: ' . $databaseError) . HTML_FONT_END;
+    exit();
+}
 
 // Security Functions (to lock pages)
 $sec = new \LanSuite\Security();

--- a/modules/news/comment.php
+++ b/modules/news/comment.php
@@ -1,7 +1,8 @@
 <?php
 
 // Check if news id is valid
-$check = $db->qry_first('SELECT caption FROM %prefix%news WHERE newsid = %int%', $_GET['newsid']);
+$newsQuery = 'SELECT caption FROM %prefix%news WHERE newsid = ?';
+$check = $database->queryWithOnlyFirstRow($newsQuery, 'i', [$_GET['newsid']]);
 if ($check["caption"] != "") {
     $framework->AddToPageTitle($check["caption"]);
     $func->SetRead('news', $_GET['newsid']);

--- a/modules/news/comment.php
+++ b/modules/news/comment.php
@@ -2,7 +2,7 @@
 
 // Check if news id is valid
 $newsQuery = 'SELECT caption FROM %prefix%news WHERE newsid = ?';
-$check = $database->queryWithOnlyFirstRow($newsQuery, 'i', [$_GET['newsid']]);
+$check = $database->queryWithOnlyFirstRow($newsQuery, [$_GET['newsid']]);
 if ($check["caption"] != "") {
     $framework->AddToPageTitle($check["caption"]);
     $func->SetRead('news', $_GET['newsid']);

--- a/modules/news/plugins/home.php
+++ b/modules/news/plugins/home.php
@@ -22,7 +22,7 @@ $query = '
   GROUP BY n.newsid
   ORDER BY n.top DESC, date DESC
   LIMIT 0, ?';
-$newsResult = $database->queryWithFullResult($query, 'i', [$cfg['home_item_cnt_news']]);
+$newsResult = $database->queryWithFullResult($query, [$cfg['home_item_cnt_news']]);
 if (count($newsResult) > 0) {
     foreach($newsResult as $row) {
         $page = floor(($row['comments'] - 1) / 20);

--- a/modules/news/plugins/home.php
+++ b/modules/news/plugins/home.php
@@ -3,7 +3,7 @@
 $smarty->assign('caption', t('Aktuelle News') . ' <span class="small">[<a href="ext_inc/newsfeed/news.xml" class="menu" title="XML Newsfeed">RSS</a>]</span>');
 $content = '';
 
-$query = $db->qry("
+$query = '
   SELECT
     n.newsid,
     n.caption,
@@ -15,16 +15,16 @@ $query = $db->qry("
     LEFT JOIN %prefix%comments AS c ON (
       c.relatedto_id = n.newsid
       AND (
-        c.relatedto_item = 'news'
+        c.relatedto_item = "news"
         OR c.relatedto_item IS NULL
       )
     )
   GROUP BY n.newsid
   ORDER BY n.top DESC, date DESC
-  LIMIT 0,%int%", $cfg['home_item_cnt_news']);
-
-if ($db->num_rows($query) > 0) {
-    while ($row = $db->fetch_array($query)) {
+  LIMIT 0, ?';
+$newsResult = $database->queryWithFullResult($query, 'i', [$cfg['home_item_cnt_news']]);
+if (count($newsResult) > 0) {
+    foreach($newsResult as $row) {
         $page = floor(($row['comments'] - 1) / 20);
         $smarty->assign('link', "index.php?mod=board&action=thread&tid={$row['tid']}&posts_page={$page}#pid{$row['pid']}");
 


### PR DESCRIPTION
## Context

This PR adds a new class `Database()` and deprecates the old class `DB()`.
The new class has first-class support for prepared statements. Primarily to support the security efforts and protect us against SQL Injections. Furthermore, is this considered best practice in software engineering.

This implementation is based on MySQLi, which is already required for LanSuite.

In this PR, there are also two example queries implemented in the News module to showcase a possible usage.

## Design choices

* The new class is not backward compatible / not a drop-in replacement - It is meant to be as a step-by-step migration to replace the old `DB()` class over time
* The new class does not support things like `print_error()` or debug capabilities (like adding the records to `log` table - Primarily because 
* The new class does not implement ALL functions of the previous one yet. `mysqli_fetch_array`is missing. The reason: We should prefer working with `assoc()` functions due to a more readable code by accessing the fields by name rather than number (0, 1, ...) - Assoc function is implemented in the new Database class
* The new class does not implement ALL functions of the previous one yet. `mysqli_fetch_field_direct` is missing. The reason: This will be implemented once the function is needed (during migration)
* The new class does not escape any values like the previous one (e.g. via `$func->NoHTML`). The reason: The class itself does not know in which context the value is used. Depending on the context (HTML, CSS, JS, ...) the value need a different type of escaping
* The new class has no external (global) dependencies like `$auth`, `$func`, ... - This makes it easy to re-use and test
* The new class throws PHP Exceptions rather than returning an error via string - The caller (code that uses the database class) should handle the error

## TODO

* Writing unit tests

## Open Questions

1. Debug/Timing query measurement: Do we need it? If yes, I can take this and implement this in an additional PR (to not blow this one up)
2. Error reporting in the `log` table: Do we need it? If yes, I can take this and implement this in an additional PR (to not blow this one up)

## MySQLi vs. PDO

This implementation uses MySQLi.
PDO (https://www.php.net/manual/en/pdo.prepare.php) supports named parameters.
It is brought up here: https://github.com/lansuite/lansuite/pull/488#issuecomment-1570177788
Especially in long queries, naming can help a lot.

Queries with named parameters can look like
```php
$sql = 'SELECT name, colour, calories
    FROM fruit
    WHERE calories < :calories AND colour = :colour';
```

vs (now):

```php
$sql = 'SELECT name, colour, calories
    FROM fruit
    WHERE calories < ? AND colour = ?';
```

I am also happy to implement this as PDO / with named parameters.
Let me know what you think. (/cc @M4LuZ)

## Possible next steps

* Getting a first review on this Pull Request - If there is a positive feedback, I can move on and implement the unit tests