### PR TITLE
Documentation Deploy: Enable workflow_dispatch

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
This enables us to deploy the documentation via click.
Right now, the page is not build and not visible.