### PR TITLE
[Boxes] Fix: Mark an menu item as blue if Admin access is required

### DIFF
--- a/modules/boxes/Classes/Boxes.php
+++ b/modules/boxes/Classes/Boxes.php
@@ -25,6 +25,7 @@ class Boxes
     {
         global $func;
 
+        $requirement = intval($requirement);
         $link_class = match ($requirement) {
             2, 3 => 'admin',
             default => 'menu',


### PR DESCRIPTION
### What is this PR doing?

If a menu item is requiring Administrator access, it is marked blue.
This feature has been broken, due to direct type matching / comparison.
This PR is fixing this.

Before

<img width="160" alt="Screenshot 2023-09-16 at 13 38 36" src="https://github.com/lansuite/lansuite/assets/320064/916b57fa-a137-4825-9a73-63f5e1899438">

After

<img width="79" alt="Screenshot 2023-09-16 at 13 38 50" src="https://github.com/lansuite/lansuite/assets/320064/8db25661-5fd3-4a16-ae1f-ae0368701aca">


### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed