### PR TITLE
Fix several warnings on the first page hit when no session exists

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -254,12 +254,17 @@ class Auth
                 $user = [
                     'userid' => 0,
                     'found' => 0,
+                    'user_login' => 0,
                 ];
             }
 
             // Needs to be a seperate query; WHERE (p.party_id IS NULL OR p.party_id=%int%) does not work when 2 parties exist
             if ($func->isModActive('party')) {
-                $party_query = $db->qry_first('SELECT p.checkin AS checkin, p.checkout AS checkout FROM %prefix%party_user AS p WHERE p.party_id=%int% AND user_id=%int%', $party->party_id, $user['userid']);
+                $partyID = 0;
+                if ($party) {
+                    $partyID = $party->party_id;
+                }
+                $party_query = $db->qry_first('SELECT p.checkin AS checkin, p.checkout AS checkout FROM %prefix%party_user AS p WHERE p.party_id=%int% AND user_id=%int%', $partyID, $user['userid']);
             }
 
             // Count login errors

--- a/modules/party/Classes/Party.php
+++ b/modules/party/Classes/Party.php
@@ -31,7 +31,7 @@ class Party
                 $this->party_id = $setPartyIDGETParameter;
             } elseif (is_numeric($setPartyIDPOSTParameter)) {
                 $this->party_id = $setPartyIDPOSTParameter;
-            } elseif (is_numeric($_SESSION['party_id'])) {
+            } elseif (array_key_exists('party_id', $_SESSION) && is_numeric($_SESSION['party_id'])) {
                 // Look whether this partyId exists
                 $row = $db->qry_first('SELECT 1 AS found FROM %prefix%partys WHERE party_id = %int%', $_SESSION['party_id']);
                 if (is_array($row) && $row['found']) {


### PR DESCRIPTION
### What is this PR doing?

Fix several warnings on the first page hit when no session exists

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed, only warning fixes
- [X] Documentation update -> Not needed