### PR TITLE
[News] Fix PHP Warning if GET-Parameter `mcact` is not set

### DIFF
--- a/modules/news/comment.php
+++ b/modules/news/comment.php
@@ -44,7 +44,8 @@ if ($check["caption"] != "") {
     }
     $smarty->assign('text', $text);
 
-    if ($_GET["mcact"] == "" or $_GET["mcact"] == "show") {
+    $mcactParameter = $_GET["mcact"] ?? '';
+    if ($mcactParameter == '' || $mcactParameter == 'show') {
         $dsp->NewContent(t('Newsmeldung + Kommentare'), t('Hier kannst du diese News kommentieren'));
         $dsp->AddSingleRow($smarty->fetch("modules/news/templates/show_single_row_$news_type.htm"));
         $dsp->AddSingleRow($dsp->FetchSpanButton(t('Newsübersicht'), "index.php?mod=news&action=show"));


### PR DESCRIPTION
### What is this PR doing?

[News] Fix PHP Warning if GET-Parameter `mcact` is not set

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, PHP Warning
- [X] Documentation update -> Not needed