### PR TITLE
Module inclusion: Fix PHP Warning if no auth is set in Database

### DIFF
--- a/index_module.inc.php
+++ b/index_module.inc.php
@@ -117,7 +117,11 @@ if (!$missing_fields && !$siteblock) {
                 } elseif ($fileInModDirectoryExists) {
                     // Case like
                     //  - /?mod=downloads&action=stats_grafik
-                    if ($authentication->authorized($menu['requirement'])) {
+                    $authRequirement = 0;
+                    if ($menu && $menu['requirement']) {
+                        $authRequirement = $menu['requirement'];
+                    }
+                    if ($authentication->authorized($authRequirement)) {
                         include_once($pathToInclude);
                     }
 


### PR DESCRIPTION
### What is this PR doing?

If no auth is set in database (which can happen, because it is not needed), we need to double check if the database return value `$menu` is not null.

This is a bugfix to avoid PHP Warnings, e.g. in the News -> Comment section.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, PHP warning fix
- [X] Documentation update -> Not needed