### PR TITLE
Development: Add basic Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### What is this PR doing?
+
+<!--
+Please describe what you add, change, or fix in this PR.
+This is a useful place to
+
+- bug: add how to reproduce it
+- explain your design decisions/thoughts
+-->
+
+### Which issue(s) this PR fixes:
+
+Fixes #
+
+### Checklist
+
+- [ ] `CHANGELOG.md` entry
+- [ ] Documentation update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Development] Introduced PHP_CodeSniffer to ensure a unified coding standard inside our codebase
 - [Development] Introduced a Makefile to make standard commands easier and scriptable
 - [Development] Introduced an automated way to create a new production release incl., documentation and API docs
+- [Development] Add basic Pull Request template
 - [Documentation] Introduced an official documentation website at https://lansuite.github.io/lansuite/
 - [System] Introduced symfony/error-handler to provide more information in an error case rather than the native PHP errors (only active in debug mode)
 - [System] Introduced symfony/cache to easily provide other cache backends like APCu (next to file caching)


### PR DESCRIPTION
### What is this PR doing?

This PR adds a basic pull request template.

The idea is to enable others to understand the single change better + don't forget things like the Changelog or documentation upgrade.

### Which issue(s) this PR fixes:

None

### Checklist

- [x] `CHANGELOG.md` entry -> https://github.com/lansuite/lansuite/pull/708 need merge first
- [X] Documentation update -> Not needed