### PR TITLE
Remove `nofollow.php` from index root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [System] Remove `ini_set('url_rewriter.tags', '')`
 - [System] Remove hardcoded set date_default_timezone_set to Europe/Berlin
 - [System] Removed mysql_ functionality in favor of mysqli
+- [System] Remove nofollow.php from index root
 - [Installation] Remove install check "magic_quotes_gpc"
 - [Installation] Remove install check "register_globals"
 - [Installation] Remove install check "register_argc_argv"

--- a/modules/partylist/show.php
+++ b/modules/partylist/show.php
@@ -41,7 +41,7 @@ if (!$_GET['partyid']) {
 
     $ms2->AddIconField('details', 'index.php?mod=partylist&action='. $_GET['action'] .'&partyid=', t('Details'));
     if ($_GET['action'] != 'history') {
-        $ms2->AddIconField('signon', 'nofollow.php?mod=partylist&step=10&design=base&partyid=', t('Anmelden'));
+        $ms2->AddIconField('signon', 'index.php?mod=partylist&step=10&design=base&partyid=', t('Anmelden'));
     }
     $ms2->AddIconField('edit', 'index.php?mod=partylist&action=add&partyid=', t('Editieren'), 'EditAllowed');
     if ($auth['type'] >= 3) {
@@ -69,7 +69,7 @@ if (!$_GET['partyid']) {
     $dsp->NewContent($row['name'], $row['motto']);
     $dsp->AddDoubleRow(t('Datum'), $func->unixstamp2date($row['start'], 'datetime') .' bis '. $func->unixstamp2date($row['end'], 'datetime'));
     $dsp->AddDoubleRow(t('Adresse'), $row['street'] .' '. $row['hnr'] .', '. $row['plz'] .' '. $row['city']);
-    $dsp->AddDoubleRow(t('Webseite'), '<a href="'. $row['url'] .'" target="_blank">'. $row['url'] .'</a> ' . $dsp->FetchIcon('signon', 'nofollow.php?mod=partylist&step=10&design=base&partyid=' . $_GET['partyid']));
+    $dsp->AddDoubleRow(t('Webseite'), '<a href="'. $row['url'] .'" target="_blank">'. $row['url'] .'</a> ' . $dsp->FetchIcon('signon', 'index.php?mod=partylist&step=10&design=base&partyid=' . $_GET['partyid']));
     $dsp->AddDoubleRow(t('Anmeldestatus'), AddSignonStatus($row['ls_url']));
     $dsp->AddDoubleRow(t('Zusätzliche Infos'), $func->text2html($row['text']));
     $dsp->AddDoubleRow(t('Eingetragen durch'), $dsp->FetchUserIcon($row['userid'], $row['username']));

--- a/nofollow.php
+++ b/nofollow.php
@@ -1,2 +1,0 @@
-<?php
-require('index.php');

--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,3 @@ Disallow: design/templates/
 Disallow: inc/
 Disallow: modules/
 Disallow: install.php
-Disallow: nofollow.php


### PR DESCRIPTION
### What is this PR doing?

The `nofollow.php` file doesn't serve any value. It includes the `index.php`.

If something should not be crawled, we should protect this behind a user login.
We can't control what search companies index (if the data is public available).

### Which issue(s) this PR fixes:

None

### Checklist

- [x] `CHANGELOG.md` entry -> https://github.com/lansuite/lansuite/pull/708 need merge first
- [X] Documentation update -> Not needed