### PR TITLE
[XSS] Prevent XSS possibility in http-equiv="refresh" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 
 - [Database] Introduced a new Database class with first-class prepared statement support
 - [System] Protect module inclusion for path traversal
+- [XSS] Prevent XSS possibility in http-equiv="refresh" header
 
 ## [4.2] - 2015-03-15
 

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -295,13 +295,14 @@ class Framework
     public function html_out()
     {
         global $templ, $cfg, $db, $auth, $smarty, $func, $debug, $request;
+
         $compression_mode = $this->check_optimizer();
 
         // Prepare Header
-        if ($request->query->get('sitereload')) {
-            $smarty->assign('main_header_sitereload', '<meta http-equiv="refresh" content="'.$_GET['sitereload'].'; URL='.$_SERVER["PHP_SELF"].'?'.$_SERVER['QUERY_STRING'].'">');
-        } else {
-            $smarty->assign('main_header_sitereload', '');
+        $siteReloadParameter = intval($request->query->get('sitereload'));
+        $smarty->assign('main_header_sitereload', '');
+        if ($siteReloadParameter) {
+            $smarty->assign('main_header_sitereload', '<meta http-equiv="refresh" content="' . $siteReloadParameter . '; URL='.$_SERVER["PHP_SELF"].'?'.$_SERVER['QUERY_STRING'].'">');
         }
 
         // Add special CSS and JS


### PR DESCRIPTION
### What is this PR doing?

[XSS] Prevent XSS possibility in http-equiv="refresh" header

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update - Not needed