### PR TITLE
[Usermgr] Fix bug when you edit the user profile, address data is not shown

### DIFF
--- a/modules/usrmgr/Functions/Addr1Input.php
+++ b/modules/usrmgr/Functions/Addr1Input.php
@@ -18,6 +18,8 @@ function Addr1Input($field, $mode, $error = ''): bool|string
             if ($streetAndNoParameter == '' && $streetParameter  && $streetNoParameter) {
                 $_POST['street|hnr'] = $streetParameter  . ' ' . $streetNoParameter;
             }
+
+            $streetAndNoParameter = $_POST['street|hnr'] ?? '';
             $dsp->AddTextFieldRow('street|hnr', t('Straße und Hausnummer'), $streetAndNoParameter, $error, '', Optional('street'));
             return false;
             break;

--- a/modules/usrmgr/Functions/Addr2Input.php
+++ b/modules/usrmgr/Functions/Addr2Input.php
@@ -17,6 +17,8 @@ function Addr2Input($field, $mode, $error = ''): bool|string
             if ($plzAndCityParameter == '' && $plzParameter && $_POST['city']) {
                 $_POST['plz|city'] = $plzParameter .' '. $_POST['city'];
             }
+
+            $plzAndCityParameter = $_POST['plz|city'] ?? '';
             $dsp->AddTextFieldRow('plz|city', t('PLZ und Ort'), $plzAndCityParameter, $error, '', Optional('city'));
             return false;
             break;


### PR DESCRIPTION
### What is this PR doing?

If a user has an address entered and the user edit its profile, the address data is not shown in the edit fields.

The reason: The super global $_POST is written and we don't read this again.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed