### PR TITLE
[Authentication] Replace magic number comparision of $auth['type'] >= 3 with the usage of \LS_AUTH_TYPE_SUPERADMIN

### DIFF
--- a/inc/Classes/MasterComment.php
+++ b/inc/Classes/MasterComment.php
@@ -61,7 +61,7 @@ class MasterComment
         $ms2->AddIconField('quote', 'javascript:document.getElementById(\'text\').value += \'[quote]\' + document.getElementById(\'post%id%\').innerHTML + \'[/quote]\'', t('Zitieren'));
         $ms2->AddIconField('edit', $CurentURLBase.'&commentid=%id%#dsp_form2', t('Editieren'), 'MasterCommentEditAllowed');
 
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddIconField('delete', $CurentURLBase.'&mc_step=10&commentid=', t('Löschen'));
         }
 

--- a/index.php
+++ b/index.php
@@ -253,7 +253,7 @@ if ($config['environment']['configured'] == 0) {
     $IsAboutToInstall = 1;
 
     // Force Admin rights for installing User
-    $auth["type"] = 3;
+    $auth['type'] = \LS_AUTH_TYPE_SUPERADMIN;
     $auth["login"] = 1;
     $auth['userid'] = 0;
 

--- a/modules/board/admin_search.php
+++ b/modules/board/admin_search.php
@@ -35,10 +35,10 @@ if ($_POST['action']) {
     $ms2->AddResultField(t('IP'), 'INET6_NTOA(p.ip) AS ip');
     $ms2->AddResultField(t('Datum'), 'p.date', 'MS2GetDate');
 
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=board&action=delete&step=10&pid=', t('Delete'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddMultiSelectAction(t('Delete'), 'index.php?mod=board&action=admin_search&mode=del', 1);
     }
   

--- a/modules/board/forum.php
+++ b/modules/board/forum.php
@@ -151,7 +151,7 @@ if ($_GET['action'] != 'bookmark') {
     if ($auth['type'] >= 2) {
         $ms2->AddIconField('edit', 'index.php?mod=board&action=forum&step=10&fid='. $_GET['fid'] .'&tid=', t('Überschrift editieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=board&action=delete&step=11&tid=', t('Löschen'));
     }
 

--- a/modules/board/show.php
+++ b/modules/board/show.php
@@ -18,7 +18,7 @@ $ms2->AddIconField('details', 'index.php?mod=board&action=forum&fid=', t('Detail
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=board&action=add&var=change&fid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=board&action=delete&step=2&fid=', t('Löschen'));
 }
 $ms2->PrintSearch('index.php?mod=board', 'f.fid');

--- a/modules/boxes/show.php
+++ b/modules/boxes/show.php
@@ -72,7 +72,7 @@ $ms2->AddResultField(t('Quelldatei'), 'b.source');
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=boxes&amp;step=20&amp;boxid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=boxes&amp;step=30&amp;boxid=', t('Löschen'));
 }
 

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -135,7 +135,7 @@ if (!$bugidParameter || $actionParameter == 'delete') {
     if ($auth['type'] >= 2) {
         $ms2->AddIconField('edit', 'index.php?mod=bugtracker&action=add&bugid=', t('Editieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=bugtracker&action=delete&bugid=', t('Löschen'));
     }
 

--- a/modules/cashmgr/myaccounting.php
+++ b/modules/cashmgr/myaccounting.php
@@ -1,8 +1,8 @@
 <?php
 
-if ($_GET['act'] == "him" && $auth['type'] < 3) {
+if ($_GET['act'] == "him" && $auth['type'] < \LS_AUTH_TYPE_SUPERADMIN) {
     $func->information("ACCESS_DENIED");
-} elseif ($_GET['act'] == "him" && $auth['type'] = 3) {
+} elseif ($_GET['act'] == "him" && $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
     $stepParameter = $_GET['step'] ?? 0;
     switch ($stepParameter) {
         case 2:

--- a/modules/cashmgr/show.php
+++ b/modules/cashmgr/show.php
@@ -26,7 +26,7 @@ if (!$stepParameter) {
 
 switch ($stepParameter) {
     case 1:
-        if ($auth['type'] < 3) {
+        if ($auth['type'] < \LS_AUTH_TYPE_SUPERADMIN) {
             $func->information("ACCESS_DENIED");
         } else {
             $dsp->NewContent(t('Kalkulation'), t('Zur aktuellen Lanparty zum derzeitigen Stand'));

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -24,11 +24,11 @@ switch ($stepParameter) {
         if ($auth['type'] >= 2) {
             $ms2->AddIconField('edit', 'index.php?mod=clanmgr&step=30&clanid=', t('Editieren'));
         }
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddIconField('delete', 'index.php?mod=clanmgr&step=20&clanid=', t('Löschen'));
         }
 
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=clanmgr&step=20', 1);
         }
 
@@ -86,7 +86,7 @@ switch ($stepParameter) {
         $ms2->AddResultField(t('Rolle'), 'u.clanadmin', 'ShowRole');
     
         $ms2->AddIconField('details', 'index.php?mod=usrmgr&action=details&userid=', t('Clan-Details'));
-        if ($auth['type'] >= 3 | ($auth['clanid'] == $_GET['clanid'] & $auth['clanadmin'] == 1)) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN || ($auth['clanid'] == $_GET['clanid'] && $auth['clanadmin'] == 1)) {
             $ms2->AddIconField('delete', 'index.php?mod=clanmgr&action=clanmgr&step=40&clanid='. $_GET['clanid'] .'&userid=', t('Löschen'));
         }
 
@@ -128,7 +128,7 @@ switch ($stepParameter) {
 
     // Delete
     case 20:
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             if ($_GET['clanid']) {
                 $_POST['action'][$_GET['clanid']] = 1;
             }

--- a/modules/downloads/stats.php
+++ b/modules/downloads/stats.php
@@ -2,7 +2,7 @@
 $dsp->NewContent(t('Statistiken'), $_GET['file']);
 
 // Delete
-if ($_GET['delfile'] and $auth['type'] >= 3) {
+if ($_GET['delfile'] and $auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $md = new \LanSuite\MasterDelete();
     $md->Delete('download_stats', 'file', $_GET['delfile']);
 }
@@ -18,7 +18,7 @@ if (!$_GET['file']) {
     $ms2->AddResultField(t('Downloads'), 'SUM(s.hits) AS hits');
 
     $ms2->AddIconField('details', 'index.php?mod=downloads&action=stats&file=', t('Details'));
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=downloads&action=stats&delfile=', t('Löschen'));
     }
 

--- a/modules/guestbook/show.php
+++ b/modules/guestbook/show.php
@@ -18,7 +18,7 @@ $ms2->AddResultField(t('Datum'), 'g.date', 'MS2GetDate');
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=guestbook&action=add&guestbookid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=guestbook&action=delete&guestbookid=', 1);
 }
 $ms2->PrintSearch('index.php?mod=guestbook', 'g.guestbookid');

--- a/modules/home/show.php
+++ b/modules/home/show.php
@@ -5,7 +5,7 @@ $db->qry('DELETE FROM %prefix%lastread WHERE DATEDIFF(NOW(), date) > 7 AND tab !
 
 if ($auth["type"] == 1) {
     $home_page = $cfg["home_login"];
-} elseif ($auth["type"] == 2 or $auth["type"] == 3) {
+} elseif ($auth["type"] == 2 or $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
     $home_page = $cfg["home_admin"];
 } else {
     $home_page = $cfg["home_logout"];

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -52,7 +52,7 @@ if ($auth['type'] <= 1) {
             if ($auth['type'] >= 2) {
                   $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
-            if ($auth['type'] >= 3) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
                   $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
             }
 
@@ -86,7 +86,7 @@ if ($auth['type'] <= 1) {
             if ($auth['type'] >= 2) {
                 $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
-            if ($auth['type'] >= 3) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
                 $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
             }
 

--- a/modules/install/log.php
+++ b/modules/install/log.php
@@ -49,7 +49,7 @@ switch ($_GET["step"]) {
         $ms2->AddResultField(t('Prio.'), 'l.type');
 
         $ms2->AddIconField('details', 'index.php?mod=install&action=log&step=2&logid=', t('Details'));
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddMultiSelectAction(t('Löschen'), "index.php?mod=install&action=log&step=10", 1);
         }
 

--- a/modules/install/mc_search.php
+++ b/modules/install/mc_search.php
@@ -60,7 +60,7 @@ $ms2->AddResultField(t('Beitrags ID'), 'c.relatedto_id');
 $ms2->AddResultField(t('Datum'), 'UNIX_TIMESTAMP(c.date) AS date', 'MS2GetDate');
 $ms2->AddResultField(t('Auslöser'), 'u.username', 'UserNameAndIcon');
 
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=install&action=mc_search&step=10', 1);
 }
 

--- a/modules/install/sessions.php
+++ b/modules/install/sessions.php
@@ -45,7 +45,7 @@ switch ($_GET["step"]) {
         $ms2->AddResultField(t('Eingeloggt'), 'a.logintime', 'MS2GetDate');
         $ms2->AddResultField(t('Letzter Aufruf'), 'a.lasthit', 'MS2GetDate');
 
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddMultiSelectAction(t('Session beenden'), "index.php?mod=install&action=sessions&step=10", 1);
         }
 

--- a/modules/install/translation.php
+++ b/modules/install/translation.php
@@ -85,7 +85,7 @@ switch ($stepParameter) {
     case 10:
         $dsp->NewContent(t('Übersetzen'), t('Es müssen nur Einträge eingetragen werden, die sich in der Zielsprache vom Orginal unterscheiden'));
 
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $dsp->AddFieldSetStart(t('FrameWork'));
             $dsp->AddSingleRow($translation->TUpdateFromFiles('inc/classes'));
             $dsp->AddFieldSetEnd();

--- a/modules/news/search.inc.php
+++ b/modules/news/search.inc.php
@@ -20,7 +20,7 @@ $ms2->AddIconField('details', 'index.php?mod=news&action=comment&newsid=', t('De
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=news&action=change&step=2&newsid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=news&action=delete&step=2&newsid=', t('Löschen'));
 }
 

--- a/modules/noc/search.inc.php
+++ b/modules/noc/search.inc.php
@@ -14,7 +14,7 @@ $ms2->AddIconField('details', 'index.php?mod=noc&action=details_device&deviceid=
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=noc&action=change_device&step=2&deviceid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=noc&action=delete_device&step=2&deviceid=', t('Löschen'));
 }
 

--- a/modules/party/price.php
+++ b/modules/party/price.php
@@ -30,7 +30,7 @@ if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=party&action=price_edit&party_id='. $_GET['party_id'] .'&price_id=', t('Editieren'));
 }
 
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=party&action=price_del&party_id='. $_GET['party_id'], 1);
 }
 

--- a/modules/partylist/show.php
+++ b/modules/partylist/show.php
@@ -45,7 +45,7 @@ if (!$_GET['partyid']) {
         $ms2->AddIconField('signon', 'index.php?mod=partylist&step=10&design=base&partyid=', t('Anmelden'));
     }
     $ms2->AddIconField('edit', 'index.php?mod=partylist&action=add&partyid=', t('Editieren'), 'EditAllowed');
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=partylist&action=delete&partyid=', t('Löschen'));
     }
 

--- a/modules/poll/search.inc.php
+++ b/modules/poll/search.inc.php
@@ -21,7 +21,7 @@ if ($auth['type'] >= 2) {
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=poll&action=change&step=2&pollid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=poll&action=delete&step=2&pollid=', t('Löschen'));
 }
 

--- a/modules/rent/search.inc.php
+++ b/modules/rent/search.inc.php
@@ -22,7 +22,7 @@ if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=rent&action=add&stuffid=', t('Editieren'));
 }
 
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=rent&action=delete&stuffid=', t('Löschen'));
 }
 

--- a/modules/sample/show.php
+++ b/modules/sample/show.php
@@ -84,7 +84,7 @@ $ms2->AddIconField('details', 'index.php?mod=news&action=comment&newsid=', t('De
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=news&action=change&step=2&newsid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=news&action=delete&step=2&newsid=', t('Löschen'));
 }
 

--- a/modules/seating/search_basic_blockselect.inc.php
+++ b/modules/seating/search_basic_blockselect.inc.php
@@ -20,20 +20,20 @@ if ($target_url) {
 } else {
     $ms2->AddIconField('details', 'index.php?mod=seating&action=show&step=2&blockid=', t('Details'));
 
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('ip_generate', 'index.php?mod=seating&action=ipgen&blockid=', t('IPs generieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('ip_edit', 'index.php?mod=seating&action=ip&step=2&blockid=', t('IPs editieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('ip_del', 'index.php?mod=seating&action=ipgen&step=20&blockid=', t('IPs löschen'));
     }
 
     if ($auth['type'] >= 2) {
         $ms2->AddIconField('edit', 'index.php?mod=seating&action=edit&step=2&blockid=', t('Editieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=seating&action=delete&step=2&blockid=', t('Löschen'));
     }
 }

--- a/modules/server/search.inc.php
+++ b/modules/server/search.inc.php
@@ -23,7 +23,7 @@ $ms2->AddIconField('details', 'index.php?mod=server&action=show_details&serverid
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=server&action=change&step=2&serverid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=server&action=delete&step=2&serverid=', t('Löschen'));
 }
 

--- a/modules/sponsor/search.inc.php
+++ b/modules/sponsor/search.inc.php
@@ -9,7 +9,7 @@ $ms2->AddResultField('Autor', 's.url');
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=sponsor&amp;action=change&amp;sponsorid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=sponsor&amp;action=delete&amp;step=2&sponsorid=', t('Löschen'));
 }
 

--- a/modules/tournament2/search.inc.php
+++ b/modules/tournament2/search.inc.php
@@ -32,17 +32,17 @@ if ($auth['type'] >= 2) {
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=tournament2&action=change&step=1&tournamentid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=tournament2&action=delete&step=2&tournamentid=', t('Löschen'));
 }
 
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction('Anmeldung &ouml;ffnen', 'index.php?mod=tournament2&action=changestat&step=open', 1);
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction('Anmeldung sperren', 'index.php?mod=tournament2&action=changestat&step=lock', 1);
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction('L&ouml;schen', 'index.php?mod=tournament2&action=delete&step=10', 1);
 }
 

--- a/modules/tournament2/tournaments_change.php
+++ b/modules/tournament2/tournaments_change.php
@@ -2,7 +2,7 @@
 $stepParameter = $_GET['step'] ?? 0;
 switch ($stepParameter) {
     case "open":
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 echo $key;
                 $db->qry('UPDATE %prefix%tournament_tournaments SET status = %string% WHERE tournamentid = %int%', "open", $key);
@@ -13,7 +13,7 @@ switch ($stepParameter) {
         break;
   
     case "lock":
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 echo $key;
                 $db->qry('UPDATE %prefix%tournament_tournaments SET status = %string% WHERE tournamentid = %int%', "locked", $key);

--- a/modules/troubleticket/search_main.inc.php
+++ b/modules/troubleticket/search_main.inc.php
@@ -21,6 +21,6 @@ if ($auth['type'] >= 2) {
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=troubleticket&action=change&step=2&ttid=', 'Edit');
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=troubleticket&action=delete&step=2&ttid=', 'Delete');
 }

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -43,7 +43,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
                 $selections = [];
                 $selections['1'] = t('Benutzer');
                 $selections['2'] = t('Administrator');
-                if ($auth['type'] >= 3) {
+                if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
                     $selections['3'] = t('Superadmin');
                 }
                 $mf->AddField(t('Benutzertyp'), 'type', \LanSuite\MasterForm::IS_SELECTION, $selections, '', '', 1, array('2', '3'));

--- a/modules/usrmgr/details.php
+++ b/modules/usrmgr/details.php
@@ -99,7 +99,7 @@ if (!$user_data['userid']) {
     if (IsAuthorizedAdmin() or ($_GET['userid'] == $auth['userid'])) { # and $cfg['user_self_details_change']
         $name .= ' '. $dsp->FetchIcon('edit', 'index.php?mod=usrmgr&action=change&step=1&userid=' . $_GET['userid'], t('Editieren'));
     }
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $name .= ' '. $dsp->FetchIcon('delete', 'index.php?mod=usrmgr&action=delete&step=2&userid=' . $_GET['userid'], t('Löschen'));
     }
     $name .= '</td></tr></table>';
@@ -345,7 +345,7 @@ if (!$user_data['userid']) {
     $ms2->AddResultField(t('Internet-Mail'), 'b.email');
     $ms2->AddResultField(t('System-Mail'), 'b.sysemail');
 
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=usrmgr&action=details&userid='. $_GET['userid'] .'&step=10&tab=1', 1);
     }
 
@@ -390,7 +390,7 @@ if (!$user_data['userid']) {
         $dsp->EndTab();
     }
 
-    if ($auth['type'] >= 3) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $dsp->StartTab(t('Sessions'), 'generate');
 
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('usrmgr');

--- a/modules/usrmgr/search.inc.php
+++ b/modules/usrmgr/search.inc.php
@@ -33,7 +33,7 @@ $ms2->AddIconField('change_pw', 'index.php?mod=usrmgr&action=newpwd&step=2&useri
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('assign', 'index.php?mod=auth&action=switch_to&userid=', t('Benutzer wechseln'), 'IfLowerUserlevel');
 }
-if ($auth['type'] >= 3 and $func->isModActive('foodcenter')) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN and $func->isModActive('foodcenter')) {
     $ms2->AddIconField('paid', 'index.php?mod=foodcenter&action=account&act=payment&step=2&userid=', t('Geld auf Konto buchen'));
 }
 $ms2->AddIconField('locked', 'index.php?mod=usrmgr&step=11&userid=', t('Account freigeben'), 'IfLocked');
@@ -48,7 +48,7 @@ while ([$caption, $inc] = $plugin->fetch()) {
 if ($auth['type'] >= 2) {
     $ms2->AddIconField('edit', 'index.php?mod=usrmgr&action=change&step=1&userid=', t('Editieren'));
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=usrmgr&action=delete&step=2&userid=', t('Löschen'));
 }
 
@@ -67,7 +67,7 @@ if ($auth['type'] >= 2) {
 if ($auth['type'] >= 2) {
     $ms2->AddMultiSelectAction(t('Sperren'), "index.php?mod=usrmgr&step=10", 1, 'locked');
 }
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddMultiSelectAction(t('Löschen'), "index.php?mod=usrmgr&action=delete&step=10", 1, 'delete');
 }
 

--- a/modules/usrmgr/user_fields.php
+++ b/modules/usrmgr/user_fields.php
@@ -13,7 +13,7 @@ switch ($stepParameter) {
         $ms2->AddResultField('Bezeichnung', 'f.caption');
         $ms2->AddResultField('Optional', 'f.optional');
     
-        if ($auth['type'] >= 3) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddIconField('delete', 'index.php?mod=usrmgr&action=user_fields&step=20&fieldid=', t('Löschen'));
         }
         $ms2->PrintSearch('index.php?mod=usrmgr&action=user_fields', 'f.fieldid');

--- a/modules/wiki/search.php
+++ b/modules/wiki/search.php
@@ -18,7 +18,7 @@ $ms2->AddResultField(t('Letzer Autor'), 'u.username', 'UserNameAndIcon');
 $ms2->AddResultField(t('Letzte Änderung'), 'UNIX_TIMESTAMP(v.date) AS date', 'MS2GetDate');
 
 $ms2->AddIconField('details', 'index.php?mod=wiki&action=show&postid=', t('Details'));
-if ($auth['type'] >= 3) {
+if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=wiki&action=delete&step=2&postid=', t('Löschen'));
 }
 


### PR DESCRIPTION
### What is this PR doing?

We use the magic number "3" everywhere to indicate permissions.
Using the constant `\LS_AUTH_TYPE_SUPERADMIN` creates more context for the reader and is also easier to search for.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed