### PR TITLE
[install] fix for broken MariaDB version check

### DIFF
--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -657,6 +657,7 @@ class Install
         if (!$currentMysqlVersion) {
             $mysqlVersionCheck = $not_possible . t('Konnte MySQL-Version nicht überprüfen, da keine Verbindung mit den Standarddaten (%1@%2) möglich war. <br/>Dies ist kein direkter Fehler, bedeutetet aber, dass einige Setup-Schritte per Hand durchgeführt werden müssen. <br/>Bitte Stelle sicher, dass du MySQL mindestens in Version %3 benutzt.', $configuration['database']['user'], $configuration['database']['server'], \LANSUITE_MINIMUM_MYSQL_VERSION);
         } elseif (str_contains($currentMysqlVersion, 'MariaDB')) {
+            $currentMariaDBVersion = $currentMysqlVersion;
             $pos = strpos($currentMysqlVersion, '-');
             if ($pos !== false) {
                 $currentMariaDBVersion = substr($currentMysqlVersion, 0, $pos);

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -657,7 +657,10 @@ class Install
         if (!$currentMysqlVersion) {
             $mysqlVersionCheck = $not_possible . t('Konnte MySQL-Version nicht überprüfen, da keine Verbindung mit den Standarddaten (%1@%2) möglich war. <br/>Dies ist kein direkter Fehler, bedeutetet aber, dass einige Setup-Schritte per Hand durchgeführt werden müssen. <br/>Bitte Stelle sicher, dass du MySQL mindestens in Version %3 benutzt.', $configuration['database']['user'], $configuration['database']['server'], \LANSUITE_MINIMUM_MYSQL_VERSION);
         } elseif (str_contains($currentMysqlVersion, 'MariaDB')) {
-            $currentMariaDBVersion = substr($currentMysqlVersion, strpos($currentMysqlVersion, '-')+1);
+            $pos = strpos($currentMysqlVersion, '-');
+            if ($pos !== false) {
+                $currentMariaDBVersion = substr($currentMysqlVersion, 0, $pos);
+            }
             if (version_compare($currentMariaDBVersion, $minMariaDBVersion) >= 0) {
                 $mysqlVersionCheck = $optimize . t('MariaDB Version %1 gefunden. <br/>Bitte beachte, das LanSuite primär für MySQL entwickelt wurde und es daher zu unerwarteten Problemen mit MariaDB kommen kann!', $currentMariaDBVersion);
             } else {


### PR DESCRIPTION
### What is this PR doing?

I know, MariaDB is not the main focus, but checking the version-string the wrong way didn't help.
The first part is the relevant version number, not the part after the dash.
The `substr()` parameters are mixed up. 

### Which issue(s) this PR fixes:

Fixes broken MariaDB version check

### Checklist

- [ ] `CHANGELOG.md` entry
- [ ] Documentation update