### PR TITLE
Scripts to build a reliable production release

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: "ShellCheck"
+
+on:
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: "Testing shell scripts"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@v2

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,5 +10,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@v2
+        uses: ludeeus/action-shellcheck@2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -11,29 +11,34 @@ bin/phpcs
 bin/phpcs.bat
 bin/phpunit
 bin/phpunit.bat
+bin/patch-type-declarations
+bin/phan
+bin/phan_client
+bin/php-parse
+bin/phpstan
+bin/phpstan.phar
+bin/rector
+bin/tocheckstyle
+bin/var-dump-server
 
 # Release archives
-LanSuite-*.tar.gz
-LanSuite-*_checksums.txt
+builds/LanSuite-*.tar.gz
+builds/LanSuite-*_checksums.txt
 
 # Generated folder/files
 /vendor/
 
 # Docs
 .DS_Store
-node_modules
-lib/core/metadata.js
-lib/core/MetadataBlog.js
 website/translated_docs
 website/build/
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
 
-#IDE
+# IDE
 .idea/
 
 # Docker 
 # Avoid accidently commit of .env files
 docker/*.env
-bin/*

--- a/Dockerfile-Production-Release
+++ b/Dockerfile-Production-Release
@@ -1,7 +1,7 @@
 # Get composer
 FROM composer:2.5.8 as composer
 
-FROM php:8.0.29-fpm-bullseye
+FROM php:8.1.20-fpm-bullseye
 
 # Install libraries and PHP-Extensions that are not provided by the base image
 RUN apt-get update \

--- a/Dockerfile-Production-Release
+++ b/Dockerfile-Production-Release
@@ -1,0 +1,31 @@
+# Get composer
+FROM composer:2.5.8 as composer
+
+FROM php:8.0.29-fpm-bullseye
+
+# Install libraries and PHP-Extensions that are not provided by the base image
+RUN apt-get update \
+    && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libsnmp-dev \
+        snmp \
+        unzip \
+        libzip-dev \
+        git \
+    && docker-php-ext-install -j$(nproc) mysqli snmp \
+    && docker-php-ext-configure gd --enable-gd --prefix=/usr --with-jpeg --with-freetype \
+    && docker-php-ext-install -j$(nproc) gd \
+    # Cleanup
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Composer setup starts here. The zip extension is required for that.
+RUN docker-php-ext-install zip
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+# Copy prepare-release.sh script
+COPY ./bin/prepare-release.sh /usr/local/bin/prepare-release.sh
+
+ENTRYPOINT ["/usr/local/bin/prepare-release.sh"]

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -17,19 +17,6 @@
 LANSUITE_GIT_URL="https://github.com/lansuite/lansuite.git"
 OUTPUT_DIR="/builds/"
 
-# Our own sha256sum function call.
-# That takes into account machines that don't have sha256sum but do have sha2 (i.e. macOS)
-sha256sum_() {
-    hash -r
-    if type sha256sum >& /dev/null; then
-        sha256sum "$@"
-    elif type shasum >& /dev/null; then
-        shasum -a 256 "$@"
-    else
-        sha2 -q -256 "$@"
-    fi
-}
-
 # log function
 #
 #   Parameter #1: Logging state. INFO, WARNING or ERROR
@@ -184,7 +171,7 @@ if [ -f CHECKSUM_FILENAME ]; then
     exit 1;
 fi
 
-sha256sum_ "${OUTPUT_DIR}${LANSUITE_FILENAME}.tar.gz" >> "$CHECKSUM_FILENAME"
+shasum -a 256 "${OUTPUT_DIR}${LANSUITE_FILENAME}.tar.gz" >> "$CHECKSUM_FILENAME"
 log "INFO" "Generating checksums ... Done."
 log "INFO" ""
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -22,11 +22,11 @@ OUTPUT_DIR="/builds/"
 sha256sum_() {
     hash -r
     if type sha256sum >& /dev/null; then
-        echo "$(sha256sum $@)"
+        sha256sum "$@"
     elif type shasum >& /dev/null; then
-        echo "$(shasum -a 256 $@)"
+        shasum -a 256 "$@"
     else
-        echo "$(sha2 -q -256 $@)"
+        sha2 -q -256 "$@"
     fi
 }
 
@@ -88,6 +88,7 @@ fi
 
 log "INFO" "Checking out the git repository $LANSUITE_GIT_URL ..."
 git clone $LANSUITE_GIT_URL
+# shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
     log "INFO" "Checking out the git repository $LANSUITE_GIT_URL ... Done."
 else
@@ -96,10 +97,11 @@ else
 fi
 
 # Switch to working directory
-cd ./lansuite/
+cd ./lansuite/ || exit
 
 log "INFO" "Fetching remote tags from $LANSUITE_GIT_URL ..."
 git fetch --all --tags
+# shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
     log "INFO" "Fetching remote tags from $LANSUITE_GIT_URL ... Done."
 else
@@ -115,14 +117,16 @@ if [ -z "$LANSUITE_VERSION" ]; then
     RELEASE_VERSION="snapshot-$COMMIT_SHA"
 else
     log "INFO" "LanSuite version $LANSUITE_VERSION given. Checking if tag exists ..."
-    git show-ref --verify refs/tags/$LANSUITE_VERSION
+    git show-ref --verify "refs/tags/$LANSUITE_VERSION"
+    # shellcheck disable=SC2181
     if [ $? -eq 0 ]; then
         log "INFO" "LanSuite version $LANSUITE_VERSION given. Checking if tag exists ... Done."
         log "INFO" "Running in release mode with tag $LANSUITE_VERSION."
 
         # Switching to the local tag
         log "INFO" "Switching to $LANSUITE_VERSION ..."
-        git checkout tags/$LANSUITE_VERSION
+        git checkout "tags/$LANSUITE_VERSION"
+        # shellcheck disable=SC2181
         if [ $? -eq 0 ]; then
             log "INFO" "Switching to $LANSUITE_VERSION ...Done."
         else
@@ -169,7 +173,7 @@ tar --exclude .git \
     --exclude Dockerfile-Production-Release \
     --exclude docker-compose.yml \
     --exclude docker-compose.dump.yml \
-    -cvzf ${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz .
+    -cvzf "${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz" .
 log "INFO" "Packaging release archive ... Done."
 
 # Building checksums
@@ -180,7 +184,7 @@ if [ -f CHECKSUM_FILENAME ]; then
     exit 1;
 fi
 
-echo $(sha256sum_ ${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz) >> $CHECKSUM_FILENAME
+sha256sum_ "${OUTPUT_DIR}${LANSUITE_FILENAME}.tar.gz" >> "$CHECKSUM_FILENAME"
 log "INFO" "Generating checksums ... Done."
 log "INFO" ""
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -165,13 +165,15 @@ log "INFO" "Packaging release archive ... Done."
 
 # Building checksums
 log "INFO" "Generating checksums ..."
-CHECKSUM_FILENAME="${OUTPUT_DIR}${LANSUITE_FILENAME}_checksums.txt"
+CHECKSUM_FILENAME="${LANSUITE_FILENAME}_checksums.txt"
 if [ -f CHECKSUM_FILENAME ]; then
     log "ERROR" "Checksum file $CHECKSUM_FILENAME already exists."
     exit 1;
 fi
 
-shasum -a 256 "${OUTPUT_DIR}${LANSUITE_FILENAME}.tar.gz" >> "$CHECKSUM_FILENAME"
+cd "${OUTPUT_DIR}" || exit
+
+shasum -a 256 "${LANSUITE_FILENAME}.tar.gz" >> "$CHECKSUM_FILENAME"
 log "INFO" "Generating checksums ... Done."
 log "INFO" ""
 

--- a/website/docs/development/production-release.md
+++ b/website/docs/development/production-release.md
@@ -1,0 +1,49 @@
+---
+id: production-release
+title: Creating a Release
+sidebar_position: 5
+---
+
+## Introduction
+
+The production release is not the same as the LanSuite development version (aka the GitHub repository).
+The production release only contains the required files to run LanSuite as a website.
+It does not contain any functionality to develop the platform.
+
+## Usage
+
+To build a production release, we are using Docker.
+This way, we ensure that every contributor can release the same production release with the same version constraints.
+
+### Building the image
+
+First step: Building the docker image to create a release:
+
+```
+docker build --file ./Dockerfile-Production-Release --tag lansuite/lansuite:prod-release .
+```
+
+### Building a release from the latest version
+
+If you aim to build a production release from the latest git HEAD:
+
+```
+docker run  --rm --volume=./builds:/builds:rw lansuite/lansuite:prod-release
+```
+
+### Building a release from a tag
+
+If you want to build a production release from a git tag:
+
+```
+docker run  --rm --volume=./builds:/builds:rw -e "LANSUITE_VERSION=v4.2-beta" lansuite/lansuite:prod-release
+```
+
+Please replace `v4.2-beta` with your git tag in the command.
+
+### Archives
+
+In your `./builds/` folder, you now have two files:
+
+* 1 x tar.gz, which is the compressed LanSuite production release
+* 1 x file with a checksum of the `.tar.gz` file


### PR DESCRIPTION
## Context

A reliable way to build a production release based on Docker.

Why docker?
This way, we can ensure all folks involved build the same production release under the same version constraints.

## Documentation

A chapter was added to build the production release.