### PR TITLE
[PicGallery] Several PHP Warning fixes

### DIFF
--- a/inc/Classes/GD.php
+++ b/inc/Classes/GD.php
@@ -42,10 +42,6 @@ class GD
             $GD = gd_info();
             $this->available = 1;
 
-            if ($GD['Freetype Support']) {
-                $this->free_type = 1;
-            }
-
             if ($GD['FreeType Support']) {
                 $this->free_type = 1;
             }


### PR DESCRIPTION
### What is this PR doing?

This fixes several PHP Warnings in the PicGallery module

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, due to PHP upgrade
- [X] Documentation update -> Not needed