### PR TITLE
Github Actions: Fix automatic generation and publishing of our documentation

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -4,12 +4,19 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/documentation-deploy.yml'
+      - 'website/**'
   workflow_dispatch:
 
 jobs:
   deploy:
     name: "Documentation: Deploy to GitHub Pages"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     defaults:
       run:
         shell: bash
@@ -30,11 +37,11 @@ jobs:
         run: make build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
+          publish_dir: ./website/build
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/website/Makefile
+++ b/website/Makefile
@@ -21,7 +21,6 @@ clean: ## Deletes the generated content and node_modules
 build: ## Compiles the documentation into static content
 	npm run build
 
-
 .PHONY: deploy
 deploy: ## Renders and deploys the documentation to https://lansuite.github.io/lansuite/
 	npm run deploy


### PR DESCRIPTION
The automatic workflow to publish documentation is not working as expected.
See the log in https://github.com/lansuite/lansuite/actions/runs/5840281890/job/15839361226

```
[INFO] ForceOrphan: false
  /usr/bin/git clone --depth=1 --single-branch --branch gh-pages ***github.com/lansuite/lansuite.git /home/runner/actions_github_pages_1691828153980
  Cloning into '/home/runner/actions_github_pages_169182815[39](https://github.com/lansuite/lansuite/actions/runs/5840281890/job/15839361226#step:6:42)80'...
  [INFO] clean up /home/runner/actions_github_pages_1691828153980
  [INFO] chdir /home/runner/actions_github_pages_1691828153980
  /usr/bin/git rm -r --ignore-unmatch *
  rm '.nojekyll'
  [INFO] chdir /home/runner/actions_github_pages_1691828153980
  [INFO] prepare publishing assets
  [INFO] copy /home/runner/work/lansuite/lansuite/build to /home/runner/actions_github_pages_1691828153980
  cp: no such file or directory: /home/runner/work/lansuite/lansuite/build/*
  cp: no such file or directory: /home/runner/work/lansuite/lansuite/build/.*
  [INFO] delete excluded assets
  rm: no paths given
  [INFO] Created /home/runner/actions_github_pages_1691828153980/.nojekyll
```

The main reason was that the `working-directory` is not considered when building the publish directory.

The rest of the pull request are smaller improvements like
* adding the full version to avoid breaking changes by automatic upgrades
* limiting permissions of a github action workfow
* only trigger changes if the documentation actually has changed