### PR TITLE
Fix SQL error in Cashmgr and Mastersearch2 when two dropdown search fields are involved

### DIFF
--- a/modules/cashmgr/myaccounting.php
+++ b/modules/cashmgr/myaccounting.php
@@ -1,8 +1,9 @@
 <?php
 
-if ($_GET['act'] == "him" && $auth['type'] < \LS_AUTH_TYPE_SUPERADMIN) {
+$actParameter = $_GET['act'] ?? '';
+if ($actParameter == "him" && $auth['type'] < \LS_AUTH_TYPE_SUPERADMIN) {
     $func->information("ACCESS_DENIED");
-} elseif ($_GET['act'] == "him" && $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
+} elseif ($actParameter == "him" && $auth['type'] == \LS_AUTH_TYPE_SUPERADMIN) {
     $stepParameter = $_GET['step'] ?? 0;
     switch ($stepParameter) {
         case 2:
@@ -17,7 +18,7 @@ if ($_GET['act'] == "him" && $auth['type'] < \LS_AUTH_TYPE_SUPERADMIN) {
     }
 }
 
-if (!$_GET['act'] || ($_GET['act'] && $stepParameter == 2)) {
+if (!$actParameter || ($actParameter && $stepParameter == 2)) {
     if ($userid == null) {
         $userid = $auth['userid'];
     }


### PR DESCRIPTION
### What is this PR doing?

In the CashManager module, two dropdowns are used for searching.
The MasterSearch class generates a SQL `HAVING` statement based on this.
The field that appears in the `HAVING` statement is not appearing in the `SELECT` statement of this query.

This throws an SQL error, because the documentation at https://dev.mysql.com/doc/refman/8.0/en/select.html says:

> The SQL standard requires that HAVING must reference only columns in the GROUP BY clause or columns used in aggregate functions. However, MySQL supports an extension to this behavior, and permits HAVING to refer to columns in the [SELECT](https://dev.mysql.com/doc/refman/8.0/en/select.html) list and columns in outer subqueries as well.

### PR Dependency

https://github.com/lansuite/lansuite/pull/797 needs to be merged before.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed