### PR TITLE
[Masterform] Fix PHP Warning in longtext fields

### DIFF
--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -760,7 +760,8 @@ class MasterForm
                                                     ob_end_clean();
                                                     $dsp->AddSingleRow($fcke_content);
 
-                                                    if ($this->error[$field['name']]) {
+                                                    $errorMessage = $this->error[$field['name']] ?? '';
+                                                    if ($errorMessage) {
                                                         $dsp->AddDoubleRow($field['caption'], $dsp->errortext_prefix . $this->error[$field['name']] . $dsp->errortext_suffix);
                                                     }
                                                 } else {


### PR DESCRIPTION
### What is this PR doing?

[[Masterform] Fix PHP Warning in longtext fields](https://github.com/lansuite/lansuite/commit/0cf5cc013646c7caae6830d9c9c778332d1207d3)

Please merge https://github.com/lansuite/lansuite/pull/802 before.
This PR contains the commits from https://github.com/lansuite/lansuite/pull/802.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - None
- [X] Documentation update - None