### PR TITLE
introduce separate API keys for maps, translate and analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [System] Use utf8 by default
 - [System] Update Google Analytics Integration
 - [System] Enabled Google Analytics Integration anonymizeIp feature
+- [System] Separated Google API-Keys for Analytics, Maps and Translate into dedicated settings (#887)
 - [System] Don't enforce php-snmp; only suggest it (#148)
 - [Database] Set utf8mb4 as the default charset
 - [Database] Add default database port to connection string if not configured

--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -884,7 +884,7 @@ class MasterForm
                                                 $start = $area[0];
                                                 $end = $area[1];
                                                 $fieldErrorText = $this->error[$field['name']] ?? '';
-                                                $dsp->AddDateTimeRow($field['name'], $field['caption'], 0,  $fieldErrorText, $values, '', $start, $end, 1, $field['optional']);
+                                                $dsp->AddDateTimeRow($field['name'], $field['caption'], 0, $fieldErrorText, $values, '', $start, $end, 1, $field['optional']);
                                                 break;
 
                                             // Password-Row

--- a/modules/guestlist/usermap.php
+++ b/modules/guestlist/usermap.php
@@ -67,7 +67,7 @@ if ($cfg['guestlist_guestmap'] == 2) {
             $smarty->assign('adresses', $adresses);
             $dsp->AddSingleRow($smarty->fetch('modules/guestlist/templates/googlemaps.htm'));
         } else {
-            $func->error(t('Ein Google Mamps API key wurde nicht konfiguriert, ist aber notwendig zur Benutzung von Google Maps-Diensten.'));
+            $func->error(t('Ein Google Maps API key wurde nicht konfiguriert, ist aber notwendig zur Benutzung von Google Maps-Diensten.'));
         }
     } else {
         $get_cur = $db->qry_first('SELECT COUNT(userid) as n FROM %prefix%user AS user LEFT JOIN %prefix%party_user AS party ON user.userid = party.user_id WHERE party_id=%int% AND (%plain%)', $party->party_id, ($cfg["guestlist_showorga"] == 0 ? "type = 1" : "type >= 1"));

--- a/modules/guestlist/usermap.php
+++ b/modules/guestlist/usermap.php
@@ -62,12 +62,12 @@ if ($cfg['guestlist_guestmap'] == 2) {
         }
         $adresses .= '];';
         $db->free_result($res);
-        if (!empty($cfg['google_analytics_id'])) {
-            $smarty->assign('apikey', 'key='. $cfg['google_analytics_id']);
+        if (!empty($cfg['google_maps_key'])) {
+            $smarty->assign('apikey', 'key='. $cfg['google_maps_key']);
             $smarty->assign('adresses', $adresses);
             $dsp->AddSingleRow($smarty->fetch('modules/guestlist/templates/googlemaps.htm'));
         } else {
-            $func->error(t('Die Google Analytics ID wurde nicht konfiguriert, ist aber notwendig zur Benutzung von Google Maps-Diensten.'));
+            $func->error(t('Ein Google Mamps API key wurde nicht konfiguriert, ist aber notwendig zur Benutzung von Google Maps-Diensten.'));
         }
     } else {
         $get_cur = $db->qry_first('SELECT COUNT(userid) as n FROM %prefix%user AS user LEFT JOIN %prefix%party_user AS party ON user.userid = party.user_id WHERE party_id=%int% AND (%plain%)', $party->party_id, ($cfg["guestlist_showorga"] == 0 ? "type = 1" : "type >= 1"));

--- a/modules/install/mod_settings/config.xml
+++ b/modules/install/mod_settings/config.xml
@@ -421,13 +421,6 @@ nospamfor.us</default>
         <default></default>
         <description>Google API-Key um Google-Maps Code zu aktivieren</description>
       </item>
-        </item>
-        <item>
-        <name>google_translate_key</name>
-        <type>string</type>
-        <default></default>
-        <description>Google API-Key um Google-Translate Code zu aktivieren</description>
-      </item>
     </items>
   </group>
   <group>

--- a/modules/install/mod_settings/config.xml
+++ b/modules/install/mod_settings/config.xml
@@ -413,7 +413,20 @@ nospamfor.us</default>
         <name>google_analytics_id</name>
         <type>string</type>
         <default></default>
-        <description>Google-Analytics-ID. ID um Google-Analytics Code zu aktivieren</description>
+        <description>Google API-Key um Google-Analytics Code zu aktivieren</description>
+      </item>
+        <item>
+        <name>google_maps_key</name>
+        <type>string</type>
+        <default></default>
+        <description>Google API-Key um Google-Maps Code zu aktivieren</description>
+      </item>
+        </item>
+        <item>
+        <name>google_translate_key</name>
+        <type>string</type>
+        <default></default>
+        <description>Google API-Key um Google-Translate Code zu aktivieren</description>
       </item>
     </items>
   </group>

--- a/modules/partylist/map.php
+++ b/modules/partylist/map.php
@@ -16,8 +16,8 @@ if ($res->num_rows > 0) {
         $addresses .= "showAddress('Germany', '". addslashes($row['city']) ."', '". addslashes($row['plz']) ."', '". addslashes($row['street']) ."', '". addslashes($row['hnr']) ."', '". addslashes($text) ."');\r\n";
     }
     $smarty->assign('addresses', $addresses);
-    if (!empty($cfg['google_analytics_id'])) {
-        $smarty->assign('apikey', $cfg['google_analytics_id']);
+    if (!empty($cfg['google_maps_key'])) {
+        $smarty->assign('apikey', $cfg['google_maps_key']);
         $dsp->AddSingleRow($smarty->fetch('modules/guestlist/templates/googlemaps.htm'));
     } else {
         $func->error(t('Die Google Analytics ID wurde nicht konfiguriert, ist aber notwendig zur Benutzung von Google Maps-Diensten.'));

--- a/website/docs/getting-started/settings.md
+++ b/website/docs/getting-started/settings.md
@@ -10,7 +10,7 @@ Below you find an explanation of the various config settings you find in the Lan
 
 ## Common settings
 
-To be added
+To be added (TODO)
 
 ### Website-specific
 

--- a/website/docs/getting-started/settings.md
+++ b/website/docs/getting-started/settings.md
@@ -1,0 +1,25 @@
+---
+id: settings
+title: Settings
+sidebar_position: 4
+---
+
+# LanSuite generic config settings
+
+Below you find an explanation of the various config settings you find in the LanSuite Admin Area
+
+## Common settings
+
+To be added
+
+### Website-specific
+
+| *Name* | *Description* |
+| --- | --- | 
+| Party-Link  | URL (including protocol)  to the page, e.g. https://lansuite.de/lansuite     |
+| Page title | The page title set for the Browser window and RSS feed |
+| SSL-Party-Link | (Currently) optional dedicated URL for HTTPS page access |
+| Google Maps API Key | A Google API key that has the privileges to execute API calls for the Google Maps geolocation / geocoding API. Display of Maps is not functional unless provided |
+| Google Translate API Key | A Google API key that has the privileges to execute API calls for the Google translation API. Translation functionality in the related module is nonfunction if not provided |
+| Google Analytics ID | An ID used for google Analytics. Causes the related JS file to be included if defined|
+| Contact Mail | A mail address to be used to contact the person (/Org) acting as webmaster (Responsible for the web content) 

--- a/website/docs/getting-started/settings.md
+++ b/website/docs/getting-started/settings.md
@@ -6,7 +6,8 @@ sidebar_position: 4
 
 # LanSuite generic config settings
 
-Below you find an explanation of the various config settings you find in the LanSuite Admin Area
+Below you find an explanation of the various config settings in the LanSuite Admin Area.
+
 
 ## Common settings
 
@@ -20,6 +21,5 @@ To be added (TODO)
 | Page title | The page title set for the Browser window and RSS feed |
 | SSL-Party-Link | (Currently) optional dedicated URL for HTTPS page access |
 | Google Maps API Key | A Google API key that has the privileges to execute API calls for the Google Maps geolocation / geocoding API. Display of Maps is not functional unless provided |
-| Google Translate API Key | A Google API key that has the privileges to execute API calls for the Google translation API. Translation functionality in the related module is nonfunction if not provided |
 | Google Analytics ID | An ID used for google Analytics. Causes the related JS file to be included if defined|
 | Contact Mail | A mail address to be used to contact the person (/Org) acting as webmaster (Responsible for the web content) 


### PR DESCRIPTION
### What is this PR doing?

This splits off the currently single API key definition into three dedicated values for translation, maps and analytics API
This prevents the permanent (and propably non-GDRP-compliant) inclusion of google analytics if an API key is defined for use in gmaps

### Checklist

- [x] `CHANGELOG.md` entry
- [x] Documentation update