### PR TITLE
[Party] Add information `Gesamt` in the Party box to show how many people can sign up for a party

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Installation] Added check for incompatible SQL Modes to the first installation page
 - [Installation] If there is no `config.php` file available during installation, create it during setup from the default config
 - [Discord] Introduced a new module to manage Discord Servers
+- [Party] Add information `Gesamt` in the Party box to show how many people can sign up for a party
   
 ### Changed
 

--- a/modules/party/boxes/signonstatus.php
+++ b/modules/party/boxes/signonstatus.php
@@ -99,6 +99,7 @@ if ($cfg['sys_internet']) {
 }
 
 $box->EngangedRow($bar);
+$box->EngangedRow(t('Gesamt').': '. $max);
 $box->EngangedRow(t('Angemeldet').': '. $cur);
 $box->EngangedRow(t('Bezahlt').': '. $paid);
 $box->EngangedRow(t('Frei').': '. ($max - $paid));


### PR DESCRIPTION
### What is this PR doing?

Add information `Gesamt` in the Party box to show how many people can sign up for a party

<img width="169" alt="Screenshot 2023-09-16 at 09 47 01" src="https://github.com/lansuite/lansuite/assets/320064/89ead430-b6bb-4157-9004-9807628c6b76">

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update - Not needed