### PR TITLE
[Seating] Fix "Fatal error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, bool given in /modules/seating/Classes/Seat2.php on line 376"

### DIFF
--- a/modules/seating/Classes/Seat2.php
+++ b/modules/seating/Classes/Seat2.php
@@ -373,7 +373,7 @@ class Seat2
 
                 $partyUserCheckin = 0;
                 $partyUserCheckout = 0;
-                if (array_key_exists('checkin', $party_user) && array_key_exists('checkout', $party_user)) {
+                if (is_array($party_user) && array_key_exists('checkin', $party_user) && array_key_exists('checkout', $party_user)) {
                     $partyUserCheckin = $party_user['checkin'];
                     $partyUserCheckout = $party_user['checkout'];
                 }


### PR DESCRIPTION
### What is this PR doing?

Fixing this error:

<img width="1185" alt="Screenshot 2024-02-28 at 19 36 06" src="https://github.com/lansuite/lansuite/assets/320064/815901b6-9b61-46fe-b97f-3f250435951c">

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed