### PR TITLE
Impoved access to module DB update function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [System] Introduced symfony/cache to easily provide other cache backends like APCu (next to file caching)
 - [System] Introduced symfony/http-foundation to unify safe access to superglobals
 - [Database] Added the setting to replace the hardcoded database table prefix `lansuite_` with something admin configurable
+- [Database] Introduced options to update single module DB structure (#927)
 - [Tournament] Added tournament icon for Starcraft II
 - [Tournament] Added tournament icon for Counter-Strike: Global Offensive
 - [Tournament] Added tournament icon for Rocket League

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -708,7 +708,7 @@ class Install
             }
         }
         $dsp->AddDoubleRow(t('Schreibrechte im Ordner \'ext_inc\''), $ext_inc_check);
-        
+
         // PHP temp folder access
         $tmpfile = tmpfile();
         if (!$tmpfile) {
@@ -718,7 +718,7 @@ class Install
             fclose($tmpfile);
         }
         $dsp->AddDoubleRow(t('Schreiben temporärer Dateien'), $tmp_check);
-        
+
         $dsp->AddFieldSetEnd();
 
         #### Warning ####
@@ -771,7 +771,7 @@ class Install
             $ftp_check = $not_possible . t('Auf deinem System konnte das PHP-Modul <b>FTP-Library</b> nicht gefunden werden. Dies hat zur Folge haben, dass das Download-Modul nur im Standard-Modus, jedoch nicht im FTP-Modus, verwendet werden kann');
         }
         $dsp->AddDoubleRow("FTP Library", $ftp_check);
-        
+
         // APCu-Lib
         if (extension_loaded('apcu')) {
             $apcu_check = $ok;
@@ -779,7 +779,7 @@ class Install
             $apcu_check = $optimize . t('Auf deinem System konnte das PHP-Modul <b>APCu</b> nicht gefunden werden. Dies wird verwendet, um verschiedenste Daten für schnellen Zugriff zwischenzuspeichern. Eine Aktivierung ist bei vielen Seitenzugriffen angeraten. Als Fallback werden die Daten im Dateisystem vorgehalten');
         }
         $dsp->AddDoubleRow("APCu", $apcu_check);
-        
+
         // OpenSSL
         if (extension_loaded('openssl')) {
             $openssl_check = $ok;
@@ -985,7 +985,8 @@ class Install
             $smarty->assign('menu_link', $menu_link);
 
             if (file_exists("modules/{$row["name"]}/mod_settings/db.xml")) {
-                $db_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=40&module={$row["name"]}\">". t('DB') ."</a>";
+                $db_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=40&module={$row["name"]}&tab=2\">". t('DB config') ."</a>";
+                $db_link .=  " | <a href=\"index.php?mod=install&action=mod_cfg&step=42&module={$row["name"]}&tab=2\">". t('DB update') ."</a>";
             } else {
                 $db_link = "";
             }

--- a/modules/install/mod_cfg.php
+++ b/modules/install/mod_cfg.php
@@ -292,7 +292,11 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
                         $dsp->AddFieldsetEnd();
 
                         $dsp->AddFieldsetStart(t('Weitere Aktionen'));
-                        $dsp->AddDoubleRow('', $dsp->FetchSpanButton('Modul-Datenbank zurücksetzen', 'index.php?mod=install&action=mod_cfg&step=41&module='. $_GET['module'] .'&tab=2'));
+                        $dsp->AddDoubleRow(
+                            t('Modul-Datenbankstruktur aus Quelldateien anpassen'),
+                            $dsp->FetchSpanButton('Modul-Datenbank aktualiseren', 'index.php?mod=install&action=mod_cfg&step=42&module='. $_GET['module'] .'&tab=2') .
+                            $dsp->FetchSpanButton('Modul-Datenbank zurücksetzen', 'index.php?mod=install&action=mod_cfg&step=41&module='. $_GET['module'] .'&tab=2')
+                        );
                         $dsp->AddFieldsetEnd();
                         break;
                 }


### PR DESCRIPTION
### What is this PR doing?

When trying to work on #925 I had to note that there is functionality to update just a single module DB, but it appears not to be accessible anywhere
This introduces buttons on the general module overview and the module db config page to just execute an update of the db structure of the selected module.
It also fixes the DB option on the module overview not actually linking to the DB tab of the module

### Which issue(s) this PR fixes:

None

### Checklist

- [x] `CHANGELOG.md` entry
- [x] ~Documentation update~