### PR TITLE
Fix not working board delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Tournament] Tournament overview is not displayed if played as a league (#142)
 - [Tournament] MySQL Warning in module tournament2 if the user is not logged in (#97)
 - [Guestlist] Restrict user information shown on Google Maps according to their settings and never show the street details ... unless you are an administrator
+- [Board] Deletion of board failed without error (#861)
 
 ### Security
 

--- a/modules/board/delete.php
+++ b/modules/board/delete.php
@@ -20,7 +20,7 @@ if ($pidParameter) {
 
 // Delete board
 } else {
-    match ($request->query->getInt('step',0)) {
+    match ($stepParameter) {
         2 => $md->Delete('board_forums', 'fid', $fidParameter),
         10 => $md->MultiDelete('board_forums', 'fid'),
         default => include_once 'modules/board/show.php'

--- a/modules/board/delete.php
+++ b/modules/board/delete.php
@@ -2,23 +2,27 @@
 
 $md = new \LanSuite\MasterDelete();
 
+$pidParameter = $request->query->getInt('pid', 0);
+$tidParameter = $request->query->getInt('tid', 0);
+$fidParameter = $request->query->getInt('fid', 0);
+$stepParameter = $request->query->getInt('step', 0);
+
+
 // Delete post
-$pidParameter = $_GET['pid'] ?? 0;
-$tidParameter = $_GET['tid'] ?? 0;
-$stepParameter = $_GET['step'] ?? 0;
+
 if ($pidParameter) {
     $md->DeleteIfEmpty['board_threads'] = 'tid';
-    $md->Delete('board_posts', 'pid', $_GET['pid']);
+    $md->Delete('board_posts', 'pid', $pidParameter);
 
 // Delete thread
 } elseif ($tidParameter) {
-    $md->Delete('board_threads', 'tid', $_GET['tid']);
+    $md->Delete('board_threads', 'tid', $tidParameter);
 
 // Delete board
 } else {
-    match ((int)$stepParameter) {
-        2 => $md->Delete('board_forums', 'fid', $_GET['fid']),
+    match ($request->query->getInt('step',0)) {
+        2 => $md->Delete('board_forums', 'fid', $fidParameter),
         10 => $md->MultiDelete('board_forums', 'fid'),
-        default => include_once('modules/board/show.php'),
+        default => include_once 'modules/board/show.php'
     };
 }

--- a/modules/board/delete.php
+++ b/modules/board/delete.php
@@ -16,7 +16,7 @@ if ($pidParameter) {
 
 // Delete board
 } else {
-    match ($stepParameter) {
+    match ((int)$stepParameter) {
         2 => $md->Delete('board_forums', 'fid', $_GET['fid']),
         10 => $md->MultiDelete('board_forums', 'fid'),
         default => include_once('modules/board/show.php'),


### PR DESCRIPTION
### What is this PR doing?

adds implit typecasting to int for match statement to hit cases `2` and `10`
This failed previously due to `$stepParameter` being a string and thus always the default case to display the board was exected

### Which issue(s) this PR fixes:

Fixes #861 

### Checklist

- [x] `CHANGELOG.md` entry
- [x] ~Documentation update~ (bugfix only)