### PR TITLE
Auth: Fix "wrong credentials" warning, if cookie login is tried

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -243,7 +243,7 @@ class Auth
             $cookierow = $db->qry_first('SELECT userid from %prefix%cookie WHERE cookieid = %int% AND password = %string%', $tmp_login_email, $tmp_login_pass);
             if ($cookierow) {
                 $user = $db->qry_first(
-                    'SELECT *, 1 AS found, 1 AS user_login FROM %prefix%user WHERE (userid = %int%)',
+                    'SELECT *, 1 AS found, 0 AS user_login FROM %prefix%user WHERE (userid = %int%)',
                     $cookierow['userid']
                 );
 


### PR DESCRIPTION
### What is this PR doing?

In https://github.com/lansuite/lansuite/commit/0843ff7ca886ba39c710019a8b04fe791d18a90c I added the field `1 AS user_login` in the execution path of the cookie login.
Mainly, because PHP was throwing a warning of accessing the `user_login` field.

This introduced a bug, that shows the following warning all the time:

![23a661c7-6f48-4a43-b73a-191ff6800405](https://github.com/lansuite/lansuite/assets/320064/7d4889d1-de75-4ef7-8b51-b18e05e66ba7)

The value 1 of the field `user_login` is used to determine, if a user is logging in actively. For the cookie login, this value should not be valid.

To avoid throwing a PHP Warning, we added the value of this field to 0 in case of a cookie login.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed