### PR TITLE
index.php add block to catch DB error on first install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Installation] Skip cache for installation module
 - [Installation] Fixed #344: Switching to English during Installation breaks the Installation page (#650)
 - [Installation] Fixed dropdown to select the design
+- [Installation] Fixed Database error when going from step 2 to 1 in install wizzard (#871)
 - [Home] Set module `home` as default if we don't have a module parameter
 - [Clanmgr] Only prefix clan URL with http:// if an URL was entered
 - [Clanmgr] Only prefix URL field with http:// for display when an URL exists

--- a/index.php
+++ b/index.php
@@ -249,7 +249,12 @@ if ($config['environment']['configured'] == 0) {
     $_GET['action'] = 'wizard';
 
     // Silent connect
-    $db->connect(1);
+    try {
+        $db->connect(1);
+    } catch (\mysqli_sql_exception $e) {
+        //ignore connection error, this wil be dealt with later in the installation
+    }
+
     $IsAboutToInstall = 1;
 
     // Force Admin rights for installing User


### PR DESCRIPTION
### What is this PR doing?

This adds a try-catch block in the branch run for systems not considered configured.
This catches an error, when a semi-OK config.php existis.

### Which issue(s) this PR fixes:

Fixes #871

### Checklist

- [x] `CHANGELOG.md` entry
- [x] ~Documentation update~ (bugfix only)