### PR TITLE
[Cron2] Fix several PHP Warnings

### DIFF
--- a/modules/cron2/add.php
+++ b/modules/cron2/add.php
@@ -4,7 +4,7 @@ $dsp->NewContent(t('Cronjob hinzufügen'), '');
 $mf = new \LanSuite\MasterForm();
 
 $mf->AddField(t('Name'), 'name');
-$mf->AddField(t('Statement'), '`function`');
+$mf->AddField(t('Statement'), 'function');
 $mf->AddField(t('Aktiv'), 'active', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
 $mf->AddField(
     t('Typ'),
@@ -15,4 +15,5 @@ $mf->AddField(
 );
 $mf->AddField(t('Ausführen täglich, um'), 'runat');
 
-$mf->SendForm('index.php?mod=cron2&action=add', 'cron', 'jobid', $_GET['jobid']);
+$jobIdParameter = $_GET['jobid'] ?? 0;
+$mf->SendForm('index.php?mod=cron2&action=add', 'cron', 'jobid', $jobIdParameter);

--- a/modules/cron2/show.php
+++ b/modules/cron2/show.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // Delete
     case 10:
         $md = new \LanSuite\MasterDelete();


### PR DESCRIPTION
### What is this PR doing?

Fix several warnings in the module Cron2

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, only PHP warnings 
- [X] Documentation update -> not needed