### PR TITLE
[Usrmgr] Fix PHP Warning: Undefined variable $signstat_info in modules/usrmgr/boxes/userdata.php on line XYZ

### DIFF
--- a/modules/usrmgr/boxes/userdata.php
+++ b/modules/usrmgr/boxes/userdata.php
@@ -95,6 +95,7 @@ if ($party->count > 0 and $_SESSION['party_info']['partyend'] > time()) {
         AND pu.party_id = %int%", $auth["userid"], $party->party_id);
 
     $paidstat_info = '';
+    $signstat_info = '';
     if ($query_signstat == null) {
         $signstat = '<font color="red">'. t('Nein') .'!</font>';
         $signstat_info = '<a href="index.php?mod=signon"><i> '. t('Hier anmelden') .'</i></a>';


### PR DESCRIPTION
### What is this PR doing?

Fix PHP Warning: Undefined variable $signstat_info in modules/usrmgr/boxes/userdata.php on line XYZ

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed