### PR TITLE
[usrmgr] Add missing empty and error check

### DIFF
--- a/modules/usrmgr/remind.php
+++ b/modules/usrmgr/remind.php
@@ -8,10 +8,13 @@ if (!$cfg['sys_internet']) {
     switch ($stepParameter) {
         // Email prüfen, Freischaltecode generieren, Email senden
         case 2:
-            $user_data = $db->qry_first("SELECT username FROM %prefix%user WHERE email = %string%", $_POST['pwr_mail']);
-            if ($user_data['username'] == "LS_SYSTEM") {
+            $passwordReminderMail = $_POST['pwr_mail'] ?? '';
+            $user_data = $db->qry_first("SELECT username FROM %prefix%user WHERE email = %string%", $passwordReminderMail);
+            if ($user_data === false || $user_data['username'] == "") {
+                $func->information(t('Die von dir eigegebene Email existiert nicht in der Datenbank'), "index.php?mod=usrmgr&action=pwrecover&step=1");
+            } elseif ($user_data['username'] == "LS_SYSTEM") {
                 $func->information(t('Für den System-Account darf kein neues Passwort generiert werden'), "index.php?mod=usrmgr&action=pwrecover&step=1");
-            } elseif ($user_data['username']) {
+            } else {
                 $fcode = '';
                 for ($x = 0; $x <= 24; $x++) {
                     $fcode .= chr(random_int(65, 90));
@@ -45,8 +48,6 @@ if (!$cfg['sys_internet']) {
                 //now assemble it all into a mail
                 $mail->create_inet_mail($user_data['username'], $_POST['pwr_mail'], $cfg['usrmgr_pwrecovery_subject'], $pwrecoverytxt);
                 $func->confirmation(t('Dir wurde nun eine Freischalte-URL an die angegebene Emailadresse gesendet. Mit dem Aufruf dieser URL wird dir neues Passwort generiert werden.'), "index.php");
-            } else {
-                $func->information(t('Die von dir eigegebene Email existiert nicht in der Datenbank'), "index.php?mod=usrmgr&action=pwrecover&step=1");
             }
             break;
 


### PR DESCRIPTION
### What is this PR doing?

If you call `http://.../index.php?mod=usrmgr&action=pwrecover&step=2`  out of nowhere you get a warning about an undefined array key.
```
PHP Warning: Undefined array key "pwr_mail" in /www/htdocs/xxx/modules/usrmgr/remind.php on line 11
PHP Warning: Trying to access array offset on value of type bool in /www/htdocs/xxx/modules/usrmgr/remind.php on line 12
PHP Warning: Trying to access array offset on value of type bool in /www/htdocs/xxx/modules/usrmgr/remind.php on line 14
```
