### PR TITLE
Fix PHP Warning when login remember is active via Cookie

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -235,7 +235,7 @@ class Auth
             $cookierow = $db->qry_first('SELECT userid from %prefix%cookie WHERE cookieid = %int% AND password = %string%', $tmp_login_email, $tmp_login_pass);
             if ($cookierow) {
                 $user = $db->qry_first(
-                    'SELECT *, 1 AS found FROM %prefix%user WHERE (userid = %int%)',
+                    'SELECT *, 1 AS found, 1 AS user_login FROM %prefix%user WHERE (userid = %int%)',
                     $cookierow['userid']
                 );
 


### PR DESCRIPTION
### What is this PR doing?

When you have been logged in and come back later, LanSuite checks if it remembers your cookie. For this a SQL query is executed, see https://github.com/lansuite/lansuite/blob/7178fc5937c74006f50e09bb26089efa5084f766/inc/Classes/Auth.php#L238

In similar queries, the key `user_login` is required (and accessed in PHP code later on), see https://github.com/lansuite/lansuite/blob/7178fc5937c74006f50e09bb26089efa5084f766/inc/Classes/Auth.php#L245 and https://github.com/lansuite/lansuite/blob/7178fc5937c74006f50e09bb26089efa5084f766/inc/Classes/Auth.php#L301

This throws a warning, due to non existing array key.

This PR is fixing this warning by ensuring that the key is always there.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed