### PR TITLE
Fix condition bug by using | vs. ||

### DIFF
--- a/modules/clanmgr/Functions/CheckExistingClan.php
+++ b/modules/clanmgr/Functions/CheckExistingClan.php
@@ -7,7 +7,7 @@ function CheckExistingClan()
 {
     global $auth, $db, $func;
     $clanuser = $db->qry_first("SELECT clanid FROM %prefix%user WHERE userid=%int%", $auth['userid']);
-    if ($clanuser["clanid"] == null | $clanuser["clanid"] == 0) {
+    if ($clanuser["clanid"] == null || $clanuser["clanid"] == 0) {
         return true;
     } else {
         $func->error(t('Bevor du einen neuen Clan anlegen kannst, musst du aus deinem aktuellen Clan austreten.'), "index.php?mod=clanmgr");

--- a/modules/foodcenter/statchange.php
+++ b/modules/foodcenter/statchange.php
@@ -176,7 +176,7 @@ switch ($stepParameter) {
             $time = time();
             $totprice = 0;
             foreach ($_POST["action"] as $item => $val) {
-                if ($_GET["status"] == 6 | $_GET["status"] == 7) {
+                if ($_GET["status"] == 6 || $_GET["status"] == 7) {
                     $db->qry("UPDATE %prefix%food_ordering SET status = %string%, lastchange = %string%, supplytime = %string%  WHERE id = %string%", $_GET["status"], $time, $time, $item);
 
                     $abfrage = $db->qry_first("


### PR DESCRIPTION
### What is this PR doing?

Sometimes, in the codebase `|` is used where `||` should be used in if conditions.
This can be intentional if we aim to run a bit operation.
However, in an if condition, most of the time, this is not the case.

This PR is fixing those bugs.

### Attention

This PR depends on https://github.com/lansuite/lansuite/pull/792.
Please merge https://github.com/lansuite/lansuite/pull/792 before this one.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry -> Not needed
- [X] Documentation update -> Not needed