### PR TITLE
index_module: Protect module inclusion for path traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ bin/rector
 bin/tocheckstyle
 bin/var-dump-server
 
+# PHPUnit
+.phpunit.result.cache
+
 # Release archives
 builds/LanSuite-*.tar.gz
 builds/LanSuite-*_checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 ### Security
 
 - [Database] Introduced a new Database class with first-class prepared statement support
+- [System] Protect module inclusion for path traversal
 
 ## [4.2] - 2015-03-15
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/cache": "^v6.0.19",
         "psr/simple-cache": "^1.0",
         "symfony/http-foundation": "^6.0",
-        "symfony/error-handler": "^6.0"
+        "symfony/error-handler": "^6.0",
+        "symfony/filesystem": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",
@@ -83,6 +84,7 @@
         },
         "files": [
             "inc/base/define.php",
+            "inc/Functions/BuildModuleFilePath.php",
             "inc/Functions/T.php",
             "inc/Functions/FetchDataRow.php",
             "inc/Functions/FetchPostRow.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "629514007c15df2063ce9795f550d9b2",
+    "content-hash": "6043b264507f2966e9aff973c2ee55a4",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -1087,6 +1087,69 @@
             "time": "2023-07-16T17:05:46+00:00"
         },
         {
+            "name": "symfony/filesystem",
+            "version": "v6.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-01T08:30:39+00:00"
+        },
+        {
             "name": "symfony/http-foundation",
             "version": "v6.3.2",
             "source": {
@@ -1162,6 +1225,88 @@
                 }
             ],
             "time": "2023-07-23T21:58:39+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4419,88 +4564,6 @@
                 }
             ],
             "time": "2023-02-25T16:59:41+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",

--- a/inc/Classes/Database.php
+++ b/inc/Classes/Database.php
@@ -181,9 +181,9 @@ class Database
      * Executes $query as prepared statement and returns
      * only the first row.
      * 
-     * In case of an empty result, an empty array is returned.
+     * In case of an empty result, null is returned.
      */
-    public function queryWithOnlyFirstRow(string $query, array $parameterValues = []): array
+    public function queryWithOnlyFirstRow(string $query, array $parameterValues = []): array|null
     {
         $statement = $this->query($query, $parameterValues);
         $queryResult = $this->getStatementResult($statement);

--- a/inc/Functions/BuildModuleFilePath.php
+++ b/inc/Functions/BuildModuleFilePath.php
@@ -1,0 +1,37 @@
+<?php
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+ /**
+  * Builds the correct path to include a file from a particular module.
+  *
+  * $module and $file should only contain letters, numbers and valid chars like _ or -.
+  * If this is not the case, an exception will be thrown.
+  *
+  * This function also protects for path traversal attacks.
+  */
+function BuildModuleFilePath(Filesystem $filesystem, string $rootDirectory, string $module, string $file): string
+{
+    // Some files contain a `_` or `-` char.
+    // To avoid a regular expression, we allow the chars by replacing.
+    $validChars = array('-', '_');
+
+    // Check that they only contain valid chars like letters and numbers
+    if (!ctype_alnum(str_replace($validChars, '', $module)) || !ctype_alnum(str_replace($validChars, '', $file))) {
+        throw new \Exception("Path contains unexpected characters");
+    }
+
+    $pathToInclude = $rootDirectory . 'modules' . DIRECTORY_SEPARATOR . $module . DIRECTORY_SEPARATOR . $file . '.php';
+    $pathToInclude = Path::canonicalize($pathToInclude);
+
+    if (!$filesystem->exists($pathToInclude)) {
+        throw new \Exception("File does not exist");
+    }
+
+    // Normally you would also check if the path is part of your root dir
+    // Like in https://stackoverflow.com/a/4205278
+    // This is not needed right here, because we already check for ctype_alnum above.
+
+    return $pathToInclude;
+}

--- a/index.php
+++ b/index.php
@@ -5,8 +5,12 @@ require __DIR__ . '/vendor/autoload.php';
 use Symfony\Component\Cache;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Filesystem\Filesystem;
 
 $request = Request::createFromGlobals();
+$filesystem = new Filesystem();
+
+define('ROOT_DIRECTORY', realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR);
 
 // Set error_reporting.
 // It is set to this value on purpose, because otherwise

--- a/index_module.inc.php
+++ b/index_module.inc.php
@@ -15,7 +15,7 @@ if ($_GET["mod"] != 'install' && $func->admin_exists()) {
     }
 
     // Reset $auth['type'], if no permission to Mod
-    if ($auth['type'] > 1) {
+    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
         // Has at least someone (with rights equal or above) access to this mod?
         $permission = $db->qry_first("SELECT 1 AS found FROM %prefix%user_permissions AS p
         LEFT JOIN %prefix%user AS u on p.userid = u.userid
@@ -27,7 +27,7 @@ if ($_GET["mod"] != 'install' && $func->admin_exists()) {
 
             // If not: Set his rights to user-rights
             if (!$permission['found']) {
-                $auth['type'] = 1;
+                $auth['type'] = \LS_AUTH_TYPE_USER;
                 $_SESSION['auth']['type'] = 1;
                 $authentication->auth['type'] = 1;
             }
@@ -36,11 +36,11 @@ if ($_GET["mod"] != 'install' && $func->admin_exists()) {
 }
 
 $siteblock = false;
-if ($cfg['sys_blocksite'] == 1 and $auth['type'] < 2 and $_GET['mod'] != 'info2' and $framework->modus != "ajax") {
+if ($cfg['sys_blocksite'] == 1 && $auth['type'] < \LS_AUTH_TYPE_ADMIN && $_GET['mod'] != 'info2' && $framework->modus != "ajax") {
     $siteblock = true;
 }
 
-if (!$missing_fields and !$siteblock) {
+if (!$missing_fields && !$siteblock) {
     switch ($_GET['mod']) {
         case 'logout':
             $func->confirmation(t('Du wurdest erfolgreich ausgeloggt.'), '');

--- a/tests/BuildModuleFilePathTest.php
+++ b/tests/BuildModuleFilePathTest.php
@@ -73,7 +73,8 @@ class BuildModuleFilePathTest extends TestCase
         ];
     }
 
-    private function getFilesystemMock(bool $existsReturnValue) {
+    private function getFilesystemMock(bool $existsReturnValue)
+    {
         $filesystem = $this->createConfiguredMock(
             \Symfony\Component\Filesystem\Filesystem::class,
             [

--- a/tests/BuildModuleFilePathTest.php
+++ b/tests/BuildModuleFilePathTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace LanSuite\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class BuildModuleFilePathTest extends TestCase
+{
+    #[DataProvider('dataSetInvalidModuleFileArguments')]
+    public function testInvalidModuleFileArguments(string $module, string $file): void
+    {
+        $this->expectException(\Exception::class);
+
+        $filesystemMock = $this->getFilesystemMock(true);
+        $rootDirectory = '/code/';
+
+        BuildModuleFilePath($filesystemMock, $rootDirectory, $module, $file);
+    }
+
+    public function testFileDoesNotExist(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $filesystemMock = $this->getFilesystemMock(false);
+        $rootDirectory = '/code/';
+        $module = 'news';
+        $file = 'add';
+
+        BuildModuleFilePath($filesystemMock, $rootDirectory, $module, $file);
+    }
+
+    #[DataProvider('dataSetValidModuleFileArguments')]
+    public function testValidModuleFileArguments(string $module, string $file, string $expectedResult): void
+    {
+        $filesystemMock = $this->getFilesystemMock(true);
+        $rootDirectory = '/code/';
+
+        $actualResult = BuildModuleFilePath($filesystemMock, $rootDirectory, $module, $file);
+
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    public static function dataSetValidModuleFileArguments(): array
+    {
+        // [$module, $file, $expectedResult]
+        return [
+            ['downloads', 'stats_grafik', '/code/modules/downloads/stats_grafik.php'],
+            ['about', 'overview', '/code/modules/about/overview.php'],
+            ['info2', 'change', '/code/modules/info2/change.php'],
+            ['downloads', 'stats-grafik', '/code/modules/downloads/stats-grafik.php'],
+        ];
+    }
+
+    public static function dataSetInvalidModuleFileArguments(): array
+    {
+        // [$module, $file]
+        return [
+            ['', ''],
+            ['a', ''],
+            ['', 'a'],
+            ['.', ''],
+            ['', '.'],
+            ['..', ''],
+            ['', '..'],
+            ['..', '..'],
+            ['foo/', 'bar'],
+            ['bar', 'foo/'],
+            ['../../passwd', 'abc'],
+            ['abc', '../../passwd'],
+            ['~/.ssh/config', 'baz'],
+            ['baz', '~/.ssh/config'],
+        ];
+    }
+
+    private function getFilesystemMock(bool $existsReturnValue) {
+        $filesystem = $this->createConfiguredMock(
+            \Symfony\Component\Filesystem\Filesystem::class,
+            [
+                'exists' => $existsReturnValue,
+            ],
+        );
+
+        return $filesystem;
+    }
+}


### PR DESCRIPTION
### What is this PR doing?

We introduce a new function BuildModuleFilePath, that helps
to protect and build the right path to include a particular file
from a module.

The symfony/filesystem helps us with this by abstracting and normalizing
cross-platform path functionality.

Additionally, we switched the database statements to prepared statements.

### Which issue(s) this PR fixes:

Fixes https://github.com/lansuite/lansuite/issues/596
Fixes https://github.com/lansuite/lansuite/issues/572

### Checklist

- [x] `CHANGELOG.md` entry -> https://github.com/lansuite/lansuite/pull/708 need merge first
- [X] Documentation update -> None
