### PR TITLE
[Boxes/Login] Implement Sign up and Password Recovery link as text links for better usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [User] Allow empty birthday field
 - [Statistics] Limit lasthiturl to 100 chars as we expect it to fit varchar(100)
 - [User] Enforce uniqueness of user & email for registration
+- [Boxes/Login] Sign up and Password Recovery are now text links below the login box and not only icons anymore (for better usability)
 
 ### Deprecated
 

--- a/modules/boxes/templates/box_login_content.htm
+++ b/modules/boxes/templates/box_login_content.htm
@@ -1,22 +1,41 @@
-<form name="form_loginbox" method="post" action="{$action}">
+<form name="form_loginbox" id="form_loginbox" method="post" action="{$action}">
   <table cellspacing="0" cellpadding="0">
-  <tr><td>
-    <label for="email" class="copyright">E-Mail / LS-ID</label>
-    <br /><input name="email" type="text" class="form" id="email" size="18" tabindex="1" />
-  </td><td valign="bottom" align="right">
-    {$buttons_add}
-
-  </td></tr><tr><td>
-    <label for="password" class="copyright">Passwort</label>
-    <br /><input type="password" name="password" id="password" class="form" size="18" tabindex="2" />
-  </td><td valign="bottom" align="right">
-    {$buttons_pw}
-
-  {if $ssl_link}</td></tr><tr><td colspan="2">
-    [<a href="{$ssl_link}">SSL Login</a>]{/if}
-
-  </td></tr><tr><td colspan="2">
-    {$buttons_login}
-  </td></tr></table>
+    <tr>
+      <td>
+        <label for="email" class="copyright">Username / E-Mail</label><br />
+        <input name="email" type="text" class="form" id="email" size="18" tabindex="1" />
+      </td>
+      <td valign="bottom" align="right"></td>
+    </tr>
+    <tr>
+      <td>
+        <label for="password" class="copyright">Passwort</label><br />
+        <input type="password" name="password" id="password" class="form" size="18" tabindex="2" />
+      </td>
+      <td valign="bottom" align="right">
+    {if $ssl_link}
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        [<a href="{$ssl_link}">SSL Login</a>]
+    {/if}
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        {$buttons_login}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        {$buttons_add} <a href="index.php?mod=signon">Registrieren</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        {$buttons_pw} <a href="index.php?mod=usrmgr&action=pwrecover">Passwort vergessen</a>
+      </td>
+    </tr>
+  </table>
 </form>
- 


### PR DESCRIPTION
### What is this PR doing?

In the login box, the links

* Sign up
* Password recovery

are only available as icons.
This makes it hard to "guess" what it is.

This PR implements both links as text links under the login form.

Before:
<img width="197" alt="Screenshot 2023-09-16 at 11 58 27" src="https://github.com/lansuite/lansuite/assets/320064/ba3c03ec-468d-42c6-9133-4ebd9c6986d2">

After:
<img width="173" alt="Screenshot 2023-09-16 at 12 04 37" src="https://github.com/lansuite/lansuite/assets/320064/4c761c44-5228-4c04-8109-127bd12441dc">

The design is not super awesome and can be improved.
However, I think having the links visible, is already a huge improvement.

### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update -> Not needed