### PR TITLE
Documentation: Make version constraint a bit more flexible to allow updates

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.0.0",
-    "@docusaurus/preset-classic": "3.0.0",
+    "@docusaurus/core": "^3.0.0",
+    "@docusaurus/preset-classic": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^1.3.5",
@@ -23,7 +23,7 @@
     "react-dom": "^18.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1"
+    "@docusaurus/module-type-aliases": "^3.0.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
### What is this PR doing?

This will allow us updating the package with a raised minor version, without changing the package.json

This is needed for PRs like:
- https://github.com/lansuite/lansuite/pull/816
- https://github.com/lansuite/lansuite/pull/818

They are failing due to

> [cause]: Error: Invalid name=docusaurus-plugin-content-docs version number=3.0.1.
  All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.0.0).
  Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed