### PR TITLE
[Authentication] Replace magic number comparision of $auth['type'] >= 1 with the usage of constants like \LS_AUTH_TYPE_USER (leftovers)

### DIFF
--- a/modules/bugtracker/plugins/home.php
+++ b/modules/bugtracker/plugins/home.php
@@ -17,7 +17,7 @@ $query = $db->qry("
     b.state <= 3
     AND (
       !private
-      OR ". (int)$auth['type'] ." >= 2
+      OR " . (int) $auth['type'] . " >= " . \LS_AUTH_TYPE_ADMIN . "
     )
   GROUP BY b.bugid
   ORDER BY changedate DESC

--- a/modules/bugtracker/show.php
+++ b/modules/bugtracker/show.php
@@ -73,7 +73,7 @@ if (!$bugidParameter || $actionParameter == 'delete') {
     LEFT JOIN %prefix%user AS a ON b.agent = a.userid
     LEFT JOIN %prefix%comments AS c ON (c.relatedto_id = b.bugid AND c.relatedto_item = 'BugEintrag')
     ";
-    $ms2->query['where'] = '(!private OR '. (int)$auth['type'] .' >= 2)';
+    $ms2->query['where'] = '(!private OR '. (int) $auth['type'] .' >= ' . \LS_AUTH_TYPE_ADMIN . ')';
     $ms2->query['default_order_by'] = 'changedate DESC, FIND_IN_SET(state, \'0,7,1,2,3,4,5,6\'), date DESC';
     $ms2->config['EntriesPerPage'] = 50;
     $ms2->AddBGColor('state', $colors);
@@ -178,7 +178,7 @@ if (!$bugidParameter || $actionParameter == 'delete') {
         bugid = %int%
         AND (
           !private
-          OR ". (int)$auth['type'] ." >= 2
+          OR " . (int) $auth['type'] . " >= " . \LS_AUTH_TYPE_ADMIN . "
         )", $_GET['bugid']);
 
     $dsp->NewContent($row['caption'], $types[$row['type']] .', '. t('Priorität') .': '. $row['priority']);

--- a/modules/guestlist/onlineuser.php
+++ b/modules/guestlist/onlineuser.php
@@ -11,12 +11,12 @@ $ms2->query['order_by'] = "s.lasthit";
 
 $ms2->AddResultField(t('Name'), 'u.username', 'UserNameAndIcon');
 $ms2->AddResultField(t('Modul'), 's.lasthiturl', 'getModul');
-if ($auth['type']>2) {
+if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddResultField(t('URL'), 's.lasthiturl', 'getLastHitUrl');
 }
 $ms2->AddResultField(t('Status'), 's.lasthit', 'getTimeDiffAsName');
 $ms2->AddResultField(t('Letzter Aufruf'), 's.lasthit', 'getTimeDiff');
-if ($auth['type']>2) {
+if ($auth['type'] > \LS_AUTH_TYPE_ADMIN) {
     $ms2->AddResultField(t('Letzter Heartbeat'), 's.lastajaxhit', 'getTimeDiff');
 }
 

--- a/modules/poll/search.inc.php
+++ b/modules/poll/search.inc.php
@@ -6,7 +6,7 @@ $ms2->query['from'] = "%prefix%polls AS p
   LEFT JOIN %prefix%polloptions AS o ON p.pollid = o.pollid
   LEFT JOIN %prefix%pollvotes AS v ON o.polloptionid = v.polloptionid";
 $ms2->query['default_order_by'] = 'p.changedate ASC';
-$ms2->query['where'] = (int)$auth['type'] .' >= 2 OR !p.group_id OR p.group_id = '. (int)$auth['group_id'];
+$ms2->query['where'] = (int) $auth['type'] . ' >= ' . \LS_AUTH_TYPE_ADMIN . ' OR !p.group_id OR p.group_id = '. (int)$auth['group_id'];
 
 $ms2->AddTextSearchField(t('Titel'), array('p.caption' => 'like'));
 

--- a/modules/tournament2/search.inc.php
+++ b/modules/tournament2/search.inc.php
@@ -4,7 +4,7 @@ $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
 $dsp->NewContent(t('Turnierübersicht'), t('Hier findest du eine Übersicht aller angebotenen Turniere.'));
 
 $ms2->query['from'] = "%prefix%tournament_tournaments AS t LEFT JOIN %prefix%t2_teams AS teams ON t.tournamentid = teams.tournamentid";
-$ms2->query['where'] = "(t.status != 'invisible' OR ". (int)$auth['type'] ." > 1) AND t.party_id = ". (int)$party->party_id;
+$ms2->query['where'] = "(t.status != 'invisible' OR " . (int) $auth['type'] . " > " . \LS_AUTH_TYPE_USER . ") AND t.party_id = ". (int)$party->party_id;
 $ms2->query['default_order_by'] = 't.name';
 
 $ms2->config['EntriesPerPage'] = 50;


### PR DESCRIPTION
### What is this PR doing?

This is fixing the last leftovers from https://github.com/lansuite/lansuite/pull/791, https://github.com/lansuite/lansuite/pull/790 and https://github.com/lansuite/lansuite/pull/789

### Attention

This PR depends on https://github.com/lansuite/lansuite/pull/791.
Please merge https://github.com/lansuite/lansuite/pull/791 before this one.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed