### PR TITLE
[Seating] Quote reserved SQL keyword to avoid fatal errors

### DIFF
--- a/modules/seating/ipgen.php
+++ b/modules/seating/ipgen.php
@@ -36,7 +36,14 @@ switch ($stepParameter) {
         $del_ips = $db->qry("UPDATE %prefix%seat_seats SET ip = '' WHERE blockid=%int%", $block_id);
 
         // ermittle wieviele reihen und spalten der sitzplan hat
-        $get_size = $db->qry_first("SELECT rows,cols FROM %prefix%seat_block WHERE blockid=%int%", $block_id);
+        $getSizeQuery = '
+        SELECT
+            `rows`,
+            `cols`
+        FROM %prefix%seat_block
+        WHERE
+            blockid = ?';
+        $get_size = $database->queryWithOnlyFirstRow($getSizeQuery, [$block_id]);
         $max_row = $get_size["rows"];
         $max_col = $get_size["cols"];
 
@@ -53,11 +60,12 @@ switch ($stepParameter) {
         } else {
             $order = "row ".$s_row.",col ".$s_col;
         }
+
         $query_sub = $db->qry("
           SELECT
-            seatid,
-            row,
-            col
+            `seatid`,
+            `row`,
+            `col`
           FROM %prefix%seat_seats
           WHERE
             %plain%


### PR DESCRIPTION
### What is this PR doing?

[Seating] Quote reserved SQL keyword to avoid fatal errors

`rows` is a reserved keyword in MariaDB + MySQL >8.0.2

This PR is fixing a fatal error when you generate IP addresses on a seat plan.

I did not switch the second query to the new database class, to avoid the complexity at first. This is a broader refactor process due to the usage of `%plain%`. My priority was to fix the fatal error.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed