### PR TITLE
[Auth] Fix warnings if cookie id is not set

### DIFF
--- a/inc/Classes/Auth.php
+++ b/inc/Classes/Auth.php
@@ -431,7 +431,8 @@ class Auth
 
         // Reset Cookiedata
         $this->cookie_read();
-        $db->qry('DELETE FROM %prefix%cookie WHERE userid = %int% AND cookieid = %int%', $this->auth['userid'], $this->cookie_data['userid']);
+        $cookieUserId = $this->cookie_data['userid'] ?? 0;
+        $db->qry('DELETE FROM %prefix%cookie WHERE userid = %int% AND cookieid = %int%', $this->auth['userid'], $cookieUserId);
         $this->cookie_unset();
 
         // Reset Sessiondata


### PR DESCRIPTION
### What is this PR doing?

[Auth] Fix warnings if cookie id is not set

![3cb9ed5f-96e1-4255-9f09-838324aaf47b](https://github.com/lansuite/lansuite/assets/320064/55aed693-7592-4781-8349-7b68aa281d59)


### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed