### PR TITLE
Fix timestamp conversion in `MS2GetDate`

### DIFF
--- a/modules/mastersearch2/Functions/MS2GetDate.php
+++ b/modules/mastersearch2/Functions/MS2GetDate.php
@@ -11,11 +11,9 @@ function MS2GetDate($time)
     global $dsp;
 
     // If it is a string, a date field in the format of "2005-03-15 11:12:31" comes in
-    if (is_string($time)) {
+    if (!is_numeric($time)) {
         return '<span class="small">' . $time  .'</span>';
-    }
-
-    if ($time > 0) {
+    } elseif ($time > 0) {
         return '<span class="small">'. date('d.m.y', $time) . ' ' . date('H:i', $time) .'</span>';
     }
 


### PR DESCRIPTION
### What is this PR doing?

I noticed that for reasons `UNIX_TIMESTAMP` db fields were not converted to datetime value in mastersearch when running on PHP 8.1 / MySQL 8.0.
Apparently these are returned as string (now), causing the related check in `MS2GetDate` to treat them not as timestamp.
This has been replaced with a check for a numeric string / value.
This is either a regression or incompatibility.
(there also was a theoretical chance that output is duplicated due to both cases being true, but not mutual exclusive, which has also been fixed)

It may be thought about if this conversion is replaced alltogether and we always directly convert from mysql `datetime` to (localized) datetime string

### Checklist

- [x] ~`CHANGELOG.md` entry~ (bugfix or regression)
- [x] ~Documentation update~ (nothing new)