### PR TITLE
Authentication/Logout: Reset `login` state to 0 after logout

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -424,6 +424,7 @@ class Auth
         // Reset Sessiondata
         unset($this->auth);
         unset($_SESSION['auth']);
+        $this->auth['login'] = "0";
         $this->auth["userid"] = "";
         $this->auth["email"] = "";
         $this->auth["username"] = "";


### PR DESCRIPTION
### What is this PR doing?

- Bugfix: Reset `login` state and set it explicit to 0 after logout

This will prevent undefined array key access to the field.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, warning due to PHP upgrade
- [X] Documentation update -> Not needed