### PR TITLE
PHP Warnings: Fix undefined array keys in `inc/Classes/Auth.php`

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -308,12 +308,12 @@ class Auth
                 $this->cookie_unset();
 
             // Not checked in?
-            } elseif ($func->isModActive('party') and (!$party_query["checkin"] or $party_query["checkin"] == '0000-00-00 00:00:00') and $user["type"] < 2 and !$cfg["sys_internet"]) {
+            } elseif ($func->isModActive('party') && (is_array($party_query) && (!$party_query["checkin"] || $party_query["checkin"] == '0000-00-00 00:00:00')) && $user["type"] < 2 && !$cfg["sys_internet"]) {
                 $func->information(t('Du bist nicht eingecheckt. Im Intranetmodus ist ein Einloggen nur möglich, wenn du eingecheckt bist.') .HTML_NEWLINE. t('Bitte melden dich bei der Organisation.'), '', 1);
                 $func->log_event(t('Login für %1 fehlgeschlagen (Account nicht eingecheckt).', $tmp_login_email), "2", "Authentifikation");
 
             // Already checked out?
-            } elseif ($func->isModActive('party') and $party_query["checkout"] and $party_query["checkout"] != '0000-00-00 00:00:00' and $user["type"] < 2 and !$cfg["sys_internet"]) {
+            } elseif ($func->isModActive('party') && is_array($party_query) && $party_query["checkout"] && $party_query["checkout"] != '0000-00-00 00:00:00' && $user["type"] < 2 && !$cfg["sys_internet"]) {
                 $func->information(t('Du bist bereits ausgecheckt. Im Intranetmodus ist ein Einloggen nur möglich, wenn du eingecheckt bist.') .HTML_NEWLINE. t('Bitte melden dich bei der Organisation.'), '', 1);
                 $func->log_event(t('Login für %1 fehlgeschlagen (Account ausgecheckt).', $tmp_login_email), "2", "Authentifikation");
 


### PR DESCRIPTION
### What is this PR doing?

* Fixing "undefined access to array key X" PHP Warning
* Changing `and` to `&&` and `or` to `||`

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed - Fixing PHP warnings due to PHP upgrade
- [X] Documentation update -> Not needed