### PR TITLE
Docker setup to build a production ready Docker container

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,3 +1,7 @@
+#
+# Dockerfile for development purpose.
+#
+
 # Get composer
 FROM composer:2.5.8 as composer
 

--- a/Dockerfile-production-release
+++ b/Dockerfile-production-release
@@ -1,3 +1,7 @@
+#
+# Dockerfile to create a new software release.
+#
+
 # Get composer
 FROM composer:2.5.8 as composer
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 help: ## Outputs the help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: docker-build
-docker-build: ## Builds the local docker image
-	docker build --file ./Dockerfile --tag lansuite/lansuite:latest .
+.PHONY: docker-build-dev
+docker-build-dev: ## Builds the local docker image for development purpose
+	docker build --file ./Dockerfile-development --tag lansuite/lansuite:latest .
 
 .PHONY: docker-rector-dry
 docker-rector-dry: ## Runs rector inside docker (Dry run)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ help: ## Outputs the help
 docker-build-dev: ## Builds the local docker image for development purpose
 	docker build --file ./Dockerfile-development --tag lansuite/lansuite:latest .
 
+.PHONY: docker-build-production-release
+docker-build-production-release: ## Builds the local docker image to create a new software release
+	docker build --file ./Dockerfile-production-release --tag lansuite/lansuite:prod-release .
+
 .PHONY: docker-rector-dry
 docker-rector-dry: ## Runs rector inside docker (Dry run)
 	docker-compose run php /code/bin/rector process --dry-run

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -166,7 +166,7 @@ tar --exclude .git \
     --exclude builds \
     --exclude docker \
     --exclude website \
-    --exclude Dockerfile \
+    --exclude Dockerfile-development \
     --exclude Dockerfile-Production-Release \
     --exclude docker-compose.yml \
     --exclude docker-compose.dump.yml \

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -167,7 +167,7 @@ tar --exclude .git \
     --exclude docker \
     --exclude website \
     --exclude Dockerfile-development \
-    --exclude Dockerfile-Production-Release \
+    --exclude Dockerfile-production-release \
     --exclude docker-compose.yml \
     --exclude docker-compose.dump.yml \
     -czf "${OUTPUT_DIR}$LANSUITE_FILENAME.tar.gz" .

--- a/website/docs/development/production-release.md
+++ b/website/docs/development/production-release.md
@@ -20,7 +20,7 @@ This way, we ensure that every contributor can release the same production relea
 First step: Building the docker image to create a release:
 
 ```
-docker build --file ./Dockerfile-Production-Release --tag lansuite/lansuite:prod-release .
+docker build --file ./Dockerfile-production-release --tag lansuite/lansuite:prod-release .
 ```
 
 ### Building a release from the latest version


### PR DESCRIPTION
## Context

The ticket https://github.com/lansuite/lansuite/issues/704 showed a flaw that indicated that the existing Dockerfile can be understood as Production ready.
It is meant to be for development purposes only.

This PR should fix this flaw and change the behaviour to make the existing Dockerfile production ready by default.

## What is left

This PR is not ready yet. It was coded without testing.

- [ ] Building the actual production ready `Dockerfile`
- [ ] Adding docs on how to install LanSuite with Docker
- [ ] Building a pipeline that the Docker image is automatically build when a new release is done (aka tag)
- [ ] Testing