### PR TITLE
[Authentication] Replace magic number comparision of $auth['type'] >= 1 with the usage of \LS_AUTH_TYPE_USER

### DIFF
--- a/inc/Classes/MasterComment.php
+++ b/inc/Classes/MasterComment.php
@@ -149,7 +149,7 @@ class MasterComment
         $dsp->AddFieldsetEnd();
 
         // Bookmarks and Auto-Mail
-        if ($auth['login'] and $auth['type'] > 1) {
+        if ($auth['login'] and $auth['type'] > \LS_AUTH_TYPE_USER) {
             $setBmParameter = $_GET['set_bm'] ?? '';
             if ($setBmParameter) {
                 $db->qry_first('DELETE FROM %prefix%comments_bookmark WHERE relatedto_id = %int% AND relatedto_item = %string%', $id, $mod);

--- a/modules/board/thread.php
+++ b/modules/board/thread.php
@@ -64,7 +64,7 @@ if (!$thread and $tid) {
 
     // Generate Thread-Buttons
     $buttons = '';
-    if ($auth["type"] > 1) {
+    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
         if ($thread['closed']) {
             $buttons .= ' '. $dsp->FetchIcon("unlocked", "index.php?mod=board&action=thread&step=11&tid=$tid");
         } else {
@@ -158,10 +158,10 @@ if (!$thread and $tid) {
         $smarty->assign('signature', $signature);
 
         $edit = '';
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $edit .= $dsp->FetchIcon("delete", "index.php?mod=board&action=delete&pid=$pid&posts_page=" . $_GET['posts_page'], '', '', 'right');
         }
-        if ($auth['type'] > 1 or $row["userid"] == $auth["userid"]) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER or $row["userid"] == $auth["userid"]) {
             $edit .= $dsp->FetchIcon("edit", "index.php?mod=board&action=thread&fid=$fid&tid=$tid&pid=$pid&posts_page=" . $_GET['posts_page'], '', '', 'right');
         }
         $edit .= $dsp->FetchIcon("quote", "javascript:InsertCode(document.dsp_form1.comment, '[quote]" . str_replace("\n", "\\n", addslashes(str_replace('"', '', $row["comment"]))) . "[/quote]')", '', '', 'right');
@@ -195,7 +195,7 @@ if ($thread['closed']) {
     $func->information(t('Du gehörst nicht der richtigen Gruppe an, um auf diese Beiträge zu antworten.'), NO_LINK);
 } elseif ($thread['need_group'] and $auth['group_id'] != $thread['need_group'] and !$_GET['tid']) {
     $new_thread = t('Du gehörst nicht der richtigen Gruppe an, um einen Thread in diesem Forum starten zu können');
-} elseif ($_GET['pid'] != '' and $auth['type'] <= 1 and $current_post['userid'] != $auth['userid']) {
+} elseif ($_GET['pid'] != '' and $auth['type'] <= \LS_AUTH_TYPE_USER and $current_post['userid'] != $auth['userid']) {
     $func->error('Du darfst nur deine eigenen Beiträge editieren!', NO_LINK);
 } elseif ($thread) {
     // Topic erstellen oder auf Topic antworten

--- a/modules/bugtracker/Classes/Bugtracker.php
+++ b/modules/bugtracker/Classes/Bugtracker.php
@@ -30,7 +30,7 @@ class Bugtracker
     {
         global $db, $func, $auth;
 
-        if ($auth['type'] <= 1) {
+        if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
             $row = $db->qry_first("
               SELECT
                 reporter,
@@ -114,7 +114,7 @@ class Bugtracker
 
         $row = $db->qry_first("SELECT 1 AS found FROM %prefix%bugtracker WHERE agent = %int% AND bugid = %int%", $userid, $bugid);
         if (!$row['found']) {
-            if ($auth['type'] > 1) {
+            if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                 $db->qry("UPDATE %prefix%bugtracker SET agent = %int% WHERE bugid = %int%", $userid, $bugid);
             }
 

--- a/modules/clanmgr/Functions/ShowRole.php
+++ b/modules/clanmgr/Functions/ShowRole.php
@@ -14,7 +14,7 @@ function ShowRole($role)
         $ret = t('Clan-Mitglied');
     }
 
-    if (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin']) or $auth['type'] > 1) {
+    if (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin']) or $auth['type'] > \LS_AUTH_TYPE_USER) {
         $ret = '<a href="index.php?mod=clanmgr&action=clanmgr&step=50&clanid='. $_GET['clanid'] .'&userid='. $line['userid'] .'">'. $ret .'</a>';
     }
 

--- a/modules/clanmgr/clanmgr.php
+++ b/modules/clanmgr/clanmgr.php
@@ -33,7 +33,7 @@ switch ($stepParameter) {
         }
 
         $ms2->PrintSearch('index.php?mod=clanmgr', 'c.clanid');
-        if ($auth['type'] >= 1) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_USER) {
             $dsp->AddSingleRow($dsp->FetchSpanButton(t('Hinzufügen'), 'index.php?mod=clanmgr&step=30'));
         }
     
@@ -53,16 +53,16 @@ switch ($stepParameter) {
         $dsp->AddDoubleRow(t('Webseite'), '<a href="'. $row['url'] .'" target="_blank">'. $row['url'] .'</a>');
     
         $buttons = '';
-        if ($auth['type'] >= 1 and $auth['clanid'] != $_GET['clanid']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_USER and $auth['clanid'] != $_GET['clanid']) {
             $buttons .= $dsp->FetchSpanButton(t('Clan beitreten'), 'index.php?mod='. $_GET['mod'] .'&step=60&clanid='. $_GET['clanid']).' ';
         }
-        if ($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid']) {
+        if ($auth['type'] >= \LS_AUTH_TYPE_USER and $auth['clanid'] == $_GET['clanid']) {
             $buttons .= $dsp->FetchSpanButton(t('Clan verlassen'), 'index.php?mod='. $_GET['mod'] .'&step=40&clanid='. $_GET['clanid'].'&userid='.$auth['userid']).' ';
         }
-        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
+        if (($auth['type'] >= \LS_AUTH_TYPE_USER and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $buttons .= $dsp->FetchSpanButton(t('Clan editieren'), 'index.php?mod='. $_GET['mod'] .'&step=30&clanid='. $_GET['clanid']).' ';
         }
-        if (($auth['type'] >= 1 and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
+        if (($auth['type'] >= \LS_AUTH_TYPE_USER and $auth['clanid'] == $_GET['clanid'] and $auth['clanadmin'] == 1) or $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
             $buttons .= $dsp->FetchSpanButton(t('Passwort ändern'), 'index.php?mod='. $_GET['mod'] .'&step=10&clanid='. $_GET['clanid']).' ';
         }
         $dsp->AddDoubleRow('', $buttons);
@@ -79,7 +79,7 @@ switch ($stepParameter) {
         $ms2->AddSelect('u.name');
     
         $ms2->AddResultField(t('Benutzername'), 'u.username', 'UserNameAndIcon');
-        if (!$cfg['sys_internet'] or $auth['type'] > 1 or $auth['clanid'] == $_GET['clanid']) {
+        if (!$cfg['sys_internet'] or $auth['type'] > \LS_AUTH_TYPE_USER or $auth['clanid'] == $_GET['clanid']) {
             $ms2->AddResultField(t('Vorname'), 'u.firstname', '');
             $ms2->AddResultField(t('Nachname'), 'u.name', '');
         }
@@ -204,7 +204,7 @@ switch ($stepParameter) {
     case 50:
         if ($_GET['clanid'] == '') {
             $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
-        } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin']) or $auth['type'] > 1) {
+        } elseif (($_GET['clanid'] == $auth['clanid'] and $auth['clanadmin']) or $auth['type'] > \LS_AUTH_TYPE_USER) {
             $cur_role = $db->qry_first("SELECT username, clanadmin FROM %prefix%user WHERE clanid = %int% AND userid = %int%", $_GET['clanid'], $_GET['userid']);
             if ($cur_role['clanadmin'] and CountAdmins() == 1) {
                 $func->information(t('Du kannst %1 nicht die Admin Rolle entziehen, da %1 z.z das einzige Mitglied mit der Rolle Clan-Admin ist. Benenne bitte vorher einen anderen Admin.', $cur_role['username']), "index.php?mod=clanmgr&step=2&clanid=".$_GET["clanid"]);
@@ -224,7 +224,7 @@ switch ($stepParameter) {
     case 60:
         if ($_GET['clanid'] == '') {
             $func->error(t('Keine Clan-ID angegeben!'), "index.php?mod=home");
-        } elseif ($auth["type"] < 1) {
+        } elseif ($auth['type'] < \LS_AUTH_TYPE_USER) {
             $func->error(t('Keine Berechtigung diese Funktion auszuführen'), "index.php?mod=home");
         } elseif (!$_POST['clan_pass']) {
             $dsp->SetForm("index.php?mod=clanmgr&action=clanmgr&step=60&clanid=".$_GET['clanid']);

--- a/modules/faq/show.php
+++ b/modules/faq/show.php
@@ -11,7 +11,7 @@ if ($count_cat == 0) {
         if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
             $admin_link = $dsp->FetchIcon('delete', 'index.php?mod=faq&object=item&action=delete_cat&catid=' . $row["catid"] . '&step=2');
         }
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $admin_link .= $dsp->FetchIcon('edit', 'index.php?mod=faq&object=cat&action=change_cat&catid=' . $row["catid"] . '&step=2');
         }
         $dsp->AddFieldsetStart($admin_link . $row["name"]);
@@ -21,7 +21,7 @@ if ($count_cat == 0) {
             if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
                 $admin_link = $dsp->FetchIcon('delete', 'index.php?mod=faq&object=item&action=delete_item&itemid=' . $row["itemid"] . '&step=2');
             }
-            if ($auth['type'] > 1) {
+            if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                 $admin_link .= $dsp->FetchIcon('edit', 'index.php?mod=faq&object=cat&action=change_item&itemid=' . $row["itemid"] . '&step=2');
             }
             $dsp->AddSingleRow($admin_link . $dsp->FetchLink($func->text2html($row["caption"]), 'index.php?mod=faq&action=comment&itemid='. $row["itemid"]));

--- a/modules/faq/show_item.php
+++ b/modules/faq/show_item.php
@@ -6,7 +6,7 @@ $framework->AddToPageTitle($get_data["caption"]);
 $dsp->NewContent(t('<b>F</b>requently <b>A</b>sked <b>Q</b>uestions'));
 $buttons = $dsp->FetchSpanButton(t('Zurück'), "index.php?mod=faq");
 
-if ($auth["type"] > 1) {
+if ($auth['type'] > \LS_AUTH_TYPE_USER) {
     $buttons .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=faq&object=item&action=change_item&step=2&itemid=" . $_GET["itemid"]);
     $buttons .= $dsp->FetchSpanButton(t('Löschen'), "index.php?mod=faq&object=item&action=delete_item&step=2&itemid=" . $_GET["itemid"]);
 }

--- a/modules/foodcenter/Classes/Product.php
+++ b/modules/foodcenter/Classes/Product.php
@@ -647,7 +647,7 @@ class Product
                 }
                 break;
         }
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $dsp->AddDoubleRow("", $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=foodcenter&amp;action=addproduct&amp;id=". $this->id));
         }
         $dsp->AddBackButton($worklink);

--- a/modules/foodcenter/account.php
+++ b/modules/foodcenter/account.php
@@ -2,7 +2,7 @@
 
 $account = new LanSuite\Module\Foodcenter\Accounting($auth['userid']);
 
-if ($auth['type'] > 1 && !isset($_GET['act'])) {
+if ($auth['type'] > \LS_AUTH_TYPE_USER && !isset($_GET['act'])) {
     $_GET['act'] = "menu";
 } elseif ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
     $_GET['act'] = "";

--- a/modules/guestlist/Functions/PaidIconLinkGuestlist.php
+++ b/modules/guestlist/Functions/PaidIconLinkGuestlist.php
@@ -8,7 +8,7 @@ function PaidIconLinkGuestlist($paid)
 {
     global $dsp, $line, $auth;
 
-    if ($auth['type'] > 1) {
+    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
         if ($paid) {
             return $dsp->FetchIcon('paid', 'index.php?mod=guestlist&step=11&userid=' . $line['userid'], t('Bezahlt'));
         } else {

--- a/modules/home/show.php
+++ b/modules/home/show.php
@@ -3,7 +3,7 @@
 // Delete old read states
 $db->qry('DELETE FROM %prefix%lastread WHERE DATEDIFF(NOW(), date) > 7 AND tab != "task"');
 
-if ($auth["type"] == 1) {
+if ($auth['type'] == \LS_AUTH_TYPE_USER) {
     $home_page = $cfg["home_login"];
 } elseif ($auth['type'] == \LS_AUTH_TYPE_ADMIN or $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
     $home_page = $cfg["home_admin"];

--- a/modules/info2/change.php
+++ b/modules/info2/change.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($auth['type'] <= 1) {
+if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
     $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
 
     $ms2->query['from'] = "%prefix%info AS i";

--- a/modules/info2/show.php
+++ b/modules/info2/show.php
@@ -30,7 +30,7 @@ if ($submodParameter != "" || ($_GET["id"]>=1)) {
     
     // Show edit/aktivate Buttons
     // TODO add delete
-    if ($auth["type"] > 1) {
+    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
         $buttons .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=info2&action=change&step=2&infoID={$_GET["id"]}"). " ";
         if ($info['active'] == 1) {
             $buttons .= $dsp->FetchSpanButton(t('Deaktivieren'), "index.php?mod=info2&action=change&step=20&infoID={$_GET["id"]}"). " ";

--- a/modules/news/comment.php
+++ b/modules/news/comment.php
@@ -23,7 +23,7 @@ if ($check["caption"] != "") {
     $smarty->assign('date', $func->unixstamp2date($get_news["date"], "daydatetime"));
 
     $text = '';
-    if ($auth["type"] > 1) {
+    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
         $text .= $dsp->FetchIcon("delete", "index.php?mod=news&action=delete&came_from=2&step=2&newsid={$_GET["newsid"]}", '', '', 'right');
         $text .= $dsp->FetchIcon("edit", "index.php?mod=news&action=change&came_from=1&step=2&newsid={$_GET["newsid"]}", '', '', 'right');
     }

--- a/modules/news/show.php
+++ b/modules/news/show.php
@@ -101,7 +101,7 @@ if ($overall_news == 0) {
 
                 // Buttons
                 $buttons = "";
-                if ($auth["type"] > 1) {
+                if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                     $buttons .= $dsp->FetchIcon("edit", "index.php?mod=news&amp;action=change&amp;step=2&amp;newsid=$newsid") . " ";
                     $buttons .= $dsp->FetchIcon("delete", "index.php?mod=news&amp;action=delete&amp;step=2&amp;newsid=$newsid") . " ";
                 }
@@ -164,7 +164,7 @@ if ($overall_news == 0) {
 
                 // Buttons
                 $buttons = "";
-                if ($auth["type"] > 1) {
+                if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                     $buttons .= $dsp->FetchIcon("edit", "index.php?mod=news&amp;action=change&amp;step=2&amp;newsid=$newsid") . " ";
                     $buttons .= $dsp->FetchIcon("delete", "index.php?mod=news&amp;action=delete&amp;step=2&amp;newsid=$newsid") . " ";
                 }

--- a/modules/party/plugins/usrmgr_details.php
+++ b/modules/party/plugins/usrmgr_details.php
@@ -4,7 +4,7 @@
 // modules/usrmgr/details.php to generate Modulspezific Headermenue
 // for Userdetails
 
-if ($auth['type'] >= 1) {
+if ($auth['type'] >= \LS_AUTH_TYPE_USER) {
     $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('usrmgr');
     $ms2->query['from'] = "%prefix%partys p
     LEFT JOIN %prefix%party_user u ON p.party_id = u.party_id AND u.user_id = ". (int)$_GET['userid'] ."

--- a/modules/party/plugins/usrmgr_details_tab.php
+++ b/modules/party/plugins/usrmgr_details_tab.php
@@ -3,7 +3,7 @@
 // modules/usrmgr/details.php to generate Modulspezific Headermenue
 // for Userdetails
 
-if ($auth['type'] >= 1) {
+if ($auth['type'] >= \LS_AUTH_TYPE_USER) {
     $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2('usrmgr');
     $ms2->query['from'] = "%prefix%partys p
     LEFT JOIN %prefix%party_user u ON p.party_id = u.party_id AND u.user_id = ". (int)$_GET['userid'] ."

--- a/modules/picgallery/show.php
+++ b/modules/picgallery/show.php
@@ -13,7 +13,7 @@ $icon_dir = "ext_inc/picgallery_icon/";
 $galleryNameParameter = $_POST['gallery_name'] ?? '';
 // If a new gallery should be created
 if ($galleryNameParameter) {
-    if ($cfg["picgallery_allow_user_upload"] or $auth["type"] > 1) {
+    if ($cfg["picgallery_allow_user_upload"] or $auth['type'] > \LS_AUTH_TYPE_USER) {
         $func->CreateDir('ext_inc/picgallery/'. $_GET['file'] . $galleryNameParameter);
     } else {
         $func->error(t('Du bist nicht berechtigt neue Galerien anzulegen'), "index.php?mod=picgallery&file={$_GET["file"]}");
@@ -42,7 +42,7 @@ if (!$row['found']) {
 }
 
 // Upload posted File
-if (($cfg["picgallery_allow_user_upload"] || $auth["type"] > 1) && (array_key_exists('file_upload', $_FILES) && $_FILES['file_upload'])) {
+if (($cfg["picgallery_allow_user_upload"] || $auth['type'] > \LS_AUTH_TYPE_USER) && (array_key_exists('file_upload', $_FILES) && $_FILES['file_upload'])) {
     $extension = substr($_FILES['file_upload']['name'], strrpos($_FILES['file_upload']['name'], ".") + 1, 4);
     if (IsSupportedType($extension) || IsPackage($extension)) {
         $upload = $func->FileUpload("file_upload", $root_dir);
@@ -215,7 +215,7 @@ if (!$gd->available) {
                     $smarty->assign('galleryid', $gallery_id);
 
                     $buttons = $dsp->FetchIcon("next", "index.php?mod=picgallery&file=$akt_dir$file&page={$_GET["page"]}", t('Bild anzeigen'));
-                    if ($auth["type"] > 1) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                         $buttons .= " ". $dsp->FetchIcon("delete", "index.php?mod=picgallery&action=delete&file=$akt_dir$file&page={$_GET["page"]}", t('Bild löschen'));
                     }
                     $smarty->assign('buttons', $buttons);
@@ -303,7 +303,7 @@ if (!$gd->available) {
                     $smarty->assign('galleryid', $gallery_id);
 
                     $buttons = $dsp->FetchIcon("download", "index.php?mod=picgallery&action=download&design=base&picurl=$akt_dir$package", t('Bild herrunterladen'));
-                    if ($auth["type"] > 1) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                         $buttons .= " ". $dsp->FetchIcon("delete", "index.php?mod=picgallery&action=delete&file=$akt_dir$package&page={$_GET["page"]}", t('Bild l&ouml;schen'));
                     }
                     $smarty->assign('buttons', $buttons);
@@ -333,7 +333,7 @@ if (!$gd->available) {
     $dsp->AddDoubleRow(t('Statistiken'), "$num_files ".t('Dateien')." (". (round(($dir_size / 1024), 1)) ."kB); ".t('Letzte Änderung').": ". $func->unixstamp2date($last_modified, "datetime"));
 
     // Upload-Formular
-    if ($cfg["picgallery_allow_user_upload"] or $auth["type"] > 1) {
+    if ($cfg["picgallery_allow_user_upload"] or $auth['type'] > \LS_AUTH_TYPE_USER) {
         $dsp->SetForm("index.php?mod=picgallery&file={$_GET["file"]}", "", "", "multipart/form-data");
         $dsp->AddFileSelectRow("file_upload", t('Datei hochladen'), "");
         $dsp->AddFormSubmitRow(t('Hinzufügen'));

--- a/modules/seating/Classes/Seat2.php
+++ b/modules/seating/Classes/Seat2.php
@@ -688,7 +688,7 @@ class Seat2
                                     } elseif (($seatStateValue == 2 || $seatStateValue == 3) && $seat_userid[$y][$x] == $auth['userid']) {
                                         $link = "index.php?mod=seating&action=show&step=20&blockid=$blockid&row=$y&col=$x";
                                     // If assigned and user is admin -> Possibility to free this seat
-                                    } elseif ($seatStateValue == 2 && $auth['type'] > 1) {
+                                    } elseif ($seatStateValue == 2 && $auth['type'] > \LS_AUTH_TYPE_USER) {
                                         #$link = "index.php?mod=seating&action=show&step=30&blockid=$blockid&row=$y&col=$x";
                                     }
                                 }
@@ -727,13 +727,13 @@ class Seat2
                             case "9":
                                 $tooltip .= t('Block') .': '. $this->CoordinateToBlockAndName($x + 1, $y, $blockid) . HTML_NEWLINE;
                                 $tooltip .= t('Benutzername') .': '. $user_info[$y][$x]['username'] . HTML_NEWLINE;
-                                if (!$cfg['sys_internet'] or $auth['type'] > 1 or ($auth['userid'] == $selected_user and $selected_user != false)) {
+                                if (!$cfg['sys_internet'] or $auth['type'] > \LS_AUTH_TYPE_USER or ($auth['userid'] == $selected_user and $selected_user != false)) {
                                     $tooltip .= t('Name') .': '. trim($user_info[$y][$x]['firstname']) .' '. trim($user_info[$y][$x]['name']) . HTML_NEWLINE;
                                 }
                                 $tooltip .= t('Clan') .': '. $user_info[$y][$x]['clan'] . HTML_NEWLINE;
                                 $tooltip .= t('IP') .': '. $seat_ip[$y][$x] . HTML_NEWLINE;
                                 if ($func->chk_img_path($user_info[$y][$x]['avatar_path']) and
-                                ($cfg['seating_show_user_pics'] or !$cfg['sys_internet'] or $auth['type'] > 1 or ($auth['userid'] == $selected_user and $selected_user != false))) {
+                                ($cfg['seating_show_user_pics'] or !$cfg['sys_internet'] or $auth['type'] > \LS_AUTH_TYPE_USER or ($auth['userid'] == $selected_user and $selected_user != false))) {
                                       $tooltip .= '<img src=\''. $user_info[$y][$x]['avatar_path'] .'\' style=\'max-width:100%;\' />' . HTML_NEWLINE;
                                 }
                                 break;

--- a/modules/seating/show.php
+++ b/modules/seating/show.php
@@ -113,7 +113,7 @@ switch ($stepParameter) {
                         $db->free_result($res);
                     }
                           // Delete mark, if Admin
-                    if ($auth['type'] > 1 and $seat_user['status'] == 3) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER and $seat_user['status'] == 3) {
                         $questionarray[] = t('Möchtest du als Admin diese Vormerkung entfernen?');
                         $linkarray[]     = "index.php?mod=seating&action=show&step=31&blockid={$_GET['blockid']}&row={$_GET['row']}&col={$_GET['col']}";
                     }
@@ -309,7 +309,7 @@ switch ($stepParameter) {
     
     // Free seat as admin (question)
     case 30:
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $seatingUser = $db->qry_first("
               SELECT
                 s.userid,
@@ -339,7 +339,7 @@ switch ($stepParameter) {
     
     // Free seat as admin
     case 31:
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $seat2->FreeSeat($_GET['blockid'], $_GET['row'], $_GET['col']);
             $func->confirmation(t('Der Sitzplatz wurde erfolgreich freigegeben'), "index.php?mod=seating&action=show&step=2&blockid={$_GET['blockid']}");
         }
@@ -347,7 +347,7 @@ switch ($stepParameter) {
     
     // Umsetzen als Admin
     case 32:
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $current_url = "index.php?mod=seating&action=seatadmin&step=2&userid={$_GET['userid']}";
             $target_url = "index.php?mod=seating&action=seatadmin&step=3&userid={$_GET['userid']}&blockid=";
             $target_icon = '';

--- a/modules/server/add.php
+++ b/modules/server/add.php
@@ -1,7 +1,7 @@
 <?php
 
 $get_paid = ['paid' => 0];
-if ($auth['type'] <= 1) {
+if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
     $get_paid = $db->qry_first('SELECT paid FROM %prefix%party_user WHERE user_id = %int% AND party_id = %int%', $auth['userid'], $party->party_id);
 }
 if ($cfg['server_ip_auto_assign']) {
@@ -16,9 +16,9 @@ if ($cfg['server_ip_auto_assign']) {
 
 if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     $func->information(t('Es sind keine freien IPs mehr vorhanden. Bitte einen Administrator darum den vorgesehenen Bereich zu erhöhren'), "index.php?mod=server");
-} elseif ($cfg["server_admin_only"] and $auth['type'] <= 1) {
+} elseif ($cfg["server_admin_only"] and $auth['type'] <= \LS_AUTH_TYPE_USER) {
     $func->information(t('Nur Adminsitratoren dürfen Server hinzufügen'), "index.php?mod=server");
-} elseif ((!$get_paid['paid']) and $auth["type"] <= 1) {
+} elseif ((!$get_paid['paid']) and $auth['type'] <= \LS_AUTH_TYPE_USER) {
     $func->information(t('Du musst zuerst bezahlen, um Server hinzufügen zu dürfen'), "index.php?mod=server");
 } else {
     $dsp->NewContent(t('Server'), t('Hinzufügen und Aendern der Server'));
@@ -26,7 +26,7 @@ if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     $mf = new \LanSuite\MasterForm();
     $serverIdParameter = $_GET['serverid'] ?? 0;
     if (!$serverIdParameter) {
-        if ($auth['type'] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $mf->AddDropDownFromTable(t('Besitzer'), 'owner', 'userid', 'username', 'user', '', 'type > 0');
         } else {
             $mf->AddFix('owner', $auth['userid']);

--- a/modules/server/delete.php
+++ b/modules/server/delete.php
@@ -25,7 +25,7 @@ switch ($_GET["step"]) {
             serverid = %int%", $_GET["serverid"]);
 
         if ($server) {
-            if ($server["owner"] != $auth["userid"] and $auth["type"] <= 1) {
+            if ($server["owner"] != $auth["userid"] and $auth['type'] <= \LS_AUTH_TYPE_USER) {
                 $func->information(t('Nur der Besitzer und Administratoren d&uuml;rfen diese Aktion ausf&uuml;hren'), "index.php?mod=server&action=delete");
             } else {
                 $delete = $db->qry("DELETE FROM %prefix%server WHERE serverid = %int%", $_GET["serverid"]);

--- a/modules/server/show_details.php
+++ b/modules/server/show_details.php
@@ -100,7 +100,7 @@ if ($server == "") {
         $dsp->AddDoubleRow(t('Beschreibung'), $func->text2html($server["text"]));
 
         $buttons = "";
-        if ($auth['type'] > 1 or $auth['userid'] == $server["owner"]) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER or $auth['userid'] == $server["owner"]) {
             $buttons .= $dsp->FetchSpanButton(t('Editieren'), "index.php?mod=server&action=change&step=2&serverid=$serverid") ." ";
             $buttons .= $dsp->FetchSpanButton(t('Löschen'), "index.php?mod=server&action=delete&step=2&serverid=$serverid") ." ";
         }

--- a/modules/shoutbox/shoutqueries.php
+++ b/modules/shoutbox/shoutqueries.php
@@ -21,7 +21,7 @@ switch ($_GET['shout']) {
         }
 
         if (($_POST['message'] and $auth['login']) or ($_POST['message'] and $captchaCheck)) {
-            if ($auth['type']>=1) {
+            if ($auth['type'] >= \LS_AUTH_TYPE_USER) {
                 $_POST['nickname'] = $auth['username'];
             }
 

--- a/modules/tournament2/Classes/Team.php
+++ b/modules/tournament2/Classes/Team.php
@@ -241,7 +241,7 @@ class Team
                 team.teamid = %int%", $teamid);
 
             // Check password, if set and if acction is not performed, by teamadmin or ls-admin
-            if (($auth['userid'] != $team['leaderid']) and ($auth['type'] <= 1) and ($team['password'] != '') and (md5($password) != $team['password'])) {
+            if (($auth['userid'] != $team['leaderid']) and ($auth['type'] <= \LS_AUTH_TYPE_USER) and ($team['password'] != '') and (md5($password) != $team['password'])) {
                 $func->information(t('Das eingegebene Kennwort ist nicht korrekt'));
                 return false;
 

--- a/modules/tournament2/details.php
+++ b/modules/tournament2/details.php
@@ -29,7 +29,7 @@ if (!$tournament["tournamentid"]) {
     switch ($stepParameter) {
         // Shuffle maps
         case 20:
-            if ($auth['type'] <= 1) {
+            if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
                 $func->information('ACCESS_DENIED');
             } else {
                   $maps = explode("\n", $tournament["mapcycle"]);
@@ -222,7 +222,7 @@ if (!$tournament["tournamentid"]) {
                 $map_str .= t('Runde')." $key: $val \n";
             }
             $mapcycle = t('Mapcycle'). HTML_NEWLINE . HTML_NEWLINE;
-            if ($auth['type'] > 1) {
+            if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                 $mapcycle .= '<a href="index.php?mod=tournament2&action=details&tournamentid='. $_GET['tournamentid'] .'&step=20">'. t('Maps neu mischen') .'</a>';
             }
             $dsp->AddDoubleRow($mapcycle, $func->text2html($map_str));
@@ -258,7 +258,7 @@ if (!$tournament["tournamentid"]) {
                     if ($team["seeding_mark"]) {
                         $team_out .= " ". t('Dieses Team wird beim Generieren gesetzt');
                     }
-                    if (($auth["type"] > 1) && ($tournament['status'] == "open")) {
+                    if (($auth['type'] > \LS_AUTH_TYPE_USER) && ($tournament['status'] == "open")) {
                         if ($team["seeding_mark"]) {
                             $team_out .= " <a href=\"index.php?mod=tournament2&action=details&step=11&tournamentid={$_GET['tournamentid']}&teamid={$team['teamid']}\">".t('demarkieren')."</a>";
                         } else {
@@ -296,21 +296,21 @@ if (!$tournament["tournamentid"]) {
             switch ($tournament["status"]) {
                 case "open":
                     $buttons .= $dsp->FetchSpanButton(t('Teilnehmen'), "index.php?mod=tournament2&action=join&tournamentid={$_GET['tournamentid']}&step=2"). " ";
-                    if ($auth["type"] > 1) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                         $buttons .= $dsp->FetchSpanButton(t('Generieren'), "index.php?mod=tournament2&action=generate_pairs&step=2&tournamentid={$_GET['tournamentid']}"). " ";
                     }
                     break;
                 case "process":
                     $buttons .= $dsp->FetchSpanButton(t('Paarungen'), "index.php?mod=tournament2&action=games&step=2&tournamentid={$_GET['tournamentid']}"). " ";
                     $buttons .= $dsp->FetchSpanButton(t('Spielbaum'), "index.php?mod=tournament2&action=tree&step=2&tournamentid={$_GET['tournamentid']}"). " ";
-                    if ($auth["type"] > 1) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                         $buttons .= $dsp->FetchSpanButton(t('Generieren rückgängig'), "index.php?mod=tournament2&action=undo_generate&tournamentid={$_GET['tournamentid']}"). " ";
                     }
                     break;
                 case "closed":
                     $buttons .= $dsp->FetchSpanButton(t('Paarungen'), "index.php?mod=tournament2&action=games&step=2&tournamentid={$_GET['tournamentid']}"). " ";
                     $buttons .= $dsp->FetchSpanButton(t('Spielbaum'), "index.php?mod=tournament2&action=tree&step=2&tournamentid={$_GET['tournamentid']}"). " ";
-                    if ($auth["type"] > 1) {
+                    if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                         $buttons .= $dsp->FetchSpanButton(t('Schließen rückgängig'), "index.php?mod=tournament2&action=undo_close&tournamentid={$_GET['tournamentid']}"). " ";
                     }
                     break;

--- a/modules/tournament2/plugins/home.php
+++ b/modules/tournament2/plugins/home.php
@@ -59,7 +59,7 @@ if (!$teams instanceof mysqli_result || $db->num_rows($teams) == 0) {
 }
 
 // Show dropdown to see all active games
-if ($auth['type'] > 1) {
+if ($auth['type'] > \LS_AUTH_TYPE_USER) {
     $teams = $db->qry("
       SELECT
         games1.gameid AS gid1,

--- a/modules/tournament2/submit_result.php
+++ b/modules/tournament2/submit_result.php
@@ -193,7 +193,7 @@ if ($tournament["name"] == "") {
         case 2:
             // Berechtigungsprüfung
             $berechtigt = 0;
-            if ($auth["type"] > 1) {
+            if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                 $berechtigt = 1;
             } // Admin always
             if ($cfg["t_only_loser_submit"]) {
@@ -244,7 +244,7 @@ if ($tournament["name"] == "") {
                 } else {
                     $func->information(t('Nur Teilnehmer des Aktuellen Spiels und Turnieradmins dürfen ein Ergebnis eintragen'), "index.php?mod=tournament2&action=submit_result&step=1&tournamentid=$tournamentid&gameid1=$gameid1&gameid2=$gameid2");
                 }
-            } elseif (($not_new) && ($auth["type"] <= 1)) {
+            } elseif (($not_new) && ($auth['type'] <= \LS_AUTH_TYPE_USER)) {
                 $func->information(t('Es wurde bereits ein Ergebnis für diese Partie eingetragen. Das Ergebnis kann nur noch von Turnieradmins editiert werden. Melden dich daher für Änderungen bei diesen.'), "index.php?mod=tournament2&action=submit_result&step=1&tournamentid=$tournamentid&gameid1=$gameid1&gameid2=$gameid2");
             } else {
                 // Upload Screenshot

--- a/modules/troubleticket/add.php
+++ b/modules/troubleticket/add.php
@@ -75,7 +75,7 @@ switch ($_GET["step"]) {
         }
         $dsp->AddDropDownFieldRow("tticket_priority", t('Priorität'), $t_array, $error["tticket_priority"], 1);
 
-        if ($auth["type"] > 1) {
+        if ($auth['type'] > \LS_AUTH_TYPE_USER) {
             $dsp->AddRadioRow("orgaonly", t('Sichtbar für Alle'), "0", $error["orgaonly"], 0, 1);
             $dsp->AddRadioRow("orgaonly", t('Sichtbar nur für Orgas'), "1", "", 0, 0);
         }
@@ -89,7 +89,7 @@ switch ($_GET["step"]) {
     case 2:
         $czeit = time();
 
-        if ($auth["type"] <= 1) {
+        if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
             $ticketstatus = '1';
             $vzeit = '';
         } else {

--- a/modules/troubleticket/show.php
+++ b/modules/troubleticket/show.php
@@ -93,7 +93,7 @@ switch ($_GET["step"]) {
                 $row["publiccomment"] = t(' Kein Hinweis eingetragen');
             }
             $dsp->AddDoubleRow(t('Kommentar'), $func->text2html($row["publiccomment"]));
-            if ($auth['type'] > 1) {
+            if ($auth['type'] > \LS_AUTH_TYPE_USER) {
                 if (!$row["orgacomment"]) {
                     $row["orgacomment"] = t(' Kein Hinweis eingetragen');
                 }

--- a/modules/usrmgr/Functions/ChangeAllowed.php
+++ b/modules/usrmgr/Functions/ChangeAllowed.php
@@ -23,7 +23,7 @@ function ChangeAllowed($id): bool|string
     }
 
     // Do not allow changes, if user has paid
-    if ($auth['type'] <= 1) {
+    if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
         $row2 = $db->qry_first("SELECT paid FROM %prefix%party_user WHERE party_id = %int% AND user_id = %int%", $_GET['party_id'], $id);
         if ($row2['paid']!= 0) {
             return t('Du bist für diese Party bereits auf bezahlt gesetzt. Bitte einen Admin dich auf "nicht bezahlt" zu setzen, bevor du dich abmeldest');

--- a/modules/usrmgr/Functions/CheckClanPWUsrMgr.php
+++ b/modules/usrmgr/Functions/CheckClanPWUsrMgr.php
@@ -7,7 +7,7 @@ function CheckClanPWUsrMgr($clanpw): bool|string
 {
     global $db, $auth;
 
-    if (!$_POST['new_clan_select'] and $auth['type'] <= 1 and $auth['clanid'] != $_POST['clan']) {
+    if (!$_POST['new_clan_select'] and $auth['type'] <= \LS_AUTH_TYPE_USER and $auth['clanid'] != $_POST['clan']) {
         $clan = $db->qry_first("SELECT password FROM %prefix%clan WHERE clanid = %int%", $_POST['clan']);
         if ($clan['password'] and $clan['password'] != md5($clanpw)) {
             return t('Passwort falsch!');

--- a/modules/usrmgr/add.php
+++ b/modules/usrmgr/add.php
@@ -237,7 +237,7 @@ if (!($_GET['mod'] == 'signon' && $auth['login'] && $_GET['party_id'])) {
             }
 
             // AGB and Vollmacht, if new user
-            if (!$_GET['userid'] && $auth['type'] <= 1) {
+            if (!$_GET['userid'] && $auth['type'] <= \LS_AUTH_TYPE_USER) {
                 if (ShowFieldUsrMgr('voll')) {
                     $mf->AddField(t('U18-Vollmacht') .'|'. t('Hiermit bestätige ich, die %1 der Veranstaltung <b>"%2"</b> gelesen zu haben und ggf. ausgefüllt zur Veranstaltung mitzubringen.', "<a href=\"". $cfg["signon_volllink"] ."\" target=\"new\">". t('U18 Vollmacht') .'</a>', $_SESSION['party_info']['name']), 'vollmacht', 'tinyint(1)');
                 }

--- a/modules/usrmgr/details.php
+++ b/modules/usrmgr/details.php
@@ -72,7 +72,7 @@ if (!$user_data['userid']) {
 
     // First name, last name, username, user ID
     $name = '<table width="100%" cellspacing="0" cellpadding="0"><tr><td>';
-    if (!$cfg['sys_internet'] or $auth['type'] > 1 or $auth['userid'] == $_GET['userid']) {
+    if (!$cfg['sys_internet'] or $auth['type'] > \LS_AUTH_TYPE_USER or $auth['userid'] == $_GET['userid']) {
         if ($user_data['firstname']) {
             $name .= $user_data['firstname'] .' ';
         }

--- a/modules/usrmgr/party.php
+++ b/modules/usrmgr/party.php
@@ -51,7 +51,7 @@ if ($party->count == 0) {
                 // Prices
                 $qrytmp = "SELECT * FROM %prefix%party_prices WHERE party_id = %int% AND requirement <= %string%";
                 // Show all prices for administrators and only the one not ended for normal users
-                if ($auth['type'] <= 1) {
+                if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
                     $qrytmp.=" AND enddate > now()";
                 }
                 $res2 = $db->qry($qrytmp, $row['party_id'], $auth['type']);


### PR DESCRIPTION
### What is this PR doing?

We use the magic number "1" everywhere to indicate permissions.
Using the constant `\LS_AUTH_TYPE_USER` creates more context for the reader and is also easier to search for.

### Attention

This PR depends on https://github.com/lansuite/lansuite/pull/790.
Please merge https://github.com/lansuite/lansuite/pull/790 before this one.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed