### PR TITLE
GitHub Actions: Improve when quality checks will run (on push to master, nightly and during a pull request)

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,6 +2,10 @@ name: Continuous Integration
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "5 1 * * *"
 

--- a/.github/workflows/documentation-test-deploy.yml
+++ b/.github/workflows/documentation-test-deploy.yml
@@ -2,6 +2,9 @@ name: "Documentation: Test deployment"
 
 on:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 1 * * *"
 
 jobs:
   test-deploy:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,13 @@
 name: "ShellCheck"
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 1 * * *"
 
 jobs:
   shellcheck:


### PR DESCRIPTION
### What is this PR doing?

This Pull Request adds a few more instructions on when our quality checks will run:

- On each pull request
- On each merge to master
- Nightly
- If you trigger them manually

This ensures the system stays buildable.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed