### PR TITLE
Translation: Rework Translation class with typing, documentation and a smaller Interface

### DIFF
--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -412,12 +412,12 @@ class Translation
 
     /**
      * Get the file path for a language file.
-     * Path for System/DB and modules are different.
+     * Path for "System"/"DB" and modules are different.
      *
-     * @param string    $module     Module name (System, DB, Module ...)
+     * @param string    $module     Module name ("System", "DB", Module of choice)
      * @return string
      */
-    private function get_trans_filename($module)
+    private function get_trans_filename(string $module): string
     {
         $file = match ($module) {
             'System', 'DB' => 'inc/language/' . $module . '_' . $this->transfile_name,

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -134,14 +134,7 @@ class Translation
             ORDER BY FIELD(`file`, \'System,DB,'. $module .'\')', $module);
 
         while ($row = $db->fetch_array($res, 0)) {
-            if ($row[$this->language] != '') {
-                if (!array_key_exists($module, $this->lang_cache)) {
-                    $this->lang_cache[$module] = [];
-                }
-                if (!array_key_exists($row['id'], $this->lang_cache[$module]) || $this->lang_cache[$module][$row['id']] == '') {
-                    $this->lang_cache[$module][$row['id']] = $row[$this->language];
-                }
-            }
+            $this->setLangCacheEntry($module, $row['id'], $row[$this->language]);
         }
     }
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -206,26 +206,25 @@ class Translation
     }
 
     /**
-     * Get the translation from database via hashcode
+     * Replaces parameters from $input (%1, %2, %3, ...) with the content from $parameters at the same spot.
      *
-     * @param string    $input          Text with placeholders (blabla %1 bla %2)
-     * @param array     $parameters     Parameters
+     * @param string    $input          Text with placeholders (random text %1 here %2)
+     * @param array     $parameters     Parameters that will replace %1, %2, ...
      * @param string    $key
      * @return string                   Text with inserted Parameters
      */
-    public function ReplaceParameters($input, $parameters = null, $key = null)
+    public function ReplaceParameters(string $input, array $parameters = null, string $key = null): string
     {
         global $cfg, $auth;
 
-        $z = 1;
-        if ($parameters) {
-            foreach ($parameters as $parameter) {
-                $input = str_replace('%' . $z, $parameter, $input);
-                $z++;
-            }
+        $i = 1;
+        foreach ($parameters as $parameter) {
+            $input = str_replace('%' . $i, $parameter, $input);
+            $i++;
         }
 
-        if ($key && (is_array($auth) && $auth['type'] >= 2) && $cfg['show_translation_links']) {
+        if ($key && (is_array($auth) && $auth['type'] >= \LS_AUTH_TYPE_ADMIN) && $cfg['show_translation_links']) {
+            // TODO Check if this link works at all. We don't have a module with the name "misc"
             $input .= ' <a href=index.php?mod=misc&action=translation&step=40&id='. $key .'><img src=design/images/icon_translate.png height=10 width=10 border=0></a>';
         }
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -13,6 +13,12 @@ class Translation
     private string $language = 'de';
 
     /**
+     * Default language.
+     * Will be used in cases where an invalid language was selected.
+     */
+    private string $defaultLanguage = 'de';
+
+    /**
      * Basename of the translation file
      */
     private string $transfile_name = 'translation.xml';
@@ -76,13 +82,19 @@ class Translation
     }
 
     /**
-     * Select and set the global language
+     * Selects and set the global language.
+     * The selection process happens based on a priority list:
+     *  1. POST
+     *  2. GET
+     *  3. SESSION
+     *  4. Database selection
+     *  5. Default language
      *
-     * Returns a valid language selected by the user
+     * Returns a valid language selected by the user.
      *
      * @return string
      */
-    public function get_lang()
+    public function get_lang(): string
     {
         global $cfg;
 
@@ -100,12 +112,12 @@ class Translation
             $this->language = $cfg['sys_language'];
 
         } else {
-            $this->language = 'de';
+            $this->language = $this->defaultLanguage;
         }
 
         // Protect from bad code/injections
         if (!in_array($this->language, $this->valid_lang)) {
-            $this->language = 'de';
+            $this->language = $this->defaultLanguage;
         }
 
         return $this->language;

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -313,8 +313,7 @@ class Translation
             $entry = $xml->write_tag('id', $row['id'], 4);
             $entry .= $xml->write_tag('org', $row['org'], 4);
 
-            $languagesToAdd = ['de', 'en', 'es', 'fr', 'nl', 'it'];
-            foreach ($languagesToAdd as $languageShort) {
+            foreach ($this->valid_lang as $languageShort) {
                 if ($row[$languageShort] != '') {
                     $entry .= $xml->write_tag($languageShort, $row[$languageShort], 4);
                 }
@@ -344,8 +343,7 @@ class Translation
             $entry = $xml->write_tag('id', $row['id'], 4);
             $entry .= $xml->write_tag('org', $row['org'], 4);
 
-            $languagesToAdd = ['de', 'en', 'es', 'fr', 'nl', 'it'];
-            foreach ($languagesToAdd as $languageShort) {
+            foreach ($this->valid_lang as $languageShort) {
                 if ($row[$languageShort] != '') {
                     $entry .= $xml->write_tag($languageShort, $row[$languageShort], 4);
                 }

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -139,21 +139,17 @@ class Translation
     }
 
     /**
-     * Load translations from XML-file into memory
+     * Load translations for a module from XML-file into memory
      *
-     * @param string    $module     Module name or DB / System
+     * @param string    $module     Module name or "DB" / "System"
      * @return void
      */
-    private function load_cache_byfile($module)
+    private function load_cache_byfile(string $module): void
     {
         $xmldata = $this->xml_read_to_array($module);
         if (is_array($xmldata)) {
             foreach ($xmldata as $data) {
-                $text = '';
-                if (isset($data[$this->language])) {
-                    $text = $data[$this->language];
-                }
-
+                $text = $data[$this->language] ?? '';
                 $this->setLangCacheEntry($module, $data['id'], $text);
             }
         }

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -211,7 +211,7 @@ class Translation
      * @param string        $key
      * @return string                       Text with inserted Parameters
      */
-    public function ReplaceParameters(string $input, array $parameters = null, string $key = null): string
+    public function ReplaceParameters(string $input, array $parameters, string $key = ''): string
     {
         global $cfg, $auth;
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -178,7 +178,7 @@ class Translation
             $this->lang_cache[$module] = [];
         }
 
-        if (array_key_exists($id, $this->lang_cache[$module]) && this->lang_cache[$module][$id] != '') {
+        if (array_key_exists($id, $this->lang_cache[$module]) && $this->lang_cache[$module][$id] != '') {
             return;
         }
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -649,7 +649,7 @@ class Translation
 
         } else {
             // Try to read from DB
-            if ($this->language == 'de') {
+            if ($this->language == $this->defaultLanguage) {
                 // All texts in source are in german at the moment
                 $output = $this->ReplaceParameters($input, $parameters, $key);
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -384,15 +384,15 @@ class Translation
 
         $entries = $xml->getTagContentArray('entry', $file_cont);
         foreach ($entries as $entry) {
-            $id = $xml->getFirstTagContent('id', $entry, 1);
+            $id = $xml->getFirstTagContent('id', $entry, true);
             $records[$id]['id'] = $id;
-            $records[$id]['org'] = $xml->getFirstTagContent('org', $entry, 1);
-            $records[$id]['de'] = $xml->getFirstTagContent('de', $entry, 1);
-            $records[$id]['en'] = $xml->getFirstTagContent('en', $entry, 1);
-            $records[$id]['fr'] = $xml->getFirstTagContent('fr', $entry, 1);
-            $records[$id]['it'] = $xml->getFirstTagContent('it', $entry, 1);
-            $records[$id]['es'] = $xml->getFirstTagContent('es', $entry, 1);
-            $records[$id]['nl'] = $xml->getFirstTagContent('nl', $entry, 1);
+            $records[$id]['org'] = $xml->getFirstTagContent('org', $entry, true);
+            $records[$id]['de'] = $xml->getFirstTagContent('de', $entry, true);
+            $records[$id]['en'] = $xml->getFirstTagContent('en', $entry, true);
+            $records[$id]['fr'] = $xml->getFirstTagContent('fr', $entry, true);
+            $records[$id]['it'] = $xml->getFirstTagContent('it', $entry, true);
+            $records[$id]['es'] = $xml->getFirstTagContent('es', $entry, true);
+            $records[$id]['nl'] = $xml->getFirstTagContent('nl', $entry, true);
         }
 
         return $records;

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -44,11 +44,6 @@ class Translation
     private array $lang_cache = [];
 
     /**
-     * Is cache for module loaded (database)
-     */
-    private int $cachemod_loaded_db = 0;
-
-    /**
      * Is cache for module loaded (xml)
      */
     private int $cachemod_loaded_xml  = 0;
@@ -70,7 +65,6 @@ class Translation
         if ($mode == 'db') {
             // System is configured, Language will be loaded from DB
             $this->load_cache_bydb($akt_modul);
-            $this->cachemod_loaded_db = 1;
 
         } elseif ($mode == 'xml') {
             // System is on Install, Language will be loaded from XML

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -8,11 +8,9 @@ namespace LanSuite;
 class Translation
 {
     /**
-     * Global language
-     *
-     * @var string
+     * Global language.
      */
-    public $language = 'de';
+    private string $language = 'de';
 
     /**
      * Basename of the translation file

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -43,11 +43,6 @@ class Translation
      */
     private array $lang_cache = [];
 
-    /**
-     * Is cache for module loaded (xml)
-     */
-    private int $cachemod_loaded_xml  = 0;
-
     public function __construct()
     {
         // Read language from GET, POST & set
@@ -71,7 +66,6 @@ class Translation
             $this->load_cache_byfile('System');
             $this->load_cache_byfile('DB');
             $this->load_cache_byfile($akt_modul);
-            $this->cachemod_loaded_xml = 1;
         }
     }
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -4,6 +4,9 @@ namespace LanSuite;
 
 /**
  * Global translation
+ *
+ * TODO Implement proper caching interface
+ * TODO Implement dependency injection to remove `global` keywords
  */
 class Translation
 {

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -232,39 +232,37 @@ class Translation
     }
 
     /**
-     * Get the translation from database via hashcode
+     * Get a single translation value from database via hashcode.
      *
      * @param string    $hashkey    Hash code from original text in sourcecode
      * @param string    $module
      * @param string    $long
      * @return string
      */
-    private function get_trans_db($hashkey, $module, $long)
+    private function get_trans_db(string $hashkey, string $module, string $long): string
     {
         global $db;
 
-        if (array_key_exists($hashkey, $this->lang_cache[$module]) && $this->lang_cache[$module][$hashkey]) {
-            $translated = $this->lang_cache[$module][$hashkey];
-
-        } else {
-            $row = $db->qry_first('
-                SELECT
-                    `id`,
-                    `org`,
-                    `' . $this->language . '`
-                FROM
-                    %prefix%translation' . $long . '
-                WHERE
-                    id = %string%', $hashkey);
-
-            if (is_array($row) && $row[$this->language]) {
-                $translated = $row[$this->language];
-            } else {
-                $translated = '';
-            }
+        $entry = $this->getLangCacheEntry($module, $hashkey);
+        if ($entry) {
+            return $entry;
         }
 
-        return $translated;
+        $row = $db->qry_first('
+            SELECT
+                `id`,
+                `org`,
+                `' . $this->language . '`
+            FROM
+                %prefix%translation' . $long . '
+            WHERE
+                id = %string%', $hashkey);
+
+        if (is_array($row) && $row[$this->language]) {
+            $entry = $row[$this->language];
+        }
+
+        return $entry;
     }
 
     /**

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -39,11 +39,12 @@ class Translation
     public $valid_lang = ['de', 'en', 'es', 'fr', 'nl', 'it'];
 
     /**
-     * Temporary translations
+     * In memory translation cache.
+     * Only holds one language.
      *
      * @var array
      */
-    public $lang_cache = [];
+    private array $lang_cache = [];
 
     /**
      * Is cache for module loaded (db)

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -374,34 +374,37 @@ class Translation
     }
 
     /**
-     * Parse all language sets into an array
+     * Reads all translation from the $module XML file
+     * and returns the data.
      *
      * @param string    $module     Module name e.g. file-field
      * @return array
      */
-    private function xml_read_to_array($module)
+    private function xml_read_to_array(string $module): array
     {
         $records = [];
         $xml = new XML();
 
         $lang_file = $this->get_trans_filename($module);
-        if (file_exists($lang_file)) {
-            $xml_file = fopen($lang_file, 'r');
-            $file_cont = fread($xml_file, filesize($lang_file));
-            fclose($xml_file);
+        if (!file_exists($lang_file)) {
+            return $records;
+        }
 
-            $entries = $xml->getTagContentArray('entry', $file_cont);
-            foreach ($entries as $entry) {
-                $id = $xml->getFirstTagContent('id', $entry, 1);
-                $records[$id]['id'] = $id;
-                $records[$id]['org'] = $xml->getFirstTagContent('org', $entry, 1);
-                $records[$id]['de'] = $xml->getFirstTagContent('de', $entry, 1);
-                $records[$id]['en'] = $xml->getFirstTagContent('en', $entry, 1);
-                $records[$id]['fr'] = $xml->getFirstTagContent('fr', $entry, 1);
-                $records[$id]['it'] = $xml->getFirstTagContent('it', $entry, 1);
-                $records[$id]['es'] = $xml->getFirstTagContent('es', $entry, 1);
-                $records[$id]['nl'] = $xml->getFirstTagContent('nl', $entry, 1);
-            }
+        $xml_file = fopen($lang_file, 'r');
+        $file_cont = fread($xml_file, filesize($lang_file));
+        fclose($xml_file);
+
+        $entries = $xml->getTagContentArray('entry', $file_cont);
+        foreach ($entries as $entry) {
+            $id = $xml->getFirstTagContent('id', $entry, 1);
+            $records[$id]['id'] = $id;
+            $records[$id]['org'] = $xml->getFirstTagContent('org', $entry, 1);
+            $records[$id]['de'] = $xml->getFirstTagContent('de', $entry, 1);
+            $records[$id]['en'] = $xml->getFirstTagContent('en', $entry, 1);
+            $records[$id]['fr'] = $xml->getFirstTagContent('fr', $entry, 1);
+            $records[$id]['it'] = $xml->getFirstTagContent('it', $entry, 1);
+            $records[$id]['es'] = $xml->getFirstTagContent('es', $entry, 1);
+            $records[$id]['nl'] = $xml->getFirstTagContent('nl', $entry, 1);
         }
 
         return $records;

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -114,30 +114,32 @@ class Translation
     /**
      * Load translations for a module from database into memory
      *
-     * @param string $module    Module name or DB / System
+     * @param string $module    Module name or "DB" / "System"
      * @return void
      */
-    private function load_cache_bydb($module)
+    private function load_cache_bydb(string $module): void
     {
         global $db;
 
-        if ($db->success) {
-            $res = $db->qry('
-                SELECT id, org, ' . $this->language . ' 
-                FROM %prefix%translation 
-                WHERE 
-                    file = %string% 
-                    OR file = \'DB\' 
-                    OR file = \'System\' 
-                ORDER BY FIELD(file, \'System,DB,'. $module .'\')', $module);
-            while ($row = $db->fetch_array($res, 0)) {
-                if ($row[$this->language] != '') {
-                    if (!array_key_exists($module, $this->lang_cache)) {
-                        $this->lang_cache[$module] = [];
-                    }
-                    if (!array_key_exists($row['id'], $this->lang_cache[$module]) || $this->lang_cache[$module][$row['id']] == '') {
-                        $this->lang_cache[$module][$row['id']] = $row[$this->language];
-                    }
+        $res = $db->qry('
+            SELECT
+                `id`,
+                `org`,
+                `' . $this->language . '`
+            FROM %prefix%translation
+            WHERE
+                file = %string%
+                OR file = \'DB\'
+                OR file = \'System\'
+            ORDER BY FIELD(`file`, \'System,DB,'. $module .'\')', $module);
+
+        while ($row = $db->fetch_array($res, 0)) {
+            if ($row[$this->language] != '') {
+                if (!array_key_exists($module, $this->lang_cache)) {
+                    $this->lang_cache[$module] = [];
+                }
+                if (!array_key_exists($row['id'], $this->lang_cache[$module]) || $this->lang_cache[$module][$row['id']] == '') {
+                    $this->lang_cache[$module][$row['id']] = $row[$this->language];
                 }
             }
         }

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -55,7 +55,7 @@ class Translation
      * @param string    $mode       Data source mode (xml for install, db for running system)
      * @param string    $akt_modul  Active module
      */
-    public function load_trans($mode, $akt_modul)
+    public function load_trans(string $mode, string $akt_modul): void
     {
         if ($mode == 'db') {
             // System is configured, Language will be loaded from DB

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -237,7 +237,7 @@ class Translation
      * @param string    $long
      * @return string
      */
-    public function get_trans_db($hashkey, $module, $long)
+    private function get_trans_db($hashkey, $module, $long)
     {
         global $db;
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -189,7 +189,7 @@ class Translation
     /**
      * Returns a single language cache entry.
      */
-    public function getLangCacheEntry(string $module, string $key): string
+    private function getLangCacheEntry(string $module, string $key): string
     {
         if (!array_key_exists($module, $this->lang_cache)) {
             return '';

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -23,6 +23,9 @@ class Translation
      */
     private string $transfile_name = 'translation.xml';
 
+    /**
+     * @var array<string, string>
+     */
     public array $lang_names = [
         'de' => 'Deutsch',
         'en' => 'Englisch',
@@ -34,12 +37,16 @@ class Translation
 
     /**
      * Valid languages.
+     *
+     * @var array<string>
      */
     public array $valid_lang = ['de', 'en', 'es', 'fr', 'nl', 'it'];
 
     /**
      * In memory translation cache.
      * Only holds one language.
+     *
+     * @var array<string, array<string, string>>
      */
     private array $lang_cache = [];
 
@@ -196,10 +203,10 @@ class Translation
     /**
      * Replaces parameters from $input (%1, %2, %3, ...) with the content from $parameters at the same spot.
      *
-     * @param string    $input          Text with placeholders (random text %1 here %2)
-     * @param array     $parameters     Parameters that will replace %1, %2, ...
-     * @param string    $key
-     * @return string                   Text with inserted Parameters
+     * @param string        $input          Text with placeholders (random text %1 here %2)
+     * @param array<mixed>  $parameters     Parameters that will replace %1, %2, ...
+     * @param string        $key
+     * @return string                       Text with inserted Parameters
      */
     public function ReplaceParameters(string $input, array $parameters = null, string $key = null): string
     {
@@ -365,8 +372,8 @@ class Translation
      * Reads all translation from the $module XML file
      * and returns the data.
      *
-     * @param string    $module     Module name e.g. file-field
-     * @return array
+     * @param string                                    $module     Module name e.g. file-field
+     * @return array<string, array<string, string>>
      */
     private function xml_read_to_array(string $module): array
     {
@@ -590,6 +597,8 @@ class Translation
      *
      * Example:
      *  ->translate('Du wurdest erfolgreich ausgeloggt.')
+     *
+     * @param array<mixed> $args    List of variadic arguments (see PHP doc for description)
      */
     public function translate(array $args): string
     {

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -17,10 +17,7 @@ class Translation
      */
     private string $transfile_name = 'translation.xml';
 
-    /**
-     * @var array
-     */
-    public $lang_names = [
+    public array $lang_names = [
         'de' => 'Deutsch',
         'en' => 'Englisch',
         'es' => 'Spanisch',
@@ -30,22 +27,18 @@ class Translation
     ];
 
     /**
-     * Valid languages
-     *
-     * @var array
+     * Valid languages.
      */
-    public $valid_lang = ['de', 'en', 'es', 'fr', 'nl', 'it'];
+    public array $valid_lang = ['de', 'en', 'es', 'fr', 'nl', 'it'];
 
     /**
      * In memory translation cache.
      * Only holds one language.
-     *
-     * @var array
      */
     private array $lang_cache = [];
 
     /**
-     * Is cache for module loaded (db)
+     * Is cache for module loaded (database)
      */
     private int $cachemod_loaded_db = 0;
 

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -589,7 +589,21 @@ class Translation
         return $output;
     }
 
-    public function translate(array $args)
+    /**
+     * Translates a single word/sentence into the configured language.
+     * This function accepts multiple parameter:
+     *  1. The key/name of the string to translate
+     *  2. A list of values to replace in the key/name of the string to translate.
+     *
+     * If your translation contains variables, like a username, this variable is
+     * represented by %1. %2 describes the second variable, and so on.
+     * In this case you call the function like
+     *  ->translate(<key>, $username, $var2)
+     *
+     * Example:
+     *  ->translate('Du wurdest erfolgreich ausgeloggt.')
+     */
+    public function translate(array $args): string
     {
         global $db, $config, $func, $translation_no_html_replace;
 
@@ -612,17 +626,15 @@ class Translation
         }
 
         $key = md5($input);
-        $module = '';
-        if (isset($_GET['mod']) && $_GET['mod']) {
-            $module = $_GET['mod'];
-        }
+        $module = $_GET['mod'] ?? '';
 
         $trans_text = '';
+        $long = '';
         if (strlen($input) > 255) {
             $long = '_long';
-        } else {
-            $long = '';
         }
+
+        // TODO Unit test this function and make the logic below easier
 
         $translationEntry = $this->getLangCacheEntry($module, $key);
         // If we can't find the translation in the $module cache
@@ -632,7 +644,7 @@ class Translation
         }
 
         if ($translationEntry != '') {
-            // Already in memory cache ($this->lang_cache[key])
+            // Already in memory cache
             $output = $this->ReplaceParameters($translationEntry, $parameters, $key);
 
         } else {
@@ -647,7 +659,7 @@ class Translation
                 }
 
                 // If ok replace parameter
-                if ($trans_text != '' && $trans_text != null) {
+                if ($trans_text != '') {
                     $output = $this->ReplaceParameters($trans_text, $parameters);
 
                 // If any problem on get translations just return $input

--- a/inc/Classes/Translation.php
+++ b/inc/Classes/Translation.php
@@ -160,7 +160,7 @@ class Translation
      *
      * Does not overwrite existing language cache entries.
      */
-    private function setLangCacheEntry(string $module, string $id, string $text)
+    private function setLangCacheEntry(string $module, string $id, string $text): void
     {
         if (!array_key_exists($module, $this->lang_cache)) {
             $this->lang_cache[$module] = [];

--- a/inc/Functions/T.php
+++ b/inc/Functions/T.php
@@ -17,85 +17,10 @@ $translation_no_html_replace = false;
  */
 function t()
 {
-    global $db, $config, $translation, $func, $translation_no_html_replace;
+    global $translation;
 
-    $parameters = [];
-
-    // Prepare function parameters
-    // First argument is the input string, the following are parameters
     $args = func_get_args();
-    $input = (string) array_shift($args);
-    foreach ($args as $CurrentArg) {
-        // If second Parameter is Array (old Style)
-        if (!is_array($CurrentArg)) {
-            $parameters[] = $CurrentArg;
-        } else {
-            $parameters = $CurrentArg;
-        }
-    }
-
-    if ($input == '') {
-        return '';
-    }
-
-    $key = md5($input);
-    $module = '';
-    if (isset($_GET['mod']) && $_GET['mod']) {
-        $module = $_GET['mod'];
-    }
-
-    $trans_text = '';
-    if (strlen($input) > 255) {
-        $long = '_long';
-    } else {
-        $long = '';
-    }
-
-    $translationEntry = $translation->getLangCacheEntry($module, $key);
-    // If we can't find the translation in the $module cache
-    // we walk one hierarchy higher, to the System translations.
-    if ($translationEntry == '') {
-        $translationEntry = $translation->getLangCacheEntry('System', $key);
-    }
-
-    if ($translationEntry != '') {
-        // Already in memory cache ($this->lang_cache[key])
-        $output = $translation->ReplaceParameters($translationEntry, $parameters, $key);
-
-    } else {
-        // Try to read from DB
-        if ($translation->language == 'de') {
-            // All texts in source are in german at the moment
-            $output = $translation->ReplaceParameters($input, $parameters, $key);
-
-        } else {
-            if ($db->success && EnvIsConfigured()) {
-                $trans_text = $translation->get_trans_db($key, $_GET['mod'], $long);
-            }
-
-            // If ok replace parameter
-            if ($trans_text != '' && $trans_text != null) {
-                $output = $translation->ReplaceParameters($trans_text, $parameters);
-
-            // If any problem on get translations just return $input
-            } else {
-                $output = $translation->ReplaceParameters($input, $parameters, $key);
-            }
-        }
-    }
-
-    if ($translation_no_html_replace) {
-        $translation_no_html_replace = false;
-
-        // Deprecated. Should be replaced in t() by '<', '>' and '[br]'
-        $output = str_replace('--lt--', '<', $output);
-        $output = str_replace('--gt--', '>', $output);
-        $output = str_replace('HTML_NEWLINE', '<br />', $output);
-
-        return $func->text2html($output, 4);
-    }
-
-    return $output;
+    return $translation->translate($args);
 }
 
 function t_no_html()

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -64,19 +64,6 @@ class TranslationTest extends TestCase
     }
 
     /**
-     * @covers \LanSuite\Translation::ReplaceParameters
-     */
-    public function testReplaceParameters_NoParameters()
-    {
-        $input = 'This is foo bar baz';
-
-        $translation = new \LanSuite\Translation();
-        $actual = $translation->ReplaceParameters($input);
-
-        $this->assertEquals($input, $actual);
-    }
-
-    /**
      * @covers \LanSuite\Translation::get_lang
      */
     public function testGetLanguage_Invalid()


### PR DESCRIPTION
## Context

The translation class is key to the LanSuite system.
This Pull Request reworks the translation class a bit, **without changing any functionality**.

What we did:
* [Moved t() into Translation class](https://github.com/lansuite/lansuite/commit/e596458ce63229c201d9dbfa98d6943ad6201713)
* Provided a smaller public interface by making attributes and functions that are not in public use `private`
* Updated the documentation of the methods and properties
* Types the properties and methods (arguments and return types)
* Made the class a bit more configurable by things like [Translation: Replace 'de' with $defaultLanguage](https://github.com/lansuite/lansuite/commit/62b719809e2acaac01fab2efb95c436cbbaaa7a7)
* Made the code a bit more readable by removing obsolete `else` parts
* Fixed the one or other bug that referenced a wrong variable
* Added TODO comments for future work

The whole PR might be hard to review.
That's why I provided single commits for each isolated change.

## Next steps

The work in this class should continue.
We introduced a few TODO comments for future work, but my next steps are:

* Unit test the `translate()` method
* Check unit test coverage of the `Translation` class overall
* Remove the `global` usage in this class
* Refactor the `translate()` method with the goal of more simplified code

## Previous work

In https://github.com/lansuite/lansuite/pull/650 we have started the efforts on working on the translations. This pull request continues the efforts.

## Tickets

This is related to https://github.com/lansuite/lansuite/issues/415 (it is not fixing it, but kind of pre-work)