### PR TITLE
Fix several PHP Warnings in Modules

### DIFF
--- a/index_module.inc.php
+++ b/index_module.inc.php
@@ -26,7 +26,7 @@ if ($_GET["mod"] != 'install' && $func->admin_exists()) {
             $permission = $db->qry_first("SELECT 1 AS found FROM %prefix%user_permissions WHERE module = %string% AND userid = %int%", $_GET['mod'], $auth['userid']);
 
             // If not: Set his rights to user-rights
-            if (!$permission['found']) {
+            if (!$permission) {
                 $auth['type'] = \LS_AUTH_TYPE_USER;
                 $_SESSION['auth']['type'] = 1;
                 $authentication->auth['type'] = 1;

--- a/modules/board/forum.php
+++ b/modules/board/forum.php
@@ -12,7 +12,8 @@ if ($_GET['fid'] != '') {
     $dsp->AddSingleRow($new_thread ." ". $dsp->FetchIcon("back", "index.php?mod=board"));
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // Edit headline
     case 10:
         if ($auth['type'] >= 2) {

--- a/modules/board/thread.php
+++ b/modules/board/thread.php
@@ -2,7 +2,8 @@
 
 // Exec Admin-Functions
 if ($auth['type'] >= 2) {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter ) {
         // Close Thread
         case 10:
             $db->qry("UPDATE %prefix%board_threads SET closed = 1 WHERE tid = %int%", $_GET['tid']);

--- a/modules/boxes/show.php
+++ b/modules/boxes/show.php
@@ -1,5 +1,6 @@
 <?php
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // Activate
     case 10:
         foreach ($_POST['action'] as $key => $val) {

--- a/modules/foodcenter/statchange.php
+++ b/modules/foodcenter/statchange.php
@@ -6,7 +6,8 @@ if ($auth['type'] < 2) {
     unset($_GET['step']);
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 3:
         $time = time();
         if ($_GET['status'] == 6 || $_GET['status'] == 7) {
@@ -62,7 +63,8 @@ switch ($_GET['step']) {
         break;
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('news');
 

--- a/modules/guestlist/export.php
+++ b/modules/guestlist/export.php
@@ -7,7 +7,8 @@ $userManager = new \LanSuite\Module\UsrMgr\UserManager($mail);
 
 $guestlist = new LanSuite\Module\GuestList\GuestList($seating, $userManager);
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // Export CSV
     case 10:
         if (!$_POST['action'] and $_GET['userid']) {

--- a/modules/install/design.php
+++ b/modules/install/design.php
@@ -4,7 +4,8 @@ $xml = new \LanSuite\XML();
 
 $dsp->NewContent(t('Design Manager'), t('Editiere Design-Templates und setze das aktive Design'));
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // List designs
     default:
         // Open design-dir

--- a/modules/install/mc_search.php
+++ b/modules/install/mc_search.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 10:
         $md = new \LanSuite\MasterDelete();
         $md->MultiDelete('comments', 'commentid');

--- a/modules/install/translation.php
+++ b/modules/install/translation.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $dsp->NewContent(t('Übersetzen'), t('Es müssen nur Einträge eingetragen werden, die sich in der Zielsprache vom Orginal unterscheiden'));
     

--- a/modules/mail/inbox.php
+++ b/modules/mail/inbox.php
@@ -7,7 +7,8 @@ if (!$auth['userid']) {
 
 // If logged in
 if ($auth['userid']) {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         // Label
         // None
         case 10:

--- a/modules/mail/outbox.php
+++ b/modules/mail/outbox.php
@@ -20,7 +20,8 @@ $mail_read_total = $db->qry_first("
 $dsp->NewContent(t('Postausgang'), t('Du hast <b>%1</b> Mail(s) versendet. Davon wurde(n) <b>%2</b> gelesen.', $mail_send_total["n"], $mail_read_total["n"]));
 
 if ($auth['userid']) {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         // Check if it can delete from Database and delete
         case 20:
             if (!$_POST['action'] and $_GET['mailid']) {

--- a/modules/mail/trashcan.php
+++ b/modules/mail/trashcan.php
@@ -19,7 +19,8 @@ $mail_unread_total = $db->qry_first("
 $dsp->NewContent(t('Papierkorb'), t('Du hast <b>%1</b> Mail(s) in ihrem Papierkorb. Davon wurde(n) <b>%2</b> nicht von dir gelesen.', $mail_total["n"], $mail_unread_total["n"]));
 
 if ($auth['userid']) {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         // check if it can delete from Database and delete
         case 20:
             if (!$_POST['action'] and $_GET['mailid']) {

--- a/modules/msgsys/add.php
+++ b/modules/msgsys/add.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     // Mastersearch
     default:
         $additional_where = 'u.userid != '. (int)$auth["userid"];

--- a/modules/msgsys/remove.php
+++ b/modules/msgsys/remove.php
@@ -1,7 +1,8 @@
 <?php
 
 if ($_GET['queryid']) {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter ) {
         default:
             $rowcheck = $db->qry("
               SELECT id

--- a/modules/news/delete.php
+++ b/modules/news/delete.php
@@ -1,5 +1,6 @@
 <?php
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/news/search.inc.php');
         break;

--- a/modules/noc/device_details.php
+++ b/modules/noc/device_details.php
@@ -12,7 +12,8 @@ $db->qry("SELECT * from %prefix%noc_devices WHERE id = %int%", $_GET["deviceid"]
 if (!$row = $db->fetch_array()) {
     $func->error(t('Das gew&auml;hlte Device existiert nicht'));
 } else {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         default:
             $device_ip = $row["ip"];
             $readcommunity  = $row["readcommunity"];

--- a/modules/noc/find_ip.php
+++ b/modules/noc/find_ip.php
@@ -3,7 +3,8 @@
 include_once("modules/noc/class_noc.php");
 $noc = new noc();
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case "2":
         if ($_POST['ip'] == '') {
             $error_noc['ip'] = t('Bitte gib eine IP-Adresse f&uuml;r das Device ein');
@@ -11,8 +12,8 @@ switch ($_GET['step']) {
         }
 }
 
-
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
             $dsp->NewContent(t('User im Netzwerk finden'), t('Mit diesem Formular kannst du einen User im Netzwerk lokalisieren'));
             $dsp->SetForm("index.php?mod=noc&action=find&step=2");

--- a/modules/party/price.php
+++ b/modules/party/price.php
@@ -5,7 +5,8 @@ if (!$_GET['party_id']) {
 }
 $dsp->AddDoubleRow('Party', $party->data['name']);
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 11:
         $db->qry('UPDATE %prefix%partys SET evening_price_id = %int% WHERE party_id = %int%', $_GET['evening_price_id'], $_GET['party_id']);
         $func->confirmation(t('Der neue Abendkasse-Preis wurde gesetzt'));

--- a/modules/partylist/show.php
+++ b/modules/partylist/show.php
@@ -2,7 +2,8 @@
 
 $xml = new \LanSuite\XML();
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 10:
         $row = $db->qry_first("SELECT ls_url FROM %prefix%partylist WHERE partyid = %int%", $_GET['partyid']);
         if (substr($row['ls_url'], strlen($row['ls_url']) - 1, 1) != '/') {

--- a/modules/picgallery/show.php
+++ b/modules/picgallery/show.php
@@ -42,7 +42,7 @@ if (!$row['found']) {
 }
 
 // Upload posted File
-if (($cfg["picgallery_allow_user_upload"] or $auth["type"] > 1) and $_FILES["file_upload"]) {
+if (($cfg["picgallery_allow_user_upload"] || $auth["type"] > 1) && (array_key_exists('file_upload', $_FILES) && $_FILES['file_upload'])) {
     $extension = substr($_FILES['file_upload']['name'], strrpos($_FILES['file_upload']['name'], ".") + 1, 4);
     if (IsSupportedType($extension) || IsPackage($extension)) {
         $upload = $func->FileUpload("file_upload", $root_dir);

--- a/modules/rent/back.php
+++ b/modules/rent/back.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('news');
 

--- a/modules/rent/show.php
+++ b/modules/rent/show.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/rent/search.inc.php');
         break;

--- a/modules/seating/copy.php
+++ b/modules/seating/copy.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('seating');
 

--- a/modules/seating/delete.php
+++ b/modules/seating/delete.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/seating/search.inc.php');
         break;

--- a/modules/seating/edit.php
+++ b/modules/seating/edit.php
@@ -9,8 +9,9 @@ if ($_GET['action'] == 'add' and $_GET['step'] < 2) {
 }
 
 // Error-Switch
-$error = array();
-switch ($_GET['step']) {
+$error = [];
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 3:
         // Error Columns
         if ($_POST['cols'] == "") {
@@ -158,7 +159,8 @@ switch ($_GET['step']) {
 }
 
 // Form-Switch
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/seating/search.inc.php');
         break;

--- a/modules/seating/ip.php
+++ b/modules/seating/ip.php
@@ -5,7 +5,8 @@ use LanSuite\Module\Seating\Seat2;
 $blockid = $_GET['blockid'];
 $seating_ip = $_POST['seating_ip'];
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 3:
         $seating_ip_exists = array();
         $seating_ip = array();
@@ -28,7 +29,8 @@ switch ($_GET['step']) {
         break;
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $current_url = 'index.php?mod=seating&action=ip';
         $target_url = 'index.php?mod=seating&action=ip&step=2&blockid=';

--- a/modules/seating/ipgen.php
+++ b/modules/seating/ipgen.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $_POST["ipgen_a"] = "10";
         $_POST["ipgen_b"] = "10";

--- a/modules/seating/seatadmin.php
+++ b/modules/seating/seatadmin.php
@@ -62,7 +62,8 @@ if ($_GET['userid']) {
         AND pu.party_id = %int%", $_GET['userid'], $party->party_id);
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $additional_where = "p.party_id = {$party->party_id} and u.type > 0";
         $current_url = 'index.php?mod=seating&action=seatadmin';

--- a/modules/sponsor/delete.php
+++ b/modules/sponsor/delete.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/sponsor/search.inc.php');
         break;

--- a/modules/tournament2/rangliste.php
+++ b/modules/tournament2/rangliste.php
@@ -3,7 +3,8 @@
 if (!$_GET['tournamentid']) {
     $func->error(t('Du hast kein Turnier ausgewählt!'));
 } else {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         case 1:
               include_once('modules/tournament2/search.inc.php');
             break;

--- a/modules/tournament2/tournaments_change.php
+++ b/modules/tournament2/tournaments_change.php
@@ -1,6 +1,6 @@
 <?php
-
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case "open":
         if ($auth['type'] >= 3) {
             foreach ($_POST['action'] as $key => $val) {

--- a/modules/tournament2/tree.php
+++ b/modules/tournament2/tree.php
@@ -3,7 +3,8 @@
 if (!$_GET['tournamentid']) {
     $func->error(t('Du hast kein Turnier ausgewählt!'));
 } else {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         case 1:
             include_once('modules/tournament2/search.inc.php');
             break;

--- a/modules/troubleticket/cat.php
+++ b/modules/troubleticket/cat.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     case 2:
         if ($_POST['tticket_cat'] == 0 && $_GET['act'] == "change") {
             $error['tticket_cat'] = t('Du hast keine Kategorie zum ändern ausgewählt');
@@ -16,7 +17,8 @@ switch ($_GET['step']) {
         break;
 }
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $dsp->NewContent(t('Kategorie'));
         

--- a/modules/usrmgr/checkin_assistant.php
+++ b/modules/usrmgr/checkin_assistant.php
@@ -210,7 +210,8 @@ if (!$party->party_id) {
             break;
     }
 
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         case 10:
             $seat2->AssignSeat($_GET['userid'], $_GET['blockid'], $_GET['row'], $_GET['col']);
 

--- a/modules/usrmgr/delete.php
+++ b/modules/usrmgr/delete.php
@@ -2,7 +2,8 @@
 
 $md = new \LanSuite\MasterDelete();
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/usrmgr/search.inc.php');
         break;

--- a/modules/usrmgr/newpwd.php
+++ b/modules/usrmgr/newpwd.php
@@ -2,7 +2,8 @@
 
 $user_data = $db->qry_first("SELECT name, firstname, username, type FROM %prefix%user WHERE userid = %int%", $_GET['userid']);
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/usrmgr/search.inc.php');
         break;

--- a/modules/usrmgr/remind.php
+++ b/modules/usrmgr/remind.php
@@ -4,7 +4,8 @@ $dsp->NewContent(t('Passwort vergessen'), t('Mit diesem Modul kannst du dir ein 
 if (!$cfg['sys_internet']) {
     $func->information(t('Diese Funktion ist nur im Internetmodus verfügbar'));
 } else {
-    switch ($_GET['step']) {
+    $stepParameter = $_GET['step'] ?? 0;
+    switch ($stepParameter) {
         // Email prüfen, Freischaltecode generieren, Email senden
         case 2:
             $user_data = $db->qry_first("SELECT username FROM %prefix%user WHERE email = %string%", $_POST['pwr_mail']);

--- a/modules/usrmgr/user_fields.php
+++ b/modules/usrmgr/user_fields.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('usrmgr');
     

--- a/modules/usrmgr/verify_email.php
+++ b/modules/usrmgr/verify_email.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         $dsp->NewContent(t('Email-Adresse verifizieren'), '');
 

--- a/modules/wiki/delete.php
+++ b/modules/wiki/delete.php
@@ -1,6 +1,7 @@
 <?php
 
-switch ($_GET['step']) {
+$stepParameter = $_GET['step'] ?? 0;
+switch ($stepParameter) {
     default:
         include_once('modules/wiki/search.php');
         break;


### PR DESCRIPTION
### What is this PR doing?

Fixing various "array key not found" PHP warnings.
Mainly in modules related to the `step` parameter.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed