### PR TITLE
[Mastersearch2] Fix PHP Warning: Undefined array key "icons" in result_case.htm

### DIFF
--- a/modules/mastersearch2/templates/result_case.htm
+++ b/modules/mastersearch2/templates/result_case.htm
@@ -37,7 +37,7 @@ MultiSelectSecurityQuest = new Array({$security_questions});
     {if isset($v.link)}</a>{/if}
     </td>
   {/foreach}
-  {if is_array($line.icons) && $line.icons|@count > 0}
+  {if isset($line.icons) && is_array($line.icons) && $line.icons|@count > 0}
     <td class="mastersearch2_result_row_value" valign="top" align="right" width="{$maxIcons*24}" {if isset($line.bgcolor)}{$line.bgcolor}{/if}>
     {foreach from=$line.icons item=v}
       {if isset($v.link)}<a href="{$v.link}" class="menu">{/if}


### PR DESCRIPTION
### What is this PR doing?

Fix PHP Warning: Undefined array key "icons" in result_case.htm

When icons are not defined, because they are not needed.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed