### PR TITLE
[JavaScript] Remove deprecated attribute "language" from <script> tag

### DIFF
--- a/modules/foodcenter/templates/coincounter.htm
+++ b/modules/foodcenter/templates/coincounter.htm
@@ -1,6 +1,6 @@
 <!-- TEMPLATE - STANDARD - FOOD COINCOUNTER -->
 {literal}
-<script language="JavaScript">
+<script>
 
 function doOnchange() {
 	

--- a/modules/foodcenter/templates/javascript.htm
+++ b/modules/foodcenter/templates/javascript.htm
@@ -1,5 +1,5 @@
 {literal}
-<script type="text/javascript" language="Javascript">
+<script>
 
 function change_option(id){
 	switch(id){

--- a/modules/games/templates/minesweeper.htm
+++ b/modules/games/templates/minesweeper.htm
@@ -32,7 +32,7 @@
 
 
 
-<SCRIPT language=JavaScript>
+<script>
 {literal}
 function MakeArray(n) {
 	for (var i = 0; i < n; i++)
@@ -123,7 +123,7 @@ if (mines < rows*cols) { var field = new MineField(); }
 stat = document.init_form.status;
 
 {/literal}
-</SCRIPT>
+</script>
 
 
           </td>

--- a/modules/home/templates/admin_tournament_selection.htm
+++ b/modules/home/templates/admin_tournament_selection.htm
@@ -1,4 +1,4 @@
-<script language="JavaScript" type="text/javascript">
+<script>
 {literal}
 function change_selection() {
 {/literal}

--- a/modules/mastersearch2/templates/result_case.htm
+++ b/modules/mastersearch2/templates/result_case.htm
@@ -1,8 +1,6 @@
-<script language="JavaScript" type="text/javascript">
-<!--
+<script>
 MultiSelectActions = new Array({$multi_select_actions});
 MultiSelectSecurityQuest = new Array({$security_questions});
--->
 </script>
 {if $pages != ''}
   <form name="MSEntsPerPage" method="get" action="" rel="nofollow">

--- a/modules/msgsys/boxes/messenger.php
+++ b/modules/msgsys/boxes/messenger.php
@@ -36,7 +36,7 @@ if ($auth['login']) {
         if ($row_new_msg['senderid']) {
             $item = "message_blink";
             if ($cfg['msgsys_popup']) {
-                $caption = "<script type=\"text/javascript\" language=\"JavaScript\"> 
+                $caption = "<script>
                                 var link = \"index.php?mod=msgsys&amp;action=query&amp;design=base&amp;queryid={$row["buddyid"]}$msg_sid\";
                                 var suche = /&amp;/;
 

--- a/modules/paypal/templates/javascript.htm
+++ b/modules/paypal/templates/javascript.htm
@@ -1,6 +1,5 @@
 {literal}
-<script language="JavaScript">
-<!--
+<script>
 function submitpaypal(){
     window.open('about:blank', 'PopWnd', 'width=800,height=600,resizable=yes,scrollbars=yes');
     window.setTimeout('window.document.forms[\'paypal\'].submit();', 1);
@@ -12,6 +11,5 @@ function refreshParent() {
     window.opener.progressWindow.close();
   window.close();
 }
-//-->
 </script>
 {/literal}

--- a/modules/paypal/templates/sendbox.htm
+++ b/modules/paypal/templates/sendbox.htm
@@ -9,9 +9,8 @@
 	<meta http-equiv="pragma" content="no-cache" />
 
 </head>	
-<script language="JavaScript">
+<script>
 {literal}
-<!--
 function submitpaypal(){
     window.open('about:blank', 'PopWnd');
     window.setTimeout('window.document.forms[\'paypal\'].submit();', 1);
@@ -23,7 +22,6 @@ function refreshParent() {
     window.opener.progressWindow.close();
   window.close();
 }
--->
 {/literal}
 </script>
 </head>

--- a/modules/poll/templates/show_voters.htm
+++ b/modules/poll/templates/show_voters.htm
@@ -1,8 +1,6 @@
 <div id="votes">{$templ['poll']['show']['details']['case']['control']['javascript_title']}</div>
 
-<script language="JavaScript">
-<!--
-
+<script>
 	// Define Data
 	var votes	= new Array();
 	{$templ['poll']['show']['details']['case']['control']['javascript']}
@@ -21,5 +19,4 @@
 			// Remove data
 			document.getElementById("votes").firstChild.nodeValue	= '{$templ['poll']['show']['details']['case']['control']['javascript_title']}';
 	}
-//-->
 </script>


### PR DESCRIPTION
### What is this PR doing?

The `language` tag of the `<script>` tag is deprecated. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script?retiredLocale=de#deprecated_attributes

The `type` attribute is recommended to drop if not specified otherwise, see

> [Attribute is not set (default), an empty string, or a JavaScript MIME type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script?retiredLocale=de#attribute_is_not_set_default_an_empty_string_or_a_javascript_mime_type)
Indicates that the script is a "classic script", containing JavaScript code. Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type. JavaScript MIME types are [listed in the IANA media types specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript).

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed