### PR TITLE
[Display] Fix "Deprecated: Optional parameter $id declared before required parameter $ext_txt is implicitly treated as a required parameter in ..."

### DIFF
--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -1337,7 +1337,7 @@ class Display
         return '<div class="infolink" style="display:inline">'. t($text) .'<span class="infobox">'. t($help) .'</span></div>';
     }
 
-    public function AddTripleRow($key, $value, $id = null, $ext_txt) {
+    public function AddTripleRow($key, $value, $id = null, $ext_txt = '') {
         global $smarty;
 
         if ($key == '') {


### PR DESCRIPTION
### What is this PR doing?

Fixing

```
Deprecated: Optional parameter $id declared before required parameter $ext_txt is implicitly treated as a required parameter in /inc/Classes/Display.php on line 1340
```
### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed