### PR TITLE
Add versioning strategy to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    versioning-strategy: widen
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -24,3 +25,4 @@ updates:
     directory: "/website/"
     schedule:
       interval: "monthly"
+    versioning-strategy: auto


### PR DESCRIPTION
Proposal to set a dependency update strategy for `npm` and `composer` to bump dependency versions when needed.

### What is this PR doing?

Sets versioning-strategy for `composer` to `widen` and `npm` to `auto` to include required version bumps in the dependabot PRs if needed

### Which issue(s) this PR fixes:

refs #776 #777

### Checklist

- [ ] `CHANGELOG.md` entry
- [ ] Documentation update