### PR TITLE
Define minimum PHP and MySQL Versions as PHP Constants

### DIFF
--- a/inc/base/define.php
+++ b/inc/base/define.php
@@ -5,6 +5,9 @@
  */
 define('LANSUITE_VERSION', '5.0-dev');
 
+define('LANSUITE_MINIMUM_PHP_VERSION', '8.1.0');
+define('LANSUITE_MINIMUM_MYSQL_VERSION', '5.7.0');
+
 define('VALID_LS', true);
 
 define('HTML_NEWLINE', '<br/>');

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -631,12 +631,10 @@ class Install
         $dsp->AddFieldSetStart("Kritisch - Diese Test müssen alle erfolgreich sein, damit Lansuite funktioniert");
 
         // PHP version
-        $minPHPVersion = '8.1.0';
-        $currentPHPVersion = PHP_VERSION;
-        if (version_compare($currentPHPVersion, $minPHPVersion) >= 0) {
-            $phpv_check = $ok . $currentPHPVersion;
+        if (version_compare(PHP_VERSION, \LANSUITE_MINIMUM_PHP_VERSION) >= 0) {
+            $phpv_check = $ok . PHP_VERSION;
         } else {
-            $phpv_check = $failed . t('Auf deinem System wurde die PHP-Version %1 gefunden. Lansuite benötigt mindestens PHP Version %2. Lade und installiere dir eine aktuellere Version von <a href=\'https://www.php.net\' target=\'_blank\'>PHP.net</a>.', $currentPHPVersion, $minPHPVersion);
+            $phpv_check = $failed . t('Auf deinem System wurde die PHP-Version %1 gefunden. Lansuite benötigt mindestens PHP Version %2. Lade und installiere dir eine aktuellere Version von <a href=\'https://www.php.net\' target=\'_blank\'>PHP.net</a>.', PHP_VERSION, \LANSUITE_MINIMUM_PHP_VERSION);
         }
         $dsp->AddDoubleRow("PHP Version", $phpv_check);
 
@@ -654,11 +652,10 @@ class Install
         $dsp->AddDoubleRow("MySQLi-Extension", $mysql_check);
 
         // MySQL Server version
-        $minMysqlVersion = '5.7.0';
         $minMariaDBVersion = '10.0';
         $currentMysqlVersion = $db->getServerInfo();
         if (!$currentMysqlVersion) {
-            $mysqlVersionCheck = $not_possible . t('Konnte MySQL-Version nicht überprüfen, da keine Verbindung mit den Standarddaten (%1@%2) möglich war. <br/>Dies ist kein direkter Fehler, bedeutetet aber, dass einige Setup-Schritte per Hand durchgeführt werden müssen. <br/>Bitte Stelle sicher, dass du MySQL mindestens in Version %3 benutzt.', $configuration['database']['user'], $configuration['database']['server'], $minMysqlVersion);
+            $mysqlVersionCheck = $not_possible . t('Konnte MySQL-Version nicht überprüfen, da keine Verbindung mit den Standarddaten (%1@%2) möglich war. <br/>Dies ist kein direkter Fehler, bedeutetet aber, dass einige Setup-Schritte per Hand durchgeführt werden müssen. <br/>Bitte Stelle sicher, dass du MySQL mindestens in Version %3 benutzt.', $configuration['database']['user'], $configuration['database']['server'], \LANSUITE_MINIMUM_MYSQL_VERSION);
         } elseif (str_contains($currentMysqlVersion, 'MariaDB')) {
             $currentMariaDBVersion = substr($currentMysqlVersion, strpos($currentMysqlVersion, '-')+1);
             if (version_compare($currentMariaDBVersion, $minMariaDBVersion) >= 0) {
@@ -666,10 +663,10 @@ class Install
             } else {
                 $mysqlVersionCheck = $failed . t('Die verwendete MariaDB-Version %1 ist leider zu alt. Vorrausgesetzt ist mindestens MariaDB version %2! <br/> Bitte beachte, das LanSuite primär für MySQL entwickelt wurde und es daher zu unerwarteten Problemen mit MariaDB kommen kann!', $currentMariaDBVersion, $minMariaDBVersion);
             }
-        } elseif (version_compare($currentMysqlVersion, $minMysqlVersion) >= 0) {
+        } elseif (version_compare($currentMysqlVersion, \LANSUITE_MINIMUM_MYSQL_VERSION) >= 0) {
             $mysqlVersionCheck = $ok . $currentMysqlVersion;
         } else {
-            $mysqlVersionCheck = $failed . t('LanSuite ist zu einer Datenbank mit der Version %1 verbunden. LanSuite benötigt mindestens eine MySQL Datenbank mit der Version %2. Lade und installiere dir eine aktuellere Version von <a href=\'https://www.mysql.com\' target=\'_blank\'>MySQL.com</a>.', $currentMysqlVersion, $minMysqlVersion);
+            $mysqlVersionCheck = $failed . t('LanSuite ist zu einer Datenbank mit der Version %1 verbunden. LanSuite benötigt mindestens eine MySQL Datenbank mit der Version %2. Lade und installiere dir eine aktuellere Version von <a href=\'https://www.mysql.com\' target=\'_blank\'>MySQL.com</a>.', $currentMysqlVersion, \LANSUITE_MINIMUM_MYSQL_VERSION);
         }
         $dsp->AddDoubleRow("MySQL Server Version", $mysqlVersionCheck);
 


### PR DESCRIPTION
### What is this PR doing?

This PR moves the minimum PHP and MySQL versions into PHP constants.

Side note: I think we should remove official MariaDB support. Mainly because it is not a drop in replacement for MySQL, but rather have some in-place capability to run like MySQL. Maria DB moves away from the drop-in more and more. This comment should not block this PR.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed