### PR TITLE
[Authentication] Replace magic number comparision of $auth['type'] >= 2 with the usage of \LS_AUTH_TYPE_ADMIN

### DIFF
--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -427,7 +427,7 @@ ga('send', 'pageview');
                         $smarty->assign('MainRightBox', '');
                     }
                     $smarty->assign('MainLogo', '<img src="design/'.$this->design.'/images/lansuite-logo.gif" alt="Lansuite Logo" title="Lansuite Logo" border="0" />');
-                    if ($auth['type'] >= 2 and isset($debug)) { // and $cfg['sys_showdebug'] (no more, for option now in inc/base/config)
+                    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and isset($debug)) { // and $cfg['sys_showdebug'] (no more, for option now in inc/base/config)
                         $smarty->assign('MainDebug', $debug->show());
                     }
                 } elseif ($_SESSION['lansuite']['fullscreen']) {

--- a/inc/Classes/MasterComment.php
+++ b/inc/Classes/MasterComment.php
@@ -77,7 +77,7 @@ class MasterComment
                 $row = $db->qry_first('SELECT creatorid FROM %prefix%comments WHERE commentid = %int%', $_GET['commentid']);
             }
 
-            if (!$commentIdParameter || (is_array($row) && $row['creatorid'] && $row['creatorid'] == $auth['userid']) || $auth['type'] >= 2) {
+            if (!$commentIdParameter || (is_array($row) && $row['creatorid'] && $row['creatorid'] == $auth['userid']) || $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $mf = new MasterForm();
                 $mf->LogID = $id;
 

--- a/inc/Functions/MasterCommentEditAllowed.php
+++ b/inc/Functions/MasterCommentEditAllowed.php
@@ -7,7 +7,7 @@ function MasterCommentEditAllowed()
 {
     global $line, $auth;
 
-    if ($line['creatorid'] == $auth['userid'] || $auth['type'] >= 2) {
+    if ($line['creatorid'] == $auth['userid'] || $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         return true;
     }
 

--- a/modules/board/forum.php
+++ b/modules/board/forum.php
@@ -16,7 +16,7 @@ $stepParameter = $_GET['step'] ?? 0;
 switch ($stepParameter) {
     // Edit headline
     case 10:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $dsp->AddFieldsetStart(t('Thread bearbeiten'));
             $mf = new \LanSuite\MasterForm();
             $mf->AddField(t('Überschrift'), 'caption', 'varchar(255)');
@@ -26,7 +26,7 @@ switch ($stepParameter) {
         break;
 
     case 20:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 $db->qry_first("UPDATE %prefix%board_threads SET fid = %int% WHERE tid = %int%", $_GET['to_fid'], $key);
             }
@@ -48,7 +48,7 @@ switch ($stepParameter) {
     case 43:
     case 44:
     case 45:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 $db->qry('UPDATE %prefix%board_threads SET label = %int% WHERE tid = %int%', $_GET['step'] - 40, $key);
             }
@@ -58,7 +58,7 @@ switch ($stepParameter) {
     // Sticky
     // Add
     case 50:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 $db->qry('UPDATE %prefix%board_threads SET sticky = 1 WHERE tid = %int%', $key);
             }
@@ -66,7 +66,7 @@ switch ($stepParameter) {
         break;
     // Remove
     case 51:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 $db->qry('UPDATE %prefix%board_threads SET sticky = 0 WHERE tid = %int%', $key);
             }
@@ -74,7 +74,7 @@ switch ($stepParameter) {
         break;
     // Close Threads
     case 52:
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             foreach ($_POST['action'] as $key => $val) {
                 $db->qry("UPDATE %prefix%board_threads SET closed = 1 WHERE tid = %int%", $key);
             }
@@ -148,14 +148,14 @@ if ($_GET['action'] == 'bookmark') {
 
 $ms2->AddIconField('details', 'index.php?mod=board&action=thread&tid=', t('Details'));
 if ($_GET['action'] != 'bookmark') {
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddIconField('edit', 'index.php?mod=board&action=forum&step=10&fid='. $_GET['fid'] .'&tid=', t('Überschrift editieren'));
     }
     if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=board&action=delete&step=11&tid=', t('Löschen'));
     }
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $res = $db->qry("SELECT fid, name FROM %prefix%board_forums");
         while ($row = $db->fetch_array($res)) {
             $ms2->AddMultiSelectAction(t('Verschieben nach '). $row['name'], 'index.php?mod=board&action=forum&step=20&to_fid='. $row['fid'] .'&fid='. $_GET['fid'], 1, 'in');

--- a/modules/board/show.php
+++ b/modules/board/show.php
@@ -15,7 +15,7 @@ $ms2->AddResultField(t('Beiträge'), 'COUNT(p.pid) AS posts');
 $ms2->AddResultField(t('Letzter Beitrag'), 'UNIX_TIMESTAMP(MAX(p.date)) AS LastPost', 'LastPostDetailsShow');
 
 $ms2->AddIconField('details', 'index.php?mod=board&action=forum&fid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=board&action=add&var=change&fid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/board/thread.php
+++ b/modules/board/thread.php
@@ -1,7 +1,7 @@
 <?php
 
 // Exec Admin-Functions
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $stepParameter = $_GET['step'] ?? 0;
     switch ($stepParameter ) {
         // Close Thread
@@ -139,7 +139,7 @@ if (!$thread and $tid) {
         $smarty->assign('username', $dsp->FetchUserIcon($row['userid'], $userdata["username"]));
 
         $type = $userdata["type"];
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $type .= '<br />IP: <a href="https://dnsquery.org/ipwhois/'. $row['ip'] .'" target="_blank">'. $row['ip'] .'</a>';
         }
         $smarty->assign('type', $userdata["type"]);

--- a/modules/boxes/Classes/Menu.php
+++ b/modules/boxes/Classes/Menu.php
@@ -158,7 +158,7 @@ class Menu
                     $db->free_result($res2);
 
                     // If Admin add general Management-Links
-                    if ($auth['type'] > 2) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
                         $adminIcons = $this->box->LinkItem('index.php?mod=install&amp;action=mod_cfg&amp;module='. $module, t('Mod-Konfig'), 'admin', t('Dieses Modul verwalten'));
                         $this->box->Row('<span class="AdminIcons">'. $adminIcons .'</span>');
                     }

--- a/modules/boxes/boxes.php
+++ b/modules/boxes/boxes.php
@@ -116,7 +116,7 @@ unset($BoxRes);
 
 // Add Link to boxmanager, if menu is missing and loginbox, if not logged in
 if (!$MenuActive) {
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $box = new Boxes();
         $box->Row(t('Keine Navigation gefunden. Bitte korrekte zuweisung Box / Navigation prüfen (BoxID). Temporäre Links aktiviert.'));
         $box->EmptyRow();

--- a/modules/boxes/show.php
+++ b/modules/boxes/show.php
@@ -69,7 +69,7 @@ $ms2->AddResultField(t('Position'), 'b.pos');
 $ms2->AddResultField(t('Aktiv'), 'b.active', 'TrueFalse');
 $ms2->AddResultField(t('Quelldatei'), 'b.source');
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=boxes&amp;step=20&amp;boxid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/bugtracker/add.php
+++ b/modules/bugtracker/add.php
@@ -3,7 +3,7 @@ $dsp->NewContent(t('Bugtracker'), t('Hier kannst du Fehler melden, die bei der V
 
 $bugidParameter = $_GET['bugid'] ?? 0;
 $row = $db->qry_first('SELECT reporter FROM %prefix%bugtracker WHERE bugid = %int%', $bugidParameter);
-if ($bugidParameter && $auth['type'] < 2 && $row['reporter'] != $auth['userid']) {
+if ($bugidParameter && $auth['type'] < \LS_AUTH_TYPE_ADMIN && $row['reporter'] != $auth['userid']) {
     $func->error(t('Nur Admins und der Reporter dürfen Bug-Einträge im Nachhinein editieren'), 'index.php?mod=bugtracker');
 } else {
     $mf = new \LanSuite\MasterForm();
@@ -38,7 +38,7 @@ if ($bugidParameter && $auth['type'] < 2 && $row['reporter'] != $auth['userid'])
     $mf->AddField(t('Priorität'), 'priority', \LanSuite\MasterForm::IS_SELECTION, $selections, \LanSuite\MasterForm::FIELD_OPTIONAL);
 
     // Assign bug
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $mf->AddDropDownFromTable(t('Bearbeiter'), 'agent', 'userid', 'username', 'user', t('Keinem zugeordnet'), 'type >= 2');
         $mf->AddField(t('Preis'), 'price', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
         $mf->AddField(t('Bereits gespendet'), 'price_payed', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
@@ -52,7 +52,7 @@ if ($bugidParameter && $auth['type'] < 2 && $row['reporter'] != $auth['userid'])
         $mf->AddFix('url', $_SERVER['SERVER_NAME']);
         $mf->AddFix('reporter', $auth['userid']);
         $mf->AddFix('state', '0');
-    } elseif ($auth['type'] >= 2) {
+    } elseif ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $selections = array();
         $selections['0'] = t('Neu');
         $selections['1'] = t('Bestätigt');

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -24,7 +24,7 @@ $colors[7] = '#bc851b';
 $actionPOSTParameter = $_POST['action'] ?? null;
 if ($actionPOSTParameter) {
     foreach ($actionPOSTParameter as $key => $val) {
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             // Change state
             if ($_GET['state'] != '' and $_GET['state'] >= 2) {
                 $bugtracker->SetBugState($key, $_GET['state']);
@@ -44,7 +44,7 @@ if ($actionPOSTParameter) {
 }
 
 $actionParameter = $_GET['action'] ?? '';
-if ($actionParameter == 'delete' && $auth['type'] >= 2) {
+if ($actionParameter == 'delete' && $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     if ($_GET['bugid'] != '') {
         $md = new \LanSuite\MasterDelete();
         $md->Delete('bugtracker', 'bugid', $_GET['bugid']);
@@ -132,14 +132,14 @@ if (!$bugidParameter || $actionParameter == 'delete') {
     $ms2->SetTargetPage('comments', 20);
 
     $ms2->AddIconField('details', 'index.php?mod=bugtracker&bugid=%id%&ms_page=%page%', t('Details'));
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddIconField('edit', 'index.php?mod=bugtracker&action=add&bugid=', t('Editieren'));
     }
     if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
         $ms2->AddIconField('delete', 'index.php?mod=bugtracker&action=delete&bugid=', t('Löschen'));
     }
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         foreach ($bugtracker->stati as $key => $val) {
             $ms2->AddMultiSelectAction(t('Status') .' -> '. $val, 'index.php?mod=bugtracker&state='. $key);
         }
@@ -207,7 +207,7 @@ if (!$bugidParameter || $actionParameter == 'delete') {
         $dsp->AddDoubleRow(t('SVN-Revision'), $row['revision'] .' (<a href="http://code.google.com/p/lansuite/source/detail?r='. $row['revision'] .'" target="_blank">'. t('Änderungen anzeigen') .'</a>)');
     }
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $mf = new \LanSuite\MasterForm();
         $mf->AddField(t('Fix in SVN-Revision'), 'revision');
         $mf->SendForm('', 'bugtracker', 'bugid', $_GET['bugid']);
@@ -222,7 +222,7 @@ if (!$bugidParameter || $actionParameter == 'delete') {
     if ($auth['login']) {
         $mf = new \LanSuite\MasterForm();
         $mf->ManualUpdate = 1;
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $mf->AddField(t('Status'), 'state', \LanSuite\MasterForm::IS_SELECTION, $bugtracker->stati);
         } elseif ($row['state'] == 0) {
             $mf->AddField(t('Status'), 'state', \LanSuite\MasterForm::IS_SELECTION, array('1' => $bugtracker->stati['1']));

--- a/modules/cashmgr/Functions/Check.php
+++ b/modules/cashmgr/Functions/Check.php
@@ -11,7 +11,7 @@ function Check()
 
     $ret = true;
 
-    if (($_POST['fromUserid'] != $auth['userid']) && $auth['type'] < 2) {
+    if (($_POST['fromUserid'] != $auth['userid']) && $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
         $func->error(t("Deine Identität konnte nicht verifiziert werden. Die Transaktion wird sicherheitshalber abgebrochen."));
         $ret = false;
     } elseif ($_POST['toUserid'] == -1) {

--- a/modules/cashmgr/sendmoney.php
+++ b/modules/cashmgr/sendmoney.php
@@ -22,7 +22,7 @@ while ($row = $db->fetch_array($res)) {
         $UserFound = 1;
     }
 
-    if ($auth['type'] >= 2 || !$cfg['sys_internet'] || $cfg['guestlist_shownames']) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN || !$cfg['sys_internet'] || $cfg['guestlist_shownames']) {
         $selections[$row['userid']] = $row['username'] .' ('. $row['firstname'] .' '. $row['name'] .')';
     } else {
         $selections[$row['userid']] = $row['username'];

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -5,14 +5,14 @@ $clanIDParameter = $_GET['clanid'] ?? 0;
 switch ($stepParameter) {
     default:
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('clanmgr');
-    
-        $ms2->query['from'] = "%prefix%clan AS c
-        LEFT JOIN %prefix%user AS u ON c.clanid = u.clanid";
-    
+
+        $ms2->query['from'] = '%prefix%clan AS c
+        LEFT JOIN %prefix%user AS u ON c.clanid = u.clanid';
+
         $ms2->config['EntriesPerPage'] = 20;
-        $ms2->AddTextSearchField(t('Clanname'), array('c.name' => '1337', 'c.url' => 'like'));
-        $ms2->AddTextSearchDropDown(t('Mitglieder'), 'COUNT(u.clanid)', array('' => t('Alle'), '0' => t('Ohne Mitglieder'), '>1' => t('Mit Mitglieder')));
-    
+        $ms2->AddTextSearchField(t('Clanname'), ['c.name' => '1337', 'c.url' => 'like']);
+        $ms2->AddTextSearchDropDown(t('Mitglieder'), 'COUNT(u.clanid)', ['' => t('Alle'), '0' => t('Ohne Mitglieder'), '>1' => t('Mit Mitglieder')]);
+
         $ms2->AddResultField(t('Clanname'), 'c.name');
         $ms2->AddResultField(t('Webseite'), 'c.url', 'LinkToClan');
         $ms2->AddResultField(t('Mitglieder'), 'COUNT(u.clanid) AS members');
@@ -20,8 +20,6 @@ switch ($stepParameter) {
         $ms2->AddIconField('details', 'index.php?mod=clanmgr&step=2&clanid=', t('Clan-Details'));
         if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('change_pw', 'index.php?mod=clanmgr&step=10&clanid=', t('Passwort ändern'));
-        }
-        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('edit', 'index.php?mod=clanmgr&step=30&clanid=', t('Editieren'));
         }
         if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
@@ -36,58 +34,58 @@ switch ($stepParameter) {
         if ($auth['type'] >= 1) {
             $dsp->AddSingleRow($dsp->FetchSpanButton(t('Hinzufügen'), 'index.php?mod=clanmgr&step=30'));
         }
-    
+
         break;
 
     // Details
     case 2:
         $row = $db->qry_first('SELECT name, url, clanlogo_path FROM %prefix%clan WHERE clanid = %int%', $_GET['clanid']);
-    
+
         if ($func->chk_img_path($row['clanlogo_path'])) {
-            $dsp->AddDoubleRow(t(''), '<img src="'. $row['clanlogo_path'] .'" alt="'.$row['name'].'">');
+            $dsp->AddDoubleRow(t(''), '<img src="'.$row['clanlogo_path'].'" alt="'.$row['name'].'">');
         }
         $dsp->AddDoubleRow(t('Clan'), $row['name']);
-        if ($row['url']!='' && stristr($row['url'], 'http://') === false) {
-            $row['url'] = "http://".$row['url'];
+        if ($row['url'] != '' && stristr($row['url'], 'http://') === false) {
+            $row['url'] = 'http://'.$row['url'];
         }
-        $dsp->AddDoubleRow(t('Webseite'), '<a href="'. $row['url'] .'" target="_blank">'. $row['url'] .'</a>');
-    
+        $dsp->AddDoubleRow(t('Webseite'), '<a href="'.$row['url'].'" target="_blank">'.$row['url'].'</a>');
+
         $buttons = '';
         if ($auth['type'] >= 1 and $auth['clanid'] != $_GET['clanid']) {
-            $buttons .= $dsp->FetchSpanButton(t('Clan beitreten'), 'index.php?mod='. $_GET['mod'] .'&step=60&clanid='. $_GET['clanid']).' ';
+            $buttons .= $dsp->FetchSpanButton(t('Clan beitreten'), 'index.php?mod='.$_GET['mod'].'&step=60&clanid='.$_GET['clanid']).' ';
         }
         if ($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid']) {
-            $buttons .= $dsp->FetchSpanButton(t('Clan verlassen'), 'index.php?mod='. $_GET['mod'] .'&step=40&clanid='. $_GET['clanid'].'&userid='.$auth['userid']).' ';
+            $buttons .= $dsp->FetchSpanButton(t('Clan verlassen'), 'index.php?mod='.$_GET['mod'].'&step=40&clanid='.$_GET['clanid'].'&userid='.$auth['userid']).' ';
         }
         if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-            $buttons .= $dsp->FetchSpanButton(t('Clan editieren'), 'index.php?mod='. $_GET['mod'] .'&step=30&clanid='. $_GET['clanid']).' ';
+            $buttons .= $dsp->FetchSpanButton(t('Clan editieren'), 'index.php?mod='.$_GET['mod'].'&step=30&clanid='.$_GET['clanid']).' ';
         }
         if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-            $buttons .= $dsp->FetchSpanButton(t('Passwort ändern'), 'index.php?mod='. $_GET['mod'] .'&step=10&clanid='. $_GET['clanid']).' ';
+            $buttons .= $dsp->FetchSpanButton(t('Passwort ändern'), 'index.php?mod='.$_GET['mod'].'&step=10&clanid='.$_GET['clanid']).' ';
         }
         $dsp->AddDoubleRow('', $buttons);
 
         $dsp->AddFieldSetStart(t('Mitglieder'));
         $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('clanmgr');
-    
-        $ms2->query['from'] = "%prefix%user AS u";
-        $ms2->query['where'] = "u.clanid = ". (int)$_GET['clanid'];
-    
+
+        $ms2->query['from'] = '%prefix%user AS u';
+        $ms2->query['where'] = 'u.clanid = '.(int) $_GET['clanid'];
+
         $ms2->config['EntriesPerPage'] = 100;
-    
+
         $ms2->AddSelect('u.firstname');
         $ms2->AddSelect('u.name');
-    
+
         $ms2->AddResultField(t('Benutzername'), 'u.username', 'UserNameAndIcon');
         if (!$cfg['sys_internet'] or $auth['type'] > 1 or $auth['clanid'] == $_GET['clanid']) {
             $ms2->AddResultField(t('Vorname'), 'u.firstname', '');
             $ms2->AddResultField(t('Nachname'), 'u.name', '');
         }
         $ms2->AddResultField(t('Rolle'), 'u.clanadmin', 'ShowRole');
-    
+
         $ms2->AddIconField('details', 'index.php?mod=usrmgr&action=details&userid=', t('Clan-Details'));
         if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN || ($auth['clanid'] == $_GET['clanid'] && $auth['clanadmin'] == 1)) {
-            $ms2->AddIconField('delete', 'index.php?mod=clanmgr&action=clanmgr&step=40&clanid='. $_GET['clanid'] .'&userid=', t('Löschen'));
+            $ms2->AddIconField('delete', 'index.php?mod=clanmgr&action=clanmgr&step=40&clanid='.$_GET['clanid'].'&userid=', t('Löschen'));
         }
 
         $ms2->PrintSearch('index.php?mod=clanmgr&action=clanmgr&step=2', 'u.userid');
@@ -101,9 +99,9 @@ switch ($stepParameter) {
     // Change clan password
     case 10:
         if ($_GET['clanid'] == '') {
-            $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
+            $func->error(t('Keine Clan-ID angegeben!'), 'index.php?mod=home');
         } elseif ($_GET['clanid'] != $auth['clanid'] and $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
-            $func->information(t('Du bist nicht berechtigt das Passwort dieses Clans zu ändern'), "index.php?mod=home");
+            $func->information(t('Du bist nicht berechtigt das Passwort dieses Clans zu ändern'), 'index.php?mod=home');
         } else {
             $mf = new \LanSuite\MasterForm();
 
@@ -116,10 +114,10 @@ switch ($stepParameter) {
                 $mail = new \LanSuite\Module\Mail\Mail();
 
                 // Send information mail to all clan members
-                $clanuser = $db->qry("SELECT userid, username, email FROM %prefix%user WHERE clanid=%int%", $_GET['clanid']);
+                $clanuser = $db->qry('SELECT userid, username, email FROM %prefix%user WHERE clanid=%int%', $_GET['clanid']);
                 while ($data = $db->fetch_array($clanuser)) {
-                    $mail->create_mail($auth['userid'], $data['userid'], t('Clanpasswort geändert'), t('Das Clanpasswort wurde durch den Benutzer %1 in "%2" geändert', array($auth['username'], $_POST['password_original'])));
-                    $mail->create_inet_mail($data['username'], $data['email'], t('Clanpasswort geändert'), t('Das Clanpasswort wurde durch den Benutzer %1 in "%2" geändert', array($auth['username'], $_POST['password_original'])), $cfg["sys_party_mail"]);
+                    $mail->create_mail($auth['userid'], $data['userid'], t('Clanpasswort geändert'), t('Das Clanpasswort wurde durch den Benutzer %1 in "%2" geändert', [$auth['username'], $_POST['password_original']]));
+                    $mail->create_inet_mail($data['username'], $data['email'], t('Clanpasswort geändert'), t('Das Clanpasswort wurde durch den Benutzer %1 in "%2" geändert', [$auth['username'], $_POST['password_original']]), $cfg['sys_party_mail']);
                 }
                 $func->log_event(t('Das Clanpasswort wurde durch den Benutzer %1 geändert', $auth['username']), 1, t('clanmgr'));
             }
@@ -134,18 +132,18 @@ switch ($stepParameter) {
             }
             if ($_POST['action']) {
                 foreach ($_POST['action'] as $key => $val) {
-                    $db->qry("DELETE FROM %prefix%clan WHERE clanid = %string%", $key);
-                    $db->qry("UPDATE %prefix%user SET clanid = 0 WHERE clanid = %string%", $key);
+                    $db->qry('DELETE FROM %prefix%clan WHERE clanid = %string%', $key);
+                    $db->qry('UPDATE %prefix%user SET clanid = 0 WHERE clanid = %string%', $key);
                 }
             }
             $func->confirmation(t('Löschen erfolgreich'), 'index.php?mod=clanmgr&action=clanmgr');
         }
         break;
-  
+
     // Add - Edit
     case 30:
         if ($clanIDParameter != '' and !($clanIDParameter == $auth['clanid'] and $auth['clanadmin'] == 1) and $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
-            $func->information(t('Du bist nicht berechtigt diesen Clan zu ändern'), "index.php?mod=home");
+            $func->information(t('Du bist nicht berechtigt diesen Clan zu ändern'), 'index.php?mod=home');
         } else {
             $mf = new \LanSuite\MasterForm();
 
@@ -155,22 +153,22 @@ switch ($stepParameter) {
                 $mf->AddField(t('Beitritts Passwort'), 'password', \LanSuite\MasterForm::IS_NEW_PASSWORD);
             }
             $mf->AddField(t('Webseite'), 'url', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
-            $mf->AddField(t('Clanlogo'), 'clanlogo_path', \LanSuite\MasterForm::IS_FILE_UPLOAD, 'ext_inc/clan/'. $auth['userid'] .'_', \LanSuite\MasterForm::FIELD_OPTIONAL);
+            $mf->AddField(t('Clanlogo'), 'clanlogo_path', \LanSuite\MasterForm::IS_FILE_UPLOAD, 'ext_inc/clan/'.$auth['userid'].'_', \LanSuite\MasterForm::FIELD_OPTIONAL);
 
             if (!$clanIDParameter) {
                 $mf->CheckBeforeInserFunction = 'CheckExistingClan';
             }
             $mf->AdditionalDBUpdateFunction = 'UpdateClanMgr';
-            $mf->SendForm('index.php?mod=clanmgr&step='. $_GET['step'], 'clan', 'clanid', $clanIDParameter);
+            $mf->SendForm('index.php?mod=clanmgr&step='.$_GET['step'], 'clan', 'clanid', $clanIDParameter);
 
             $dsp->AddFieldsetEnd();
-        
+
             if ($clanIDParameter) {
                 $dsp->AddFieldsetStart(t('Mitglieder'));
                 $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('clanmgr');
 
-                $ms2->query['from'] = "%prefix%user AS u";
-                $ms2->query['where'] = 'u.clanid = '. (int)$_GET['clanid'];
+                $ms2->query['from'] = '%prefix%user AS u';
+                $ms2->query['where'] = 'u.clanid = '.(int) $_GET['clanid'];
                 $ms2->config['EntriesPerPage'] = 20;
 
                 $ms2->AddResultField(t('Vorname'), 'u.firstname');
@@ -178,68 +176,68 @@ switch ($stepParameter) {
                 $ms2->AddResultField(t('Benutzername'), 'u.username');
                 $ms2->AddResultField(t('Rolle'), 'u.clanadmin', 'ShowRole');
 
-                $ms2->AddIconField('delete', 'index.php?mod=clanmgr&action=clanmgr&step=40&clanid='. $_GET['clanid'] .'&userid=', t('Löschen'));
-                $ms2->PrintSearch('index.php?mod=clanmgr&action=clanmgr&step=30&clanid='. $_GET['clanid'] .'&userid=', 'u.userid');
+                $ms2->AddIconField('delete', 'index.php?mod=clanmgr&action=clanmgr&step=40&clanid='.$_GET['clanid'].'&userid=', t('Löschen'));
+                $ms2->PrintSearch('index.php?mod=clanmgr&action=clanmgr&step=30&clanid='.$_GET['clanid'].'&userid=', 'u.userid');
                 $dsp->AddFieldsetEnd();
             }
             $dsp->AddBackButton('index.php?mod=clanmgr&action=clanmgr');
         }
         break;
-  
+
     // Delete Member
     case 40:
         if ($_GET['clanid'] == '') {
-            $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
+            $func->error(t('Keine Clan-ID angegeben!'), 'index.php?mod=home');
         } elseif (CountAdmins() == 1 and $auth['clanadmin'] == 1) {
-            $func->information(t('Löschen nicht möglich. Du bist der einzige Clan-Admin in diesem Clan. Benne bitte vorher einen weiteren Admin.'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
+            $func->information(t('Löschen nicht möglich. Du bist der einzige Clan-Admin in diesem Clan. Benne bitte vorher einen weiteren Admin.'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid']);
         } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin'] == 1) or ($_GET['clanid'] == $auth['clanid'] and $_GET['userid'] = $auth['userid']) or $auth['type'] > \LS_AUTH_TYPE_ADMIN) {
-            $db->qry("UPDATE %prefix%user SET clanid = 0 WHERE userid = %int%", $_GET['userid']);
-            $func->confirmation(t('Löschen erfolgreich'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
+            $db->qry('UPDATE %prefix%user SET clanid = 0 WHERE userid = %int%', $_GET['userid']);
+            $func->confirmation(t('Löschen erfolgreich'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid']);
         } else {
-            $func->information(t('Du bist nicht berechtigt Mitglieder aus diesem Clan zu entfernen'), "index.php?mod=home");
+            $func->information(t('Du bist nicht berechtigt Mitglieder aus diesem Clan zu entfernen'), 'index.php?mod=home');
         }
         break;
 
     // Change role
     case 50:
         if ($_GET['clanid'] == '') {
-            $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
+            $func->error(t('Keine Clan-ID angegeben!'), 'index.php?mod=home');
         } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin']) or $auth['type'] > 1) {
-            $cur_role = $db->qry_first("SELECT username, clanadmin FROM %prefix%user WHERE clanid = %int% AND userid = %int%", $_GET['clanid'], $_GET['userid']);
+            $cur_role = $db->qry_first('SELECT username, clanadmin FROM %prefix%user WHERE clanid = %int% AND userid = %int%', $_GET['clanid'], $_GET['userid']);
             if ($cur_role['clanadmin'] and CountAdmins() == 1) {
-                $func->information(t('Du kannst %1 nicht die Admin Rolle entziehen, da %1 z.z das einzige Mitglied mit der Rolle Clan-Admin ist. Benenne bitte vorher einen anderen Admin.', $cur_role['username']), "index.php?mod=clanmgr&step=2&clanid=".$_GET["clanid"]);
+                $func->information(t('Du kannst %1 nicht die Admin Rolle entziehen, da %1 z.z das einzige Mitglied mit der Rolle Clan-Admin ist. Benenne bitte vorher einen anderen Admin.', $cur_role['username']), 'index.php?mod=clanmgr&step=2&clanid='.$_GET['clanid']);
             } elseif ($cur_role['clanadmin']) {
-                $db->qry("UPDATE %prefix%user SET clanadmin = 0 WHERE userid = %int%", $_GET['userid']);
-                $func->confirmation(t('Benutzer %1 ist nun kein Clan-Admin mehr', $cur_role['username']), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
+                $db->qry('UPDATE %prefix%user SET clanadmin = 0 WHERE userid = %int%', $_GET['userid']);
+                $func->confirmation(t('Benutzer %1 ist nun kein Clan-Admin mehr', $cur_role['username']), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid']);
             } else {
-                $db->qry("UPDATE %prefix%user SET clanadmin = 1 WHERE userid = %int%", $_GET['userid']);
-                $func->confirmation(t('Benutzer %1 ist nun Clan-Admin', $cur_role['username']), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
+                $db->qry('UPDATE %prefix%user SET clanadmin = 1 WHERE userid = %int%', $_GET['userid']);
+                $func->confirmation(t('Benutzer %1 ist nun Clan-Admin', $cur_role['username']), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid']);
             }
         } else {
-            $func->information(t('Du bist nicht berechtigt die Berehtigung dieses Nutzers zu verändern'), "index.php?mod=home");
+            $func->information(t('Du bist nicht berechtigt die Berehtigung dieses Nutzers zu verändern'), 'index.php?mod=home');
         }
         break;
-  
+
     // Enter a new clan
     case 60:
         if ($_GET['clanid'] == '') {
-            $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
-        } elseif ($auth["type"] < 1) {
-            $func->error(t('Keine Berechtigung diese Funktion auszuführen'), "index.php?mod=home");
+            $func->error(t('Keine Clan-ID angegeben!'), 'index.php?mod=home');
+        } elseif ($auth['type'] < 1) {
+            $func->error(t('Keine Berechtigung diese Funktion auszuführen'), 'index.php?mod=home');
         } elseif (!$_POST['clan_pass']) {
-            $dsp->SetForm("index.php?mod=clanmgr&action=clanmgr&step=60&clanid=".$_GET['clanid']);
+            $dsp->SetForm('index.php?mod=clanmgr&action=clanmgr&step=60&clanid='.$_GET['clanid']);
             $dsp->AddSingleRow(t('Um den Clan beizutreten, musst du das Clanpasswort eingeben. Solltest du dies nicht kennen, wenden dich bitte an deinen Clan-Admin.'));
-            $dsp->AddPasswordRow("clan_pass", t('Clan Passwort'), $_POST['clan_pass'], $mail_error);
-            $dsp->AddFormSubmitRow("send");
-            $dsp->AddBackButton("index.php?mod=clanmgr&action=clanmgr&step=2&clanid=".$_GET['clanid'], "usrmgr/pwremind");
+            $dsp->AddPasswordRow('clan_pass', t('Clan Passwort'), $_POST['clan_pass'], $mail_error);
+            $dsp->AddFormSubmitRow('send');
+            $dsp->AddBackButton('index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid'], 'usrmgr/pwremind');
         } else {
             if (CheckClanPW($_POST['clan_pass'])) {
-                $db->qry("UPDATE %prefix%user SET clanid = %int%, clanadmin = 0 WHERE userid =%int%", $_GET['clanid'], $auth["userid"]);
-                $tmpclanname =  $db->qry_first("SELECT name FROM %prefix%clan WHERE clanid = %int%", $_GET['clanid']);
-                $func->confirmation(t('Du bist erfolgreich dem Clan beigetreten.'), "index.php?mod=clanmgr&action=clanmgr&step=2&clanid=".$_GET['clanid']);
+                $db->qry('UPDATE %prefix%user SET clanid = %int%, clanadmin = 0 WHERE userid =%int%', $_GET['clanid'], $auth['userid']);
+                $tmpclanname = $db->qry_first('SELECT name FROM %prefix%clan WHERE clanid = %int%', $_GET['clanid']);
+                $func->confirmation(t('Du bist erfolgreich dem Clan beigetreten.'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='.$_GET['clanid']);
                 $func->log_event(t('%1 ist dem Clan %2 beigetreten', $auth['username'], $tmpclanname['name']), 1, t('clanmgr'));
             } else {
-                $func->error(t('Das eingegebene Clanpasswort ist falsch.'), "index.php?mod=clanmgr&action=clanmgr&step=60&clanid=".$_GET['clanid']);
+                $func->error(t('Das eingegebene Clanpasswort ist falsch.'), 'index.php?mod=clanmgr&action=clanmgr&step=60&clanid='.$_GET['clanid']);
             }
         }
 }

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -18,10 +18,10 @@ switch ($stepParameter) {
         $ms2->AddResultField(t('Mitglieder'), 'COUNT(u.clanid) AS members');
 
         $ms2->AddIconField('details', 'index.php?mod=clanmgr&step=2&clanid=', t('Clan-Details'));
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('change_pw', 'index.php?mod=clanmgr&step=10&clanid=', t('Passwort ändern'));
         }
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('edit', 'index.php?mod=clanmgr&step=30&clanid=', t('Editieren'));
         }
         if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
@@ -59,10 +59,10 @@ switch ($stepParameter) {
         if ($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid']) {
             $buttons .= $dsp->FetchSpanButton(t('Clan verlassen'), 'index.php?mod='. $_GET['mod'] .'&step=40&clanid='. $_GET['clanid'].'&userid='.$auth['userid']).' ';
         }
-        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= 2) {
+        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $buttons .= $dsp->FetchSpanButton(t('Clan editieren'), 'index.php?mod='. $_GET['mod'] .'&step=30&clanid='. $_GET['clanid']).' ';
         }
-        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= 2) {
+        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $buttons .= $dsp->FetchSpanButton(t('Passwort ändern'), 'index.php?mod='. $_GET['mod'] .'&step=10&clanid='. $_GET['clanid']).' ';
         }
         $dsp->AddDoubleRow('', $buttons);
@@ -102,12 +102,12 @@ switch ($stepParameter) {
     case 10:
         if ($_GET['clanid'] == '') {
             $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
-        } elseif ($_GET['clanid'] != $auth['clanid'] and $auth['type'] < 2) {
+        } elseif ($_GET['clanid'] != $auth['clanid'] and $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
             $func->information(t('Du bist nicht berechtigt das Passwort dieses Clans zu ändern'), "index.php?mod=home");
         } else {
             $mf = new \LanSuite\MasterForm();
 
-            if ($auth['type'] < 2) {
+            if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
                 $mf->AddField(t('Dezeitiges Passwort'), 'old_password', \LanSuite\MasterForm::IS_PASSWORD, '', \LanSuite\MasterForm::FIELD_OPTIONAL, 'CheckClanPW');
             }
             $mf->AddField(t('Neues Passwort'), 'password', \LanSuite\MasterForm::IS_NEW_PASSWORD);
@@ -144,7 +144,7 @@ switch ($stepParameter) {
   
     // Add - Edit
     case 30:
-        if ($clanIDParameter != '' and !($clanIDParameter == $auth['clanid'] and $auth['clanadmin'] == 1) and $auth['type'] < 2) {
+        if ($clanIDParameter != '' and !($clanIDParameter == $auth['clanid'] and $auth['clanadmin'] == 1) and $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
             $func->information(t('Du bist nicht berechtigt diesen Clan zu ändern'), "index.php?mod=home");
         } else {
             $mf = new \LanSuite\MasterForm();
@@ -192,7 +192,7 @@ switch ($stepParameter) {
             $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
         } elseif (CountAdmins() == 1 and $auth['clanadmin'] == 1) {
             $func->information(t('Löschen nicht möglich. Du bist der einzige Clan-Admin in diesem Clan. Benne bitte vorher einen weiteren Admin.'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
-        } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin'] == 1) or ($_GET['clanid'] == $auth['clanid'] and $_GET['userid'] = $auth['userid']) or $auth['type'] > 2) {
+        } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin'] == 1) or ($_GET['clanid'] == $auth['clanid'] and $_GET['userid'] = $auth['userid']) or $auth['type'] > \LS_AUTH_TYPE_ADMIN) {
             $db->qry("UPDATE %prefix%user SET clanid = 0 WHERE userid = %int%", $_GET['userid']);
             $func->confirmation(t('Löschen erfolgreich'), 'index.php?mod=clanmgr&action=clanmgr&step=2&clanid='. $_GET['clanid']);
         } else {

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -24,9 +24,6 @@ switch ($stepParameter) {
         }
         if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddIconField('delete', 'index.php?mod=clanmgr&step=20&clanid=', t('Löschen'));
-        }
-
-        if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
             $ms2->AddMultiSelectAction(t('Löschen'), 'index.php?mod=clanmgr&step=20', 1);
         }
 
@@ -45,8 +42,8 @@ switch ($stepParameter) {
             $dsp->AddDoubleRow(t(''), '<img src="'.$row['clanlogo_path'].'" alt="'.$row['name'].'">');
         }
         $dsp->AddDoubleRow(t('Clan'), $row['name']);
-        if ($row['url'] != '' && stristr($row['url'], 'http://') === false) {
-            $row['url'] = 'http://'.$row['url'];
+        if ($row['url'] != '' && !str_starts_with(strtolower($row['url']), 'http')) {
+            $row['url'] = 'https://'.$row['url'];
         }
         $dsp->AddDoubleRow(t('Webseite'), '<a href="'.$row['url'].'" target="_blank">'.$row['url'].'</a>');
 

--- a/modules/downloads/show.php
+++ b/modules/downloads/show.php
@@ -50,7 +50,7 @@ if (!$cfg['download_use_ftp']) {
 
         // Upload submittet file
         $stepParameter = $_GET['step'] ?? 0;
-        if ($stepParameter == 20 && $auth['type'] >= 2 || ($auth['login'] && $row['allow_upload'])) {
+        if ($stepParameter == 20 && $auth['type'] >= \LS_AUTH_TYPE_ADMIN || ($auth['login'] && $row['allow_upload'])) {
             $func->FileUpload('upload', $BaseDir.$_GET['dir']);
         }
 
@@ -102,7 +102,7 @@ if (!$cfg['download_use_ftp']) {
 
         $dsp->AddFieldSetEnd();
 
-        if ($auth['type'] >= 2 or ($auth['login'] and $row['allow_upload'])) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or ($auth['login'] and $row['allow_upload'])) {
             // File Upload Box
             $dsp->AddFieldSetStart(t('Datei hochladen'));
             $dsp->SetForm('index.php?mod=downloads&step=20&dir='. $_GET['dir'], '', '', 'multipart/form-data');
@@ -127,7 +127,7 @@ if (!$cfg['download_use_ftp']) {
         }
 
         // Admin functions for dir
-        if ($auth['type'] >= 2 && ($masterFormStepParameter != 2 || $stepParameter == 10)) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN && ($masterFormStepParameter != 2 || $stepParameter == 10)) {
             $dsp->AddFieldSetStart(t('Ordner Text und Einstellungen editieren'));
             $mf = new \LanSuite\MasterForm();
 

--- a/modules/faq/show.php
+++ b/modules/faq/show.php
@@ -8,7 +8,7 @@ if ($count_cat == 0) {
     $dsp->NewContent(t('FAQ'), t('Auf dieser Seite siehst du häufig gestellte Fragen und deren Antworten'));
 
     while ($row = $db->fetch_array($get_cat)) {
-        if ($auth['type'] > 2) {
+        if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
             $admin_link = $dsp->FetchIcon('delete', 'index.php?mod=faq&object=item&action=delete_cat&catid=' . $row["catid"] . '&step=2');
         }
         if ($auth['type'] > 1) {
@@ -18,7 +18,7 @@ if ($count_cat == 0) {
 
         $get_item = $db->qry("SELECT caption,itemid FROM %prefix%faq_item WHERE catid = %int% ORDER BY caption", $row['catid']);
         while ($row = $db->fetch_array($get_item)) {
-            if ($auth['type'] > 2) {
+            if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
                 $admin_link = $dsp->FetchIcon('delete', 'index.php?mod=faq&object=item&action=delete_item&itemid=' . $row["itemid"] . '&step=2');
             }
             if ($auth['type'] > 1) {

--- a/modules/foodcenter/account.php
+++ b/modules/foodcenter/account.php
@@ -4,7 +4,7 @@ $account = new LanSuite\Module\Foodcenter\Accounting($auth['userid']);
 
 if ($auth['type'] > 1 && !isset($_GET['act'])) {
     $_GET['act'] = "menu";
-} elseif ($auth['type'] < 2) {
+} elseif ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     $_GET['act'] = "";
 }
 

--- a/modules/foodcenter/statchange.php
+++ b/modules/foodcenter/statchange.php
@@ -2,7 +2,7 @@
 
 $product_list = new LanSuite\Module\Foodcenter\ProductList();
 
-if ($auth['type'] < 2) {
+if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     unset($_GET['step']);
 }
 

--- a/modules/guestbook/show.php
+++ b/modules/guestbook/show.php
@@ -15,7 +15,7 @@ $ms2->AddResultField(t('Autor'), 'g.poster', 'UserNameAndIcon');
 $ms2->AddResultField(t('Eintrag'), 'g.text', 'Text2LSCode');
 $ms2->AddResultField(t('Datum'), 'g.date', 'MS2GetDate');
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=guestbook&action=add&guestbookid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/guestlist/export.php
+++ b/modules/guestlist/export.php
@@ -15,7 +15,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             header('Expires: 0');
             header('Cache-control: private');
             header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
@@ -40,7 +40,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             foreach ($_POST['action'] as $key => $val) {
                 $guestlist->SetExported($key, $party->party_id);
             }
@@ -63,7 +63,7 @@ if (!$party->party_id) {
     $ms2->config['EntriesPerPage'] = 100;
 
     $ms2->AddResultField(t('Benutzername'), 'u.username');
-    if ($auth['type'] >= 2 or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
         $ms2->AddResultField(t('Vorname'), 'u.firstname');
         $ms2->AddResultField(t('Nachname'), 'u.name');
     }
@@ -73,7 +73,7 @@ if (!$party->party_id) {
 
     $ms2->AddIconField('details', 'index.php?mod=guestlist&action=details&userid=', t('Details'));
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddMultiSelectAction(t('Exportieren'), "index.php?mod=guestlist&action=export&step=10", 1, 'export');
         $ms2->AddMultiSelectAction(t('Als exportiert markieren'), "index.php?mod=guestlist&action=export&step=11", 1, 'setexported');
     }

--- a/modules/guestlist/guestlist.php
+++ b/modules/guestlist/guestlist.php
@@ -15,7 +15,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             $Messages = array('success' => '', 'error' => '');
             foreach ($_POST['action'] as $key => $val) {
                 $Msg = $guestlist->SetPaid($key, $party->party_id);
@@ -44,7 +44,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             $Messages = array('success' => '', 'error' => '');
             foreach ($_POST['action'] as $key => $val) {
                 $Msg = $guestlist->SetNotPaid($key, $party->party_id);
@@ -73,7 +73,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             foreach ($_POST['action'] as $key => $val) {
                 if ($guestlist->CheckIn($key, $party->party_id)) {
                     $func->information(t('Der Benutzer #%1 konnte nicht eingecheckt werden, da er nicht auf "bezahlt" steht', array($key)), NO_LINK);
@@ -92,7 +92,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             foreach ($_POST['action'] as $key => $val) {
                 if ($guestlist->CheckOut($key, $party->party_id)) {
                     $func->information(t('Der Benutzer #%1 konnte nicht ausgecheckt werden, da er nicht eingecheckt ist', array($key)), NO_LINK);
@@ -111,7 +111,7 @@ switch ($stepParameter) {
             $_POST['action'][$_GET['userid']] = 1;
         }
 
-        if ($auth['type'] >= 2 and $_POST['action']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $_POST['action']) {
             foreach ($_POST['action'] as $key => $val) {
                 $guestlist->UndoCheckInOut($key, $party->party_id);
             }

--- a/modules/guestlist/search.inc.php
+++ b/modules/guestlist/search.inc.php
@@ -35,7 +35,7 @@ if ($party->party_id) {
 $ms2->AddTextSearchField(t('Clan'), array('c.name' => 'like'));
 
 $ms2->AddResultField(t('Benutzername'), 'u.username');
-if ($auth['type'] >= 2 or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
     $ms2->AddResultField(t('Vorname'), 'u.firstname');
     $ms2->AddResultField(t('Nachname'), 'u.name');
 }
@@ -59,7 +59,7 @@ if ($party->party_id) {
 $ms2->AddIconField('details', 'index.php?mod=guestlist&action=details&userid=', t('Details'));
 $ms2->AddIconField('send_mail', 'index.php?mod=mail&action=newmail&step=2&userID=', t('Mail senden'));
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddMultiSelectAction(t('Auf "Bezahlt" setzen'), "index.php?mod=guestlist&step=10", 1, 'paid');
     $ms2->AddMultiSelectAction(t('Auf "Nicht Bezahlt" setzen'), "index.php?mod=guestlist&step=11", 1, 'not_paid');
     $ms2->AddMultiSelectAction(t('Einchecken'), "index.php?mod=guestlist&step=20", 1, 'in');

--- a/modules/guestlist/usermap.php
+++ b/modules/guestlist/usermap.php
@@ -38,9 +38,9 @@ if ($cfg['guestlist_guestmap'] == 2) {
             };
 
             // Show detailed map to admins only, otherwise stick to user settings
-            if ($row['show_me_in_map'] == 1 || $auth['type'] >= 2) {
+            if ($row['show_me_in_map'] == 1 || $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $text = "<b>{$row['username']}</b>";
-                if ($cfg['guestlist_shownames']|| $auth['type'] >= 2) {
+                if ($cfg['guestlist_shownames']|| $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                     $text .= " {$row['firstname']} {$row['name']}";
                 }
             } else {
@@ -156,7 +156,7 @@ if ($cfg['guestlist_guestmap'] == 2) {
             $UsersOut = '';
 
             while ($current_user = $db->fetch_array($res2)) {
-                if ($auth['type'] < 2 and ($cfg['sys_internet'])) {
+                if ($auth['type'] < \LS_AUTH_TYPE_ADMIN and ($cfg['sys_internet'])) {
                     $current_user['firstname'] = '---';
                     $current_user['name'] = '---';
                 }

--- a/modules/hardware/edit.php
+++ b/modules/hardware/edit.php
@@ -1,7 +1,7 @@
 <?php
 
 // Edit Hardwareinfos for User
-if ($auth['type'] >= 2 or ($_GET['userid'] == $auth['userid'] and $cfg['user_self_details_change'])) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or ($_GET['userid'] == $auth['userid'] and $cfg['user_self_details_change'])) {
     $mf = new \LanSuite\MasterForm();
     
     $dsp->NewContent(t("Hardware &auml;ndern"), t("Hier kannst du die Hardware eingeben"));

--- a/modules/hardware/plugins/usrmgr_details_tab.php
+++ b/modules/hardware/plugins/usrmgr_details_tab.php
@@ -26,7 +26,7 @@ $dsp->AddDoubleRow(t('Sonstiges'), $hardware['sonstiges']);
  * and change of details is allowed via $cfg['user_self_details_change']
  */
 
-if ($auth['type'] >= 2 || ($_GET['userid'] == $auth['userid'] && $cfg['user_self_details_change'])) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN || ($_GET['userid'] == $auth['userid'] && $cfg['user_self_details_change'])) {
     if ($hardware['hardwareid']) {
         $plug_bttn_hw = $dsp->FetchSpanButton(t('Editieren'), 'index.php?mod=hardware&action=edit&userid='. $_GET['userid'].'&hardwareid='.$hardware['hardwareid']);
     } else {

--- a/modules/home/show.php
+++ b/modules/home/show.php
@@ -5,7 +5,7 @@ $db->qry('DELETE FROM %prefix%lastread WHERE DATEDIFF(NOW(), date) > 7 AND tab !
 
 if ($auth["type"] == 1) {
     $home_page = $cfg["home_login"];
-} elseif ($auth["type"] == 2 or $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
+} elseif ($auth['type'] == \LS_AUTH_TYPE_ADMIN or $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
     $home_page = $cfg["home_admin"];
 } else {
     $home_page = $cfg["home_logout"];
@@ -26,9 +26,9 @@ switch ($home_page) {
             $cfgArrayKey = 'home_item_cnt_' . $caption;
             if ((array_key_exists($cfgArrayKey, $cfg) && $cfg[$cfgArrayKey])
                 || ($caption == 'party' && $party->count > 0)
-                || ($caption == 'troubleticket' && $auth['type'] >= 2)
-                || ($caption == 'rent' && $auth['type'] >= 2)
-                || ($caption == 'task' && $auth['type'] >= 2)) {
+                || ($caption == 'troubleticket' && $auth['type'] >= \LS_AUTH_TYPE_ADMIN)
+                || ($caption == 'rent' && $auth['type'] >= \LS_AUTH_TYPE_ADMIN)
+                || ($caption == 'task' && $auth['type'] >= \LS_AUTH_TYPE_ADMIN)) {
                 $content = '';
                 include($inc);
                 if ($content) {

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -3,8 +3,8 @@
 if ($auth['type'] <= 1) {
     $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
 
-    $ms2->query['from'] = "%prefix%info AS i";
-    $ms2->query['where'] = "i.active";
+    $ms2->query['from'] = '%prefix%info AS i';
+    $ms2->query['where'] = 'i.active';
 
     $ms2->config['EntriesPerPage'] = 50;
 
@@ -19,7 +19,7 @@ if ($auth['type'] <= 1) {
         $_POST['content'] = $_POST['FCKeditor1'] ?? '';
     }
 
-    $stepParameter = $_GET["step"] ?? 0;
+    $stepParameter = $_GET['step'] ?? 0;
     switch ($stepParameter) {
         default:
             $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Info-Seiten editieren.'));
@@ -27,7 +27,7 @@ if ($auth['type'] <= 1) {
 
             $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
 
-            $ms2->query['from'] = "%prefix%info AS i";
+            $ms2->query['from'] = '%prefix%info AS i';
             $ms2->query['where'] = "i.link = ''";
 
             $ms2->config['EntriesPerPage'] = 50;
@@ -39,21 +39,13 @@ if ($auth['type'] <= 1) {
             $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
             if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-                  $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-                  $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-                  $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
-                  $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
+                $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
+                $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
+                $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
+                $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
             if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
-                  $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
+                $ms2->AddMultiSelectAction('Löschen', 'index.php?mod=info2&action=change&step=10', 1);
             }
 
             $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
@@ -61,7 +53,7 @@ if ($auth['type'] <= 1) {
             $dsp->AddSingleRow($dsp->FetchSpanButton('Externen Link erstellen', 'index.php?mod=info2&action=change&step=30'));
 
             $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
-            $ms2->query['from'] = "%prefix%info AS i";
+            $ms2->query['from'] = '%prefix%info AS i';
             $ms2->query['where'] = "i.link != ''";
 
             $ms2->config['EntriesPerPage'] = 50;
@@ -73,17 +65,9 @@ if ($auth['type'] <= 1) {
 
             if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
-            }
-            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
             if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
@@ -92,7 +76,7 @@ if ($auth['type'] <= 1) {
 
             $ms2->PrintSearch('index.php?mod=info2', 'i.infoID');
             break;
-    
+
         // Generate Editform
         case 2:
             if ($_GET['infoID'] != '') {
@@ -103,7 +87,7 @@ if ($auth['type'] <= 1) {
                     %prefix%info AS i
                     LEFT JOIN %prefix%menu AS m ON i.caption = m.caption AND m.action = 'show_info2'
                   WHERE
-                    i.infoID = %int%", $_GET["infoID"]);
+                    i.infoID = %int%", $_GET['infoID']);
             }
 
             $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du den Inhalt der Seite editieren.'));
@@ -117,79 +101,79 @@ if ($auth['type'] <= 1) {
                     $valkey = '';
                     $optional = 0;
                 } else {
-                      $valkey = '_'. $val;
-                      $optional = \LanSuite\MasterForm::FIELD_OPTIONAL;
+                    $valkey = '_'.$val;
+                    $optional = \LanSuite\MasterForm::FIELD_OPTIONAL;
                 }
-                $mf->AddField(t('Seitentitel'), 'caption'. $valkey, '', '', $optional);
-                $mf->AddField(t('Untertitel'), 'shorttext'. $valkey, '', '', $optional);
+                $mf->AddField(t('Seitentitel'), 'caption'.$valkey, '', '', $optional);
+                $mf->AddField(t('Untertitel'), 'shorttext'.$valkey, '', '', $optional);
                 if ($cfg['info2_use_fckedit']) {
-                    $mf->AddField(t('Text'), 'text'. $valkey, '', \LanSuite\MasterForm::HTML_WYSIWYG, $optional);
+                    $mf->AddField(t('Text'), 'text'.$valkey, '', \LanSuite\MasterForm::HTML_WYSIWYG, $optional);
                 } else {
-                    $mf->AddField(t('Text'), 'text'. $valkey, '', '', $optional);
+                    $mf->AddField(t('Text'), 'text'.$valkey, '', '', $optional);
                 }
                 $mf->AddPage($translation->lang_names[$val]);
             }
             $mf->AdditionalDBUpdateFunction = 'UpdateInfo2';
             $mf->SendForm('index.php?mod=info2&action=change&step=2', 'info', 'infoID', $_GET['infoID']);
 
-            $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
+            $dsp->AddBackButton('index.php?mod=info2&action=change', 'info2/form');
             break;
 
         // Delete entry
         case 10:
-            foreach ($_POST["action"] as $item => $val) {
-                $menu_intem = $db->qry_first("SELECT caption FROM %prefix%info WHERE infoID = %string%", $item);
-                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
-                $db->qry("DELETE FROM %prefix%info WHERE infoID = %string%", $item);
+            foreach ($_POST['action'] as $item => $val) {
+                $menu_intem = $db->qry_first('SELECT caption FROM %prefix%info WHERE infoID = %string%', $item);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem['caption']);
+                $db->qry('DELETE FROM %prefix%info WHERE infoID = %string%', $item);
             }
 
-            $func->confirmation(t('Der Eintrag wurde gelöscht.'), "index.php?mod=info2&action=change");
+            $func->confirmation(t('Der Eintrag wurde gelöscht.'), 'index.php?mod=info2&action=change');
             break;
 
         // Deactivate
         case 20:
             if ($_GET['infoID']) {
-                $_POST["action"][$_GET['infoID']] = '1';
+                $_POST['action'][$_GET['infoID']] = '1';
             }
-            foreach ($_POST["action"] as $item => $val) {
-                $db->qry("UPDATE %prefix%info SET active = 0 WHERE infoID = %string%", $item);
-                $menu_intem = $db->qry_first("SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%", $item);
-                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+            foreach ($_POST['action'] as $item => $val) {
+                $db->qry('UPDATE %prefix%info SET active = 0 WHERE infoID = %string%', $item);
+                $menu_intem = $db->qry_first('SELECT active, caption, shorttext FROM %prefix%info WHERE infoID = %string%', $item);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem['caption']);
             }
-            $func->confirmation(t('Eintrag deaktiviert'), "index.php?mod=info2&action=change");
+            $func->confirmation(t('Eintrag deaktiviert'), 'index.php?mod=info2&action=change');
             break;
-    
+
         // Activate
         case 21:
             if ($_GET['infoID']) {
-                $_POST["action"][$_GET['infoID']] = '1';
+                $_POST['action'][$_GET['infoID']] = '1';
             }
-            foreach ($_POST["action"] as $item => $val) {
-                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+            foreach ($_POST['action'] as $item => $val) {
+                $db->qry('UPDATE %prefix%info SET active = 1 WHERE infoID = %string%', $item);
             }
-            $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            $func->confirmation(t('Eintrag aktiviert'), 'index.php?mod=info2&action=change');
             break;
-    
+
         // Activate and link
         case 22:
             if ($_GET['infoID']) {
-                $_POST["action"][$_GET['infoID']] = '1';
+                $_POST['action'][$_GET['infoID']] = '1';
             }
-            foreach ($_POST["action"] as $item => $val) {
-                $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+            foreach ($_POST['action'] as $item => $val) {
+                $menu_intem = $db->qry_first('SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%', $item);
                 $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
 
-                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem['caption']);
 
-                ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+                ($cfg['info2_use_submenus']) ? $level = 1 : $level = 0;
 
                 if ($menu_intem['link']) {
-                    $link = $menu_intem['link'] .'" target="_blank';
+                    $link = $menu_intem['link'].'" target="_blank';
                 } else {
-                    $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+                    $link = 'index.php?mod=info2&action=show_info2&id='.$item;
                 }
 
-                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+                $db->qry('UPDATE %prefix%info SET active = 1 WHERE infoID = %string%', $item);
                 $db->qry("
                   INSERT INTO %prefix%menu
                   SET
@@ -201,31 +185,31 @@ if ($auth['type'] <= 1) {
                     level = %string%,
                     pos = %string%,
                     action = 'show_info2',
-                    file = 'show'", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
+                    file = 'show'", $menu_intem['caption'], $menu_intem['shorttext'], $link, $level, $info_menu['pos']);
             }
-            $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            $func->confirmation(t('Eintrag aktiviert'), 'index.php?mod=info2&action=change');
             break;
-    
+
         // Activate and link (admin only)
-        case 23:
+        case 23 :
             if ($_GET['id']) {
-                $_POST["action"][$_GET['id']] = '1';
+                $_POST['action'][$_GET['id']] = '1';
             }
-            foreach ($_POST["action"] as $item => $val) {
-                $menu_intem = $db->qry_first("SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%", $item);
+            foreach ($_POST['action'] as $item => $val) {
+                $menu_intem = $db->qry_first('SELECT active, caption, shorttext, link FROM %prefix%info WHERE infoID = %string%', $item);
                 $info_menu = $db->qry_first("SELECT pos FROM %prefix%menu WHERE module='info2'");
 
-                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem["caption"]);
+                $db->qry("DELETE FROM %prefix%menu WHERE action = 'show_info2' AND caption = %string%", $menu_intem['caption']);
 
-                ($cfg['info2_use_submenus'])? $level = 1 : $level = 0;
+                ($cfg['info2_use_submenus']) ? $level = 1 : $level = 0;
 
                 if ($menu_intem['link']) {
-                    $link = $menu_intem['link'] .'" target="_blank';
+                    $link = $menu_intem['link'].'" target="_blank';
                 } else {
-                    $link = 'index.php?mod=info2&action=show_info2&id='. $item;
+                    $link = 'index.php?mod=info2&action=show_info2&id='.$item;
                 }
 
-                $db->qry("UPDATE %prefix%info SET active = 1 WHERE infoID = %string%", $item);
+                $db->qry('UPDATE %prefix%info SET active = 1 WHERE infoID = %string%', $item);
                 $db->qry("
                   INSERT INTO %prefix%menu
                   SET
@@ -237,13 +221,13 @@ if ($auth['type'] <= 1) {
                     level = %string%,
                     pos = %string%,
                     action = 'show_info2',
-                    file = 'show'", $menu_intem["caption"], $menu_intem["shorttext"], $link, $level, $info_menu["pos"]);
+                    file = 'show'", $menu_intem['caption'], $menu_intem['shorttext'], $link, $level, $info_menu['pos']);
             }
-            $func->confirmation(t('Eintrag aktiviert'), "index.php?mod=info2&action=change");
+            $func->confirmation(t('Eintrag aktiviert'), 'index.php?mod=info2&action=change');
             break;
 
         // Define external link
-        case 30:
+        case 30 :
             $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du einen externen Link definieren.'));
 
             $mf = new \LanSuite\MasterForm();
@@ -254,15 +238,15 @@ if ($auth['type'] <= 1) {
                 if ($val == 'de') {
                     $val = '';
                 } else {
-                    $val = '_'. $val;
+                    $val = '_'.$val;
                 }
-                $mf->AddField(t('Seitentitel'), 'caption'. $val);
-                $mf->AddField(t('Popup-Infotext'), 'shorttext'. $val);
+                $mf->AddField(t('Seitentitel'), 'caption'.$val);
+                $mf->AddField(t('Popup-Infotext'), 'shorttext'.$val);
             }
             $mf->AdditionalDBUpdateFunction = 'UpdateInfo2';
             $mf->SendForm('index.php?mod=info2&action=change&step=30', 'info', 'infoID', $_GET['infoID']);
 
-            $dsp->AddBackButton("index.php?mod=info2&action=change", "info2/form");
+            $dsp->AddBackButton('index.php?mod=info2&action=change', 'info2/form');
             break;
     }
 }

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -191,7 +191,7 @@ if ($auth['type'] <= 1) {
             break;
 
         // Activate and link (admin only)
-        case 23 :
+        case 23:
             if ($_GET['id']) {
                 $_POST['action'][$_GET['id']] = '1';
             }
@@ -227,7 +227,7 @@ if ($auth['type'] <= 1) {
             break;
 
         // Define external link
-        case 30 :
+        case 30:
             $dsp->NewContent(t('Informationsseite - Bearbeiten'), t('Hier kannst du einen externen Link definieren.'));
 
             $mf = new \LanSuite\MasterForm();

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -37,19 +37,19 @@ if ($auth['type'] <= 1) {
             $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
             $ms2->AddIconField('details', 'index.php?mod=info2&action=show_info2&id=', t('Details'));
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=2&infoID=', t('Editieren'));
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                   $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                   $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                   $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                   $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
             if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
@@ -71,19 +71,19 @@ if ($auth['type'] <= 1) {
             $ms2->AddResultField(t('Link'), 'i.link', '', 140);
             $ms2->AddResultField(t('Aktiv'), 'i.active', 'ShowActiveState');
 
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddIconField('edit', 'index.php?mod=info2&action=change&step=30&infoID=', t('Editieren'));
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Deaktivieren', 'index.php?mod=info2&action=change&step=20', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren (jedoch nicht verlinken)', 'index.php?mod=info2&action=change&step=21', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren und verlinken', 'index.php?mod=info2&action=change&step=22', 1);
             }
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddMultiSelectAction('Aktivieren und verlinken nur für Admins', 'index.php?mod=info2&action=change&step=23', 1);
             }
             if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/install/plugins/home.php
+++ b/modules/install/plugins/home.php
@@ -7,10 +7,10 @@ $exclude = '';
 if (!$func->isModActive('faq')) {
     $exclude .= ' AND relatedto_item != \'faq\'';
 }
-if (!$func->isModActive('task') or $auth['type'] < 2) {
+if (!$func->isModActive('task') or $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     $exclude .= ' AND relatedto_item != \'task\'';
 }
-if ($auth['type'] < 2) {
+if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     $exclude .= ' AND relatedto_item != \'SponSupp\'';
 }
 if (!$func->isModActive('usrmgr')) {

--- a/modules/mail/newmail.php
+++ b/modules/mail/newmail.php
@@ -94,7 +94,7 @@ while ($row = $db->fetch_array($res)) {
         $UserFound = 1;
     }
 
-    if ($auth['type'] >= 2 or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or !$cfg['sys_internet'] or $cfg['guestlist_shownames']) {
         $selections[$row['userid']] = $row['username'] .' ('. $row['firstname'] .' '. $row['name'] .')';
     } else {
         $selections[$row['userid']] = $row['username'];

--- a/modules/news/search.inc.php
+++ b/modules/news/search.inc.php
@@ -17,7 +17,7 @@ $ms2->AddResultField(t('Autor'), 'u.username', 'UserNameAndIcon');
 $ms2->AddResultField(t('Datum'), 'UNIX_TIMESTAMP(n.date) AS date', 'MS2GetDate');
 
 $ms2->AddIconField('details', 'index.php?mod=news&action=comment&newsid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=news&action=change&step=2&newsid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/noc/search.inc.php
+++ b/modules/noc/search.inc.php
@@ -11,7 +11,7 @@ $ms2->AddResultField('Titel', 'n.id');
 $ms2->AddResultField('Datum', 'n.ip');
 
 $ms2->AddIconField('details', 'index.php?mod=noc&action=details_device&deviceid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=noc&action=change_device&step=2&deviceid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/party/plugins/usrmgr_details.php
+++ b/modules/party/plugins/usrmgr_details.php
@@ -20,7 +20,7 @@ if ($auth['type'] >= 1) {
     $ms2->AddResultField(t('Bezahltdatum'), 'UNIX_TIMESTAMP(u.paiddate) AS paiddate', 'MS2GetDate');
     $ms2->AddResultField(t('Eingecheckt'), 'UNIX_TIMESTAMP(u.checkin) AS checkin', 'MS2GetDate');
     $ms2->AddResultField(t('Ausgecheckt'), 'UNIX_TIMESTAMP(u.checkout) AS checkout', 'MS2GetDate');
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddIconField('edit', 'index.php?mod=usrmgr&action=party&user_id='. $_GET['userid'] .'&party_id=', t('Editieren'), 'Active');
     }
 

--- a/modules/party/plugins/usrmgr_details_tab.php
+++ b/modules/party/plugins/usrmgr_details_tab.php
@@ -19,7 +19,7 @@ if ($auth['type'] >= 1) {
     $ms2->AddResultField(t('Bezahltdatum'), 'UNIX_TIMESTAMP(u.paiddate) AS paiddate', 'MS2GetDate');
     $ms2->AddResultField(t('Eingecheckt'), 'UNIX_TIMESTAMP(u.checkin) AS checkin', 'MS2GetDate');
     $ms2->AddResultField(t('Ausgecheckt'), 'UNIX_TIMESTAMP(u.checkout) AS checkout', 'MS2GetDate');
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddIconField('edit', 'index.php?mod=usrmgr&action=party&user_id='. $_GET['userid'] .'&party_id=', t('Editieren'), 'Active');
     }
 

--- a/modules/party/price.php
+++ b/modules/party/price.php
@@ -26,7 +26,7 @@ $ms2->AddResultField(t('Preis'), 'p.price');
 $ms2->AddResultField(t('Abendkasse-Preis?'), 'party.evening_price_id', 'EveningPriceIdLink');
 $ms2->AddResultField('Party', 'party.name');
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=party&action=price_edit&party_id='. $_GET['party_id'] .'&price_id=', t('Editieren'));
 }
 

--- a/modules/party/show.php
+++ b/modules/party/show.php
@@ -22,19 +22,19 @@ switch ($stepParameter) {
         $ms2->AddResultField('Von', 'p.startdate');
         $ms2->AddResultField('Bis', 'p.enddate');
         $ms2->AddResultField(t('Mindestalter'), 'p.minage', 'GetMinimumAgeString');
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddResultField('Aktiv', 'p.party_id', 'GetActiveState');
         }
 
         $ms2->AddIconField('details', 'index.php?mod=party&action=show&step=1&party_id=', t('Details'));
         $ms2->AddIconField('signon', 'index.php?mod=usrmgr&action=party&user_id='. $auth['userid'] .'&party_id=', t('Partyanmeldung'));
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('edit', 'index.php?mod=party&action=edit&party_id=', t('Editieren'));
         }
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('delete', 'index.php?mod=party&action=delete&party_id=', t('Löschen'));
         }
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('paid', 'index.php?mod=party&action=price&step=2&party_id=', t('Preise bearbeiten'));
         }
 
@@ -42,7 +42,7 @@ switch ($stepParameter) {
 
         $dsp->AddSingleRow($dsp->FetchSpanButton(t('Hinzufügen'), 'index.php?mod=party&action=edit'));
     
-        if ($auth['type'] >= 2 and isset($_SESSION['party_id'])) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and isset($_SESSION['party_id'])) {
             $func->information(t('Der Status "Aktiv" zeigt an, welche Party standardmäßig für alle aktiviert ist, die nicht selbst eine auf der Startseite oder in der Party-Box ausgewählt haben. In deinem Browser ist jedoch aktuell die Party mit der ID %1 aktiv. Welche Party für dich persönlich die aktive ist, kannst du auf der Startseite oder in der Party-Box einstellen', $_SESSION['party_id']), NO_LINK);
         }
         break;

--- a/modules/partylist/Functions/EditAllowed.php
+++ b/modules/partylist/Functions/EditAllowed.php
@@ -7,7 +7,7 @@ function EditAllowed()
 {
     global $line, $auth;
 
-    if ($line['userid'] == $auth['userid'] or $auth['type'] >= 2) {
+    if ($line['userid'] == $auth['userid'] or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         return true;
     } else {
         return false;

--- a/modules/pdf/Classes/PDF.php
+++ b/modules/pdf/Classes/PDF.php
@@ -215,7 +215,7 @@ class PDF
                 break;
 
             case 'ticket':
-                if ($auth["userid"] == $_GET['userid'] || $auth["type"] > 2) {
+                if ($auth["userid"] == $_GET['userid'] || $auth['type'] > \LS_AUTH_TYPE_ADMIN) {
                     $this->_makeUserCard(1, 1, 1, 1, $_GET['userid']);
                 }
                 break;

--- a/modules/picgallery/show.php
+++ b/modules/picgallery/show.php
@@ -54,7 +54,7 @@ if (($cfg["picgallery_allow_user_upload"] || $auth["type"] > 1) && (array_key_ex
 
 // Set Changed Name
 $fileNameParameter = $_POST["file_name"] ?? '';
-if ($fileNameParameter && ($auth['type'] >= 2 || $cfg['picgallery_allow_user_naming'])) {
+if ($fileNameParameter && ($auth['type'] >= \LS_AUTH_TYPE_ADMIN || $cfg['picgallery_allow_user_naming'])) {
     $db->qry("UPDATE %prefix%picgallery SET caption = %string% WHERE name = %string%", $fileNameParameter, $db_dir);
 }
 
@@ -135,7 +135,7 @@ if (!$gd->available) {
     if ($dir_list) {
         foreach ($dir_list as $dir) {
             $DelDirLink = '';
-            if ($auth['type'] > 2) {
+            if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
                 $DelDirLink = ' <a href="index.php?mod=picgallery&action=delete&step=10&file='.$akt_dir.$dir.'"><img src="design/'.$auth['design'].'/images/arrows_delete.gif" border="0" /></a>';
             }
             $directory_selection .= "[<a href=\"index.php?mod=picgallery&file=$akt_dir$dir/\">$dir$DelDirLink</a>] <br />";
@@ -440,7 +440,7 @@ if (!$gd->available) {
             $dsp->AddDoubleRow("", "$prev_button $next_button $full_button $dl_button $del_button $note_button");
 
             // Change Pic-Name
-            if ($auth['type'] >= 2 or $cfg['picgallery_allow_user_naming']) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or $cfg['picgallery_allow_user_naming']) {
                 $dsp->SetForm("index.php?mod=picgallery&file={$_GET["file"]}");
                 $dsp->AddTextFieldRow("file_name", t('Bildname'), $pic['caption'], "");
                 $dsp->AddFormSubmitRow(t('Editieren'));

--- a/modules/poll/search.inc.php
+++ b/modules/poll/search.inc.php
@@ -15,10 +15,10 @@ $ms2->AddResultField(t('Status'), 'UNIX_TIMESTAMP(p.endtime) AS endtime', 'GetPo
 $ms2->AddResultField(t('Stimmen'), 'COUNT(v.polloptionid) AS Votes');
 
 $ms2->AddIconField('details', 'index.php?mod=poll&action=show&step=2&pollid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('signon', 'index.php?mod=poll&action=result&pollid=', t('Ergebnis'));
 }
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=poll&action=change&step=2&pollid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/poll/search.inc.php
+++ b/modules/poll/search.inc.php
@@ -2,13 +2,13 @@
 
 $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('news');
 
-$ms2->query['from'] = "%prefix%polls AS p
+$ms2->query['from'] = '%prefix%polls AS p
   LEFT JOIN %prefix%polloptions AS o ON p.pollid = o.pollid
-  LEFT JOIN %prefix%pollvotes AS v ON o.polloptionid = v.polloptionid";
+  LEFT JOIN %prefix%pollvotes AS v ON o.polloptionid = v.polloptionid';
 $ms2->query['default_order_by'] = 'p.changedate ASC';
-$ms2->query['where'] = (int)$auth['type'] .' >= 2 OR !p.group_id OR p.group_id = '. (int)$auth['group_id'];
+$ms2->query['where'] = (int) $auth['type'].' >= 2 OR !p.group_id OR p.group_id = '.(int) $auth['group_id'];
 
-$ms2->AddTextSearchField(t('Titel'), array('p.caption' => 'like'));
+$ms2->AddTextSearchField(t('Titel'), ['p.caption' => 'like']);
 
 $ms2->AddResultField(t('Titel'), 'p.caption');
 $ms2->AddResultField(t('Status'), 'UNIX_TIMESTAMP(p.endtime) AS endtime', 'GetPollStatus');
@@ -17,8 +17,6 @@ $ms2->AddResultField(t('Stimmen'), 'COUNT(v.polloptionid) AS Votes');
 $ms2->AddIconField('details', 'index.php?mod=poll&action=show&step=2&pollid=', t('Details'));
 if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('signon', 'index.php?mod=poll&action=result&pollid=', t('Ergebnis'));
-}
-if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=poll&action=change&step=2&pollid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/rent/plugins/home.php
+++ b/modules/rent/plugins/home.php
@@ -4,7 +4,7 @@ $smarty->assign('caption', t('Verleih'));
 $content = '';
   
 // Additional Admin-Stats
-if ($auth["type"] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $row8 = $db->qry_first("SELECT count(*) as n FROM %prefix%rentuser WHERE back_orgaid = '' AND out_orgaid != ''");
 
     // total equip

--- a/modules/rent/search.inc.php
+++ b/modules/rent/search.inc.php
@@ -14,11 +14,11 @@ $ms2->AddResultField('Titel', 's.caption');
 $ms2->AddResultField('Verliehen', 's.quantity', 'RentCount');
 $ms2->AddResultField('Besitzer', 'o.username', 'UserNameAndIcon');
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('assign', 'index.php?mod=rent&action=show&step=10&stuffid=', t('Zuweisen'));
 }
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=rent&action=add&stuffid=', t('Editieren'));
 }
 

--- a/modules/sample/show.php
+++ b/modules/sample/show.php
@@ -81,7 +81,7 @@ $ms2->AddResultField(t('Datum'), 'n.date', 'MS2GetDate');
 
 // These functions could be accessed for each row. To each link the group-by id is attached. See PrintSearch
 $ms2->AddIconField('details', 'index.php?mod=news&action=comment&newsid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=news&action=change&step=2&newsid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/seating/search_basic_blockselect.inc.php
+++ b/modules/seating/search_basic_blockselect.inc.php
@@ -30,7 +30,7 @@ if ($target_url) {
         $ms2->AddIconField('ip_del', 'index.php?mod=seating&action=ipgen&step=20&blockid=', t('IPs löschen'));
     }
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $ms2->AddIconField('edit', 'index.php?mod=seating&action=edit&step=2&blockid=', t('Editieren'));
     }
     if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/server/search.inc.php
+++ b/modules/server/search.inc.php
@@ -20,7 +20,7 @@ $ms2->AddResultField('PW', 's.pw', 'PWIcon');
 $ms2->AddResultField(t('Status'), 's.available', 'ServerStatus');
 
 $ms2->AddIconField('details', 'index.php?mod=server&action=show_details&serverid=', t('Details'));
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=server&action=change&step=2&serverid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/sponsor/search.inc.php
+++ b/modules/sponsor/search.inc.php
@@ -6,7 +6,7 @@ $ms2->query['from'] = "%prefix%sponsor AS s";
 $ms2->AddResultField('Titel', 's.name');
 $ms2->AddResultField('Autor', 's.url');
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=sponsor&amp;action=change&amp;sponsorid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/tournament2/Functions/WritePairs2.php
+++ b/modules/tournament2/Functions/WritePairs2.php
@@ -25,7 +25,7 @@ function write_pairs2(mixed $bracket, $max_pos)
 
     $templ['index']['info']['content'] .= "CreateRect(". ($xpos - 5) .", 1, ". ($box_width + 10) .", $img_height, '$bg_color_svg', '#ffffff', '');";
     $templ['index']['info']['content'] .= "CreateText('". t('Runde') .": $akt_round" ."', $xpos, 16, '');";
-    ($auth['type'] >= 2)? $link = 'index.php?mod=tournament2&action=breaks&tournamentid='. $tournamentid : $link = '';
+    ($auth['type'] >= \LS_AUTH_TYPE_ADMIN)? $link = 'index.php?mod=tournament2&action=breaks&tournamentid='. $tournamentid : $link = '';
     $templ['index']['info']['content'] .= "CreateText('". t('Zeit') .": ". $round_start ." - ". $round_end ."', $xpos, 26, '". $link ."');";
     $templ['index']['info']['content'] .= "CreateText('". t('Map') .": ". addslashes(trim($map[(abs(floor($akt_round)) % count($map))])) ."', $xpos, 36, '');";
 

--- a/modules/tournament2/search.inc.php
+++ b/modules/tournament2/search.inc.php
@@ -26,10 +26,10 @@ $ms2->AddIconField('details', 'index.php?mod=tournament2&action=details&tourname
 $ms2->AddIconField('tree', 'index.php?mod=tournament2&action=tree&step=2&tournamentid=', t('Spielbaum'), 'IfGenerated');
 $ms2->AddIconField('play', 'index.php?mod=tournament2&action=games&step=2&tournamentid=', t('Paarungen'), 'IfGenerated');
 $ms2->AddIconField('ranking', 'index.php?mod=tournament2&action=rangliste&step=2&tournamentid=', t('Rangliste'), 'IfFinished');
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('generate', 'index.php?mod=tournament2&action=generate_pairs&step=2&tournamentid=', t('Generieren'), 'IfNotGenerated');
 }
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=tournament2&action=change&step=1&tournamentid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/tournament2/submit_result.php
+++ b/modules/tournament2/submit_result.php
@@ -130,7 +130,7 @@ if ($tournament["name"] == "") {
                 $dsp->AddDoubleRow(t('Server'), '<a href="index.php?mod=server&action=show_details&serverid='.$team1['server_id'].'">'.$selections[$team1['server_id']].'</a>');
             }
             
-            if ($func->isModActive('server') and $auth['type'] >= 2) {
+            if ($func->isModActive('server') and $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $mf = new \LanSuite\MasterForm();
                 $mf->AddField(t('Server Zuweisen'), 'server_id', \LanSuite\MasterForm::IS_SELECTION, $selections, \LanSuite\MasterForm::FIELD_OPTIONAL);
                 if ($mf->SendForm("index.php?mod=tournament2&action=submit_result&step=1&tournamentid=".$tournamentid."&gameid1=".$gameid1."&gameid2=".$gameid2, 't2_games', 'gameid', $gameid1)) {

--- a/modules/tournament2/teammgr_admin.php
+++ b/modules/tournament2/teammgr_admin.php
@@ -39,7 +39,7 @@ switch ($stepParameter) {
         include_once('modules/usrmgr/search_main.inc.php');
 
         $ms2->query['where'] .= "p.party_id={$party->party_id} AND (p.paid)";
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('assign', 'index.php?mod=tournament2&action=teammgr_admin&step=21&teamid='. $teamid .'&userid=', 'Assign');
         }
 
@@ -67,7 +67,7 @@ switch ($stepParameter) {
             include_once('modules/usrmgr/search_main.inc.php');
 
             $ms2->query['where'] .= "p.party_id={$party->party_id} AND (p.paid)";
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 $ms2->AddIconField('assign', 'index.php?mod=tournament2&action=teammgr_admin&step=41&tournamentid='. $tournamentid .'&userid=', 'Assign');
             }
 

--- a/modules/troubleticket/assign.php
+++ b/modules/troubleticket/assign.php
@@ -8,7 +8,7 @@ switch ($_GET["step"]) {
         include_once('modules/usrmgr/search_main.inc.php');
     
         $ms2->query['where'] .= "u.type > 1";
-        if ($auth['type'] >= 2) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $ms2->AddIconField('assign', 'index.php?mod=troubleticket&action=assign&step=3&ttid='.$_GET['ttid'] .'&userid=', 'Assign');
         }
     

--- a/modules/troubleticket/plugins/home.php
+++ b/modules/troubleticket/plugins/home.php
@@ -4,7 +4,7 @@ $smarty->assign('caption', t('Troubletickets'));
 $content = '';
   
 // Additional Admin-Stats
-if ($auth["type"] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $row6 = $db->qry_first("SELECT COUNT(*) AS n FROM %prefix%troubleticket WHERE target_userid = '0'");
     $row7 = $db->qry_first("SELECT COUNT(*) AS n FROM %prefix%troubleticket");
     $content .= t('Troubletickets') .": ".$row6["n"]." / ".$row7["n"] . HTML_NEWLINE;

--- a/modules/troubleticket/search.inc.php
+++ b/modules/troubleticket/search.inc.php
@@ -2,7 +2,7 @@
 
 include_once('modules/troubleticket/search_main.inc.php');
 
-if ($auth['type'] < 2) {
+if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     $ms2->query['where'] .=  "AND orgaonly = '0'";
 }
 

--- a/modules/troubleticket/search_main.inc.php
+++ b/modules/troubleticket/search_main.inc.php
@@ -15,10 +15,10 @@ $ms2->AddResultField('Zuständig', 'u.username');
 $ms2->AddResultField('Status', 't.status', 'TTStatus');
 
 $ms2->AddIconField('details', 'index.php?mod=troubleticket&action=show&step=2&ttid=', 'Details');
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('assign', 'index.php?mod=troubleticket&action=assign&step=2&ttid=', 'Assign');
 }
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=troubleticket&action=change&step=2&ttid=', 'Edit');
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/usrmgr/Functions/ChangeAllowed.php
+++ b/modules/usrmgr/Functions/ChangeAllowed.php
@@ -18,7 +18,7 @@ function ChangeAllowed($id): bool|string
     }
 
     // Signon ended?
-    if ($row['senddate'] < time() and $auth['type'] < 2) {
+    if ($row['senddate'] < time() and $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
         return t('Die Anmeldung ist beendet seit'). HTML_NEWLINE .'<strong>'. $func->unixstamp2date($row['senddate'], 'daydatetime'). '</strong>';
     }
 

--- a/modules/usrmgr/Functions/CheckDeleteUser.php
+++ b/modules/usrmgr/Functions/CheckDeleteUser.php
@@ -20,7 +20,7 @@ function CheckDeleteUser($userid)
         pu.user_id = %int%
         AND UNIX_TIMESTAMP(p.enddate) > UNIX_TIMESTAMP(NOW())', $userid);
 
-    if ($auth["type"] == 2 and $get_data["type"] >= 2) {
+    if ($auth['type'] == \LS_AUTH_TYPE_ADMIN and $get_data["type"] >= 2) {
         $func->error(t('Du hast nicht die erforderlichen Rechte, um einen Admin zu löschen'), "index.php?mod=usrmgr");
     } elseif ($get_party_data["found"]) {
         $func->error(t('Dieser Benutzer ist noch zu einer Party angemeldet. Melden sie ihn zuerst ab'), "index.php?mod=usrmgr");

--- a/modules/usrmgr/Functions/IsAuthorizedAdmin.php
+++ b/modules/usrmgr/Functions/IsAuthorizedAdmin.php
@@ -8,7 +8,7 @@ function IsAuthorizedAdmin()
     global $auth, $user_data, $link;
 
     $link = '';
-    if ($auth['type'] >= 2 and $auth['type'] >= $user_data['type']) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN and $auth['type'] >= $user_data['type']) {
         return true;
     } else {
         return false;

--- a/modules/usrmgr/Functions/PartyMail.php
+++ b/modules/usrmgr/Functions/PartyMail.php
@@ -9,7 +9,7 @@ function PartyMail()
 
     $usrmgr->WriteXMLStatFile();
 
-    if ((array_key_exists('sendmail', $_POST) && $_POST['sendmail']) || $auth['type'] < 2) {
+    if ((array_key_exists('sendmail', $_POST) && $_POST['sendmail']) || $auth['type'] < \LS_AUTH_TYPE_ADMIN) {
         if ($usrmgr->SendSignonMail(1)) {
             $func->confirmation(t('Eine Bestätigung der Anmeldung wurde an deine E-Mail-Adresse gesendet.'), NO_LINK);
         } else {

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -18,11 +18,11 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
         $mf->AddFix('locked', 1);
     }
 
-    if ($auth['type'] >= 2 || !$_GET['userid'] || ($auth['userid'] == $_GET['userid'] && ($cfg['user_self_details_change'] || $missing_fields))) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN || !$_GET['userid'] || ($auth['userid'] == $_GET['userid'] && ($cfg['user_self_details_change'] || $missing_fields))) {
         // If Admin, Creating a new user, or Missing fields:
         // Show Username Field
         ($quick_signon)? $optional = 1 : $optional = 0;
-        if (($auth['type'] >= 2 || !$_GET['userid'] or $missing_fields)) {
+        if (($auth['type'] >= \LS_AUTH_TYPE_ADMIN || !$_GET['userid'] or $missing_fields)) {
             $mf->AddField(t('Benutzername'), 'username', '', '', $optional, 'CheckValidUsername');
         } else {
             $mf->AddField(t('Benutzername'), '', \LanSuite\MasterForm::IS_TEXT_MESSAGE, t('Als Benutzer kannst du deinen Benutzernamen, Bezahlt & Platz-Status, Ausweis / Sonstiges und Kommentar NICHT ändern. Wenden dich dazu bitte an einen Administrator.'));
@@ -38,7 +38,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
             $mf->AddGroup(t('Namen'));
 
             // If Admin: Usertype, Group and Module-Permissions
-            if ($auth['type'] >= 2) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                 // Usertype
                 $selections = [];
                 $selections['1'] = t('Benutzer');
@@ -90,7 +90,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
 
         // If not admin and user is created (not changed)
         // or if quick sign on is enabled
-        if ($quick_signon or ($auth['type'] < 2 && !$_GET['userid'])) {
+        if ($quick_signon or ($auth['type'] < \LS_AUTH_TYPE_ADMIN && !$_GET['userid'])) {
             $mf->AddFix('type', 1);
         }
 
@@ -210,7 +210,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
             $mf->AddGroup(t('Kontakt'));
 
             // Misc (Perso + Birthday + Gender + Newsletter)
-            if (($auth['type'] >= 2 or !$_GET['userid'] or $missing_fields)) {
+            if (($auth['type'] >= \LS_AUTH_TYPE_ADMIN or !$_GET['userid'] or $missing_fields)) {
                 if (ShowFieldUsrMgr('perso')) {
                     $mf->AddField(t('Personalausweis'), 'perso', \LanSuite\MasterForm::IS_CALLBACK, 'PersoInput', Optional('perso'));
                 }
@@ -231,7 +231,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
             }
 
             // If Admin: Picture and Comment
-            if (($auth['type'] >= 2)) {
+            if (($auth['type'] >= \LS_AUTH_TYPE_ADMIN)) {
                 $mf->AddField(t('Benutzerbild hochladen'), 'picture', \LanSuite\MasterForm::IS_FILE_UPLOAD, 'ext_inc/user_pics/', Optional('picture'));
                 $mf->AddField(t('Kommentar'), 'comment', '', \LanSuite\MasterForm::HTML_ALLOWED, \LanSuite\MasterForm::FIELD_OPTIONAL);
             }
@@ -264,7 +264,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
 
     if (!$quick_signon) {
         // Settings
-        if ($auth['type'] >= 2 or !$_GET['userid'] or $auth['userid'] == $_GET['userid']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or !$_GET['userid'] or $auth['userid'] == $_GET['userid']) {
             if ($cfg['user_design_change']) {
                 $selections = [];
                 $selections[''] = t('System-Vorgabe');

--- a/modules/usrmgr/details.php
+++ b/modules/usrmgr/details.php
@@ -218,10 +218,10 @@ if (!$user_data['userid']) {
     $dsp->AddFieldsetStart(t('Kontakt'));
     // Address
     $address = '';
-    if (($user_data['street'] != '' or $user_data['hnr']) and ($auth['type'] >= 2 or ($auth['userid'] == $_GET['userid'] and $cfg['user_showownstreet'] == '1'))) {
+    if (($user_data['street'] != '' or $user_data['hnr']) and ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or ($auth['userid'] == $_GET['userid'] and $cfg['user_showownstreet'] == '1'))) {
         $address .= $user_data['street'] .' '. $user_data['hnr'] .', ';
     }
-    if (($user_data['plz'] != '' or $user_data['city']) and ($cfg['user_showcity4all'] == '1' or $auth['type'] >= 2 or $auth['userid'] == $_GET['userid'])) {
+    if (($user_data['plz'] != '' or $user_data['city']) and ($cfg['user_showcity4all'] == '1' or $auth['type'] >= \LS_AUTH_TYPE_ADMIN or $auth['userid'] == $_GET['userid'])) {
         $address .= $user_data['plz'] .' '. $user_data['city'];
     }
     if ($address) {
@@ -240,7 +240,7 @@ if (!$user_data['userid']) {
 
     // Mail
     $mail = '<table width="100%" cellspacing="0" cellpadding="0"><tr><td>';
-    if ((!$cfg['sys_internet'] and $cfg['user_showmail4all']) or $auth['type'] >= 2 or $auth['userid'] == $_GET['userid']) {
+    if ((!$cfg['sys_internet'] and $cfg['user_showmail4all']) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN or $auth['userid'] == $_GET['userid']) {
         $mail .= '<a href="mailto:'. $user_data['email'] .'">'. $user_data['email'] .'</a> ';
     }
     $mail .= '[Newsletter-Abo:';
@@ -290,12 +290,12 @@ if (!$user_data['userid']) {
     $dsp->AddDoubleRow(t('Benutzertyp'), GetTypeDescription($user_data['type']));
 
     // Perso
-    if ($user_data['perso'] and ($auth['type'] >= 2 or ($auth['userid'] == $_GET['userid'] and $cfg['user_showownstreet'] == '1'))) {
+    if ($user_data['perso'] and ($auth['type'] >= \LS_AUTH_TYPE_ADMIN or ($auth['userid'] == $_GET['userid'] and $cfg['user_showownstreet'] == '1'))) {
         $dsp->AddDoubleRow(t('Passnummer / Sonstiges'), $user_data['perso'] .'<br>'. t('Hinweis: Die Angaben zu Straße und Passnummer sind nur für dich und die Organisatoren sichtbar.'));
     }
 
     // Birthday
-    if ($cfg['sys_internet'] == 0 or $auth['type'] >= 2 or $auth['userid'] == $_GET['userid']) {
+    if ($cfg['sys_internet'] == 0 or $auth['type'] >= \LS_AUTH_TYPE_ADMIN or $auth['userid'] == $_GET['userid']) {
         $dsp->AddDoubleRow("Geburtstag", ((int) $user_data['birthday'])? $func->unixstamp2date($user_data['birthday'], 'date') .' ('. $user_data['age']  .')' : t('Nicht angegeben'));
     }
 
@@ -355,7 +355,7 @@ if (!$user_data['userid']) {
   
     $dsp->StartTab(t('Sonstiges'));
     // logins, last login
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $lastLoginTS = $db->qry_first("SELECT max(logintime) FROM %prefix%stats_auth WHERE userid = %int% AND login = '1'", $_GET['userid']);
         $dsp->AddDoubleRow(t('Logins'), $user_data['logins']);
         if ($user_data['lastlogin']) {
@@ -423,7 +423,7 @@ if (!$user_data['userid']) {
 
     $db->free_result($user_fields);
 
-    if ($auth['type'] >= 2) {
+    if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         $buttons = $dsp->FetchSpanButton(t('Benutzerübersicht'), 'index.php?mod='. $_GET['mod'] .'&action=search').' ';
     } else {
         $buttons = $dsp->FetchSpanButton(t('Benutzerübersicht'), 'index.php?mod=guestlist&action=guestlist').' ';

--- a/modules/usrmgr/party.php
+++ b/modules/usrmgr/party.php
@@ -8,7 +8,7 @@ $seat2 = new \LanSuite\Module\Seating\Seat2();
 if ($party->count == 0) {
     $func->information(t('Aktuell sind keine Partys geplant.'), 'index.php?mod='. $_GET['mod']);
 } else {
-    if ($_GET['user_id'] == $auth['userid'] or $auth['type'] >= 2) {
+    if ($_GET['user_id'] == $auth['userid'] or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
         // Show Upcomming
         $MFID = 1;
 
@@ -35,7 +35,7 @@ if ($party->count == 0) {
                 $mf->AddChangeCondition = 'ChangeAllowed';
 
                 // Paid
-                if ($auth['type'] >= 2) {
+                if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                     $selections = array();
                     $selections['0'] = t('Nicht bezahlt');
                     $selections['1'] = t('Bezahlt');
@@ -72,7 +72,7 @@ if ($party->count == 0) {
 
                 $mf->AddFix('signondate', 'NOW()');
 
-                if ($auth['type'] >= 2) {
+                if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
                     $mf->AddField(t('Mail versenden?') .'|'. t('Den Benutzer per Mail über die Änderung informieren'), 'sendmail', 'tinyint(1)', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
                 }
                 $mf->SendButtonText = 'An-/Abmelden';

--- a/modules/usrmgr/search.inc.php
+++ b/modules/usrmgr/search.inc.php
@@ -30,7 +30,7 @@ if ($cfg['signon_show_clan']) {
 $ms2->AddIconField('details', 'index.php?mod=usrmgr&action=details&userid=', t('Details'));
 $ms2->AddIconField('send_mail', 'index.php?mod=mail&action=newmail&step=2&userID=', t('Mail senden'));
 $ms2->AddIconField('change_pw', 'index.php?mod=usrmgr&action=newpwd&step=2&userid=', t('Passwort ändern'), 'IfLowerOrEqualUserlevel');
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('assign', 'index.php?mod=auth&action=switch_to&userid=', t('Benutzer wechseln'), 'IfLowerUserlevel');
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN and $func->isModActive('foodcenter')) {
@@ -45,14 +45,14 @@ while ([$caption, $inc] = $plugin->fetch()) {
     include_once($inc);
 }
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddIconField('edit', 'index.php?mod=usrmgr&action=change&step=1&userid=', t('Editieren'));
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {
     $ms2->AddIconField('delete', 'index.php?mod=usrmgr&action=delete&step=2&userid=', t('Löschen'));
 }
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $res = $db->qry("SELECT * FROM %prefix%party_usergroups");
     $ms2->AddMultiSelectAction("Gruppenzuordung aufheben", "index.php?mod=usrmgr&action=group&step=30&group_id=0", 0, 'delete_group');
     while ($row = $db->fetch_array($res)) {
@@ -61,10 +61,10 @@ if ($auth['type'] >= 2) {
     $db->free_result($res);
 }
 
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddMultiSelectAction(t('Freigeben'), "index.php?mod=usrmgr&step=11", 1, 'unlocked');
 }
-if ($auth['type'] >= 2) {
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddMultiSelectAction(t('Sperren'), "index.php?mod=usrmgr&step=10", 1, 'locked');
 }
 if ($auth['type'] >= \LS_AUTH_TYPE_SUPERADMIN) {

--- a/modules/wiki/show.php
+++ b/modules/wiki/show.php
@@ -41,7 +41,7 @@ while ($row = $db->fetch_array($res)) {
         $links .= ' - '. $row['username'] .'@'. $row['date'] .' ';
     }
     $links .= '</a>';
-    if ($_GET['versionid'] == $row['versionid'] and $auth['type'] > 2) {
+    if ($_GET['versionid'] == $row['versionid'] and $auth['type'] > \LS_AUTH_TYPE_ADMIN) {
         $links .= ' <a href="index.php?mod=wiki&action=delete&step=10&postid='. $_GET['postid'] .'&versionid='. $_GET['versionid'] .'" rel="nofollow" class="icon_delete" title="'. t('Löschen') .'"> </a> ';
     }
     $links .= '] ';
@@ -53,7 +53,7 @@ if ($auth['login']) {
 }
 
 $links_main = '';
-if ($auth['type'] > 2) {
+if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
     $links_main .= ' <a href="index.php?mod=wiki&action=delete&step=2&postid='. $_GET['postid'] .'" class="icon_delete" title="'. t('Löschen') .'"> </a>';
 }
 


### PR DESCRIPTION
### What is this PR doing?

We use the magic number "2" everywhere to indicate permissions.
Using the constant `\ LS_AUTH_TYPE_ADMIN` creates more context for the reader and is also easier to search for.

### Attention

This PR depends on https://github.com/lansuite/lansuite/pull/789.
Please merge https://github.com/lansuite/lansuite/pull/789 before this one.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed