### PR TITLE
Bugfix: Custom designs are getting overwritten by non existing design

### DIFF
--- a/index.php
+++ b/index.php
@@ -375,7 +375,7 @@ function initializeDesign()
     }
 
     // Design switch by URL
-    if ($design != 'popup' && $design != 'base') {
+    if ($design && $design != 'popup' && $design != 'base') {
         $auth['design'] = $design;
     }
 


### PR DESCRIPTION
### What is this PR doing?

If you configure a custom design like

```
[lansuite]
default_design = "psycholan"
```

It is not getting respected but overwritten with a non-existing design.
You can overwrite the configured design by the GET parameter ?design=XXX
Because a check is missing that this parameter is set, we always overwrite the custom design with `null`.

This PR makes custom designs possible again and only overwrites the design if there is one existing in the GET parameter.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, regresseion
- [X] Documentation update -> Not needed