### PR TITLE
[Bugtracker] Fix PHP Warnings

### DIFF
--- a/modules/bugtracker/add.php
+++ b/modules/bugtracker/add.php
@@ -1,8 +1,9 @@
 <?php
 $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der Verwendung dieses Systems auftreten, sowie Feature Wünsche äußern. Können die Admins dieser Webseite sie nicht selbst beheben, haben diese die Möglichkeit sie an das Lansuite-Team weiterzureichen.'));
 
-$row = $db->qry_first('SELECT reporter FROM %prefix%bugtracker WHERE bugid = %int%', $_GET['bugid']);
-if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']) {
+$bugidParameter = $_GET['bugid'] ?? 0;
+$row = $db->qry_first('SELECT reporter FROM %prefix%bugtracker WHERE bugid = %int%', $bugidParameter);
+if ($bugidParameter && $auth['type'] < 2 && $row['reporter'] != $auth['userid']) {
     $func->error(t('Nur Admins und der Reporter dürfen Bug-Einträge im Nachhinein editieren'), 'index.php?mod=bugtracker');
 } else {
     $mf = new \LanSuite\MasterForm();
@@ -43,7 +44,7 @@ if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']
         $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     }
 
-    if (!$_GET['bugid']) {
+    if (!$bugidParameter) {
         $mf->AddFix('date', 'NOW()');
         if ($_SERVER['SERVER_NAME'] != 'lansuite.orgapage.de') {
             $mf->AddFix('version', LANSUITE_VERSION);
@@ -69,7 +70,7 @@ if ($_GET['bugid'] and $auth['type'] < 2 and $row['reporter'] != $auth['userid']
         $mf->AddField(t('Bild / Datei anhängen'), 'file', \LanSuite\MasterForm::IS_FILE_UPLOAD, 'ext_inc/bugtracker_upload/', \LanSuite\MasterForm::FIELD_OPTIONAL);
     }
 
-    $mf->SendForm('index.php?mod=bugtracker&action=add', 'bugtracker', 'bugid', $_GET['bugid']);
+    $mf->SendForm('index.php?mod=bugtracker&action=add', 'bugtracker', 'bugid', $bugidParameter);
 
     $dsp->AddBackButton('index.php?mod=bugtracker');
 }

--- a/modules/bugtracker/export.php
+++ b/modules/bugtracker/export.php
@@ -1,5 +1,6 @@
 <?php
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $dsp->NewContent(t('Bugtracker Export'), t('Nutze diese Funktion um einen Export der Bugtracker-Einträge zu erstellen, den sie auf lansuite.de importieren können'));
         $dsp->AddDoubleRow('', t('Bitte versuche Fehler zunächst selbst zu beheben und filter vor dem Export Probleme aus, die nicht von generellem Interesse für Lansuite sind. Es werden nur Probleme mit Status offen, oder bestätigt exportiert. Ergänze unvollständige Angaben, so gut du kannst. Danke, für die Hilfe!'));

--- a/modules/bugtracker/import.php
+++ b/modules/bugtracker/import.php
@@ -1,5 +1,6 @@
 <?php
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $dsp->NewContent(t('Bugtracker Import'), t('Hier kannst du die bugs.xml-Datei Importieren, die du auf deiner Webseite exportiert hast'));
         $dsp->SetForm('index.php?mod=bugtracker&action=import&step=2', '', '', 'multipart/form-data');

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -21,8 +21,9 @@ $colors[5] = '#aaaaaa';
 $colors[6] = '#999999';
 $colors[7] = '#bc851b';
 
-if ($_POST['action']) {
-    foreach ($_POST['action'] as $key => $val) {
+$actionPOSTParameter = $_POST['action'] ?? null;
+if ($actionPOSTParameter) {
+    foreach ($actionPOSTParameter as $key => $val) {
         if ($auth['type'] >= 2) {
             // Change state
             if ($_GET['state'] != '' and $_GET['state'] >= 2) {
@@ -42,7 +43,8 @@ if ($_POST['action']) {
     }
 }
 
-if ($_GET['action'] == 'delete' and $auth['type'] >= 2) {
+$actionParameter = $_GET['action'] ?? '';
+if ($actionParameter == 'delete' && $auth['type'] >= 2) {
     if ($_GET['bugid'] != '') {
         $md = new \LanSuite\MasterDelete();
         $md->Delete('bugtracker', 'bugid', $_GET['bugid']);
@@ -52,7 +54,8 @@ if ($_GET['action'] == 'delete' and $auth['type'] >= 2) {
     }
 }
 
-if (!$_GET['bugid'] or $_GET['action'] == 'delete') {
+$bugidParameter = $_GET['bugid'] ?? null;
+if (!$bugidParameter || $actionParameter == 'delete') {
     $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der Verwendung dieses Systems auftreten, sowie Feature Wünsche äußern. Können die Admins dieser Webseite sie nicht selbst beheben, haben diese die Möglichkeit sie an das Lansuite-Team weiterzureichen.'));
 
     $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('bugtracker');


### PR DESCRIPTION
### What is this PR doing?

Fix PHP Warnings in bugtracker module

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, mainly PHP warnings due to upgrades
- [X] Documentation update -> Not needed