### PR TITLE
[Install] Fix PHP Warnings in Module install overview

### DIFF
--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -972,7 +972,7 @@ class Install
         $smarty->assign('showLinks', $showLinks);
         if ($showLinks) {
             $find_config = $db->qry_first("SELECT cfg_key FROM %prefix%config WHERE (cfg_module = %string%)", $row["name"]);
-            if ($find_config["cfg_key"] != '') {
+            if (is_array($find_config) && $find_config["cfg_key"] != '') {
                 $settings_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=10&module={$row["name"]}\">". t('Konfig.') ."</a>";
             } else {
                 $settings_link = "";
@@ -980,7 +980,7 @@ class Install
             $smarty->assign('settings_link', $settings_link);
 
             $find_mod = $db->qry_first("SELECT module FROM %prefix%menu WHERE module=%string%", $row["name"]);
-            if ($find_mod["module"]) {
+            if (is_array($find_mod) && $find_mod["module"]) {
                 $menu_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=30&module={$row["name"]}\">". t('Menü') ."</a>";
             } else {
                 $menu_link = "";

--- a/modules/install/modules.php
+++ b/modules/install/modules.php
@@ -4,12 +4,13 @@ $importXml = new \LanSuite\XML();
 $installImport = new \LanSuite\Module\Install\Import($importXml);
 $install = new \LanSuite\Module\Install\Install($installImport);
 
-switch ($_GET["step"]) {
+$stepParameter = $_GET["step"] ?? 0;
+switch ($stepParameter) {
     // Update Modules
     case 2:
         $res = $db->qry("SELECT name, reqphp, reqmysql FROM %prefix%modules WHERE changeable");
         while ($row = $db->fetch_array($res)) {
-            if ($_POST[$row["name"]]) {
+            if (array_key_exists($row["name"], $_POST) && $_POST[$row["name"]]) {
                 if ($row['reqphp'] and version_compare(PHP_VERSION, $row['reqphp']) < 0) {
                     $func->information(t('Das Modul %1 kann nicht aktiviert werden, da die PHP Version %2 benötigt wird', $row["name"], $row['reqphp']), NO_LINK);
                 } else {
@@ -107,27 +108,28 @@ switch ($_GET["step"]) {
     default:
       // If Rewrite, delete corresponding items
         $rewrite_all = 0;
-        if ($_GET["rewrite"] == "all") {
+        $rewriteParameter = $_GET["rewrite"] ?? '';
+        if ($rewriteParameter == "all") {
             $db->qry("TRUNCATE TABLE %prefix%config");
             $db->qry("TRUNCATE TABLE %prefix%modules");
             $db->qry("TRUNCATE TABLE %prefix%menu");
             $rewrite_all = 1;
-        } elseif ($_GET["rewrite"]) {
-            $db->qry("DELETE FROM %prefix%modules WHERE name = %string%", $_GET["rewrite"]);
-            $db->qry("DELETE FROM %prefix%menu WHERE module = %string%", $_GET["rewrite"]);
-            $db->qry("DELETE FROM %prefix%boxes WHERE module = %string%", $_GET["rewrite"]);
+        } elseif ($rewriteParameter) {
+            $db->qry("DELETE FROM %prefix%modules WHERE name = %string%", $rewriteParameter);
+            $db->qry("DELETE FROM %prefix%menu WHERE module = %string%", $rewriteParameter);
+            $db->qry("DELETE FROM %prefix%boxes WHERE module = %string%", $rewriteParameter);
 
-            $_GET["rewrite"] .= "_";
-            if ($_GET["rewrite"] == "downloads_") {
-                $_GET["rewrite"] = "Download";
+            $rewriteParameter .= "_";
+            if ($rewriteParameter == "downloads_") {
+                $rewriteParameter= "Download";
             }
-            if ($_GET["rewrite"] == "usrmgr_") {
-                $_GET["rewrite"] = "Userdetails";
+            if ($rewriteParameter == "usrmgr_") {
+                $rewriteParameter = "Userdetails";
             }
-            if ($_GET["rewrite"] == "tournament2_") {
-                $_GET["rewrite"] = "t";
+            if ($rewriteParameter == "tournament2_") {
+                $rewriteParameter = "t";
             }
-            $find_config = $db->qry_first("DELETE FROM %prefix%config WHERE (cfg_group = %string%) OR (cfg_key LIKE %string%)", $_GET["rewrite"], $_GET["rewrite"].'%');
+            $find_config = $db->qry_first("DELETE FROM %prefix%config WHERE (cfg_group = %string%) OR (cfg_key LIKE %string%)", $rewriteParameter, $rewriteParameter .'%');
         }
 
         // Auto-Load Modules from XML-Files


### PR DESCRIPTION
### What is this PR doing?

Fixing PHP Warnings in the Installation overview while installing modules

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed