### PR TITLE
Fix #103: Generate PHP API docs for production release

### DIFF
--- a/Dockerfile-Production-Release
+++ b/Dockerfile-Production-Release
@@ -13,6 +13,7 @@ RUN apt-get update \
         unzip \
         libzip-dev \
         git \
+        wget \
     && docker-php-ext-install -j$(nproc) mysqli snmp \
     && docker-php-ext-configure gd --enable-gd --prefix=/usr --with-jpeg --with-freetype \
     && docker-php-ext-install -j$(nproc) gd \
@@ -24,6 +25,11 @@ RUN apt-get update \
 RUN docker-php-ext-install zip
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
+
+# Install phpDocumentor
+RUN wget https://phpdoc.org/phpDocumentor.phar \
+    && chmod +x phpDocumentor.phar \
+    && mv phpDocumentor.phar /usr/local/bin/phpDocumentor
 
 # Copy prepare-release.sh script
 COPY ./bin/prepare-release.sh /usr/local/bin/prepare-release.sh

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -115,9 +115,10 @@ else
         git checkout "tags/$LANSUITE_VERSION"
         # shellcheck disable=SC2181
         if [ $? -eq 0 ]; then
-            log "INFO" "Switching to $LANSUITE_VERSION ...Done."
+            log "INFO" "Switching to $LANSUITE_VERSION ... Done."
         else
-            log "ERROR" "Switching to $LANSUITE_VERSION ...Failed"exit 1;
+            log "ERROR" "Switching to $LANSUITE_VERSION ... Failed"
+            exit 1;
         fi
 
         RELEASE_VERSION=$LANSUITE_VERSION
@@ -145,7 +146,15 @@ log "INFO" "Installing dependencies via composer ..."
 composer install --no-dev --optimize-autoloader
 log "INFO" "Installing dependencies via composer ... Done."
 
-# TODO Generating PHP class / function documentation
+# Render PHP API doc
+log "INFO" "Generating PHP API docs ..."
+phpDocumentor -d "inc" -d "modules" -t "docs/api"
+if [ $? -eq 0 ]; then
+    log "INFO" "Generating PHP API docs ... Done."
+else
+    log "ERROR" "Generating PHP API docs ... Failed"
+    exit 1;
+fi
 
 # Packaging archive
 log "INFO" "Packaging release archive ..."
@@ -160,7 +169,7 @@ tar --exclude .git \
     --exclude Dockerfile-Production-Release \
     --exclude docker-compose.yml \
     --exclude docker-compose.dump.yml \
-    -cvzf "${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz" .
+    -czf "${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz" .
 log "INFO" "Packaging release archive ... Done."
 
 # Building checksums

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -149,6 +149,7 @@ log "INFO" "Installing dependencies via composer ... Done."
 # Render PHP API doc
 log "INFO" "Generating PHP API docs ..."
 phpDocumentor -d "inc" -d "modules" -t "docs/api"
+# shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
     log "INFO" "Generating PHP API docs ... Done."
 else


### PR DESCRIPTION
## Context

We install https://www.phpdoc.org/ and generate the PHP API docs for the production release.
Those are getting stored in `/docs/api`.

Furthermore
* fixed a missing whitespace
* fixed a missing line return
* removed verbose flag from tar to be able to track the log output

## Tickets

Fix #103