### PR TITLE
[Server] Rework module to fix PHP warnings, typos, switch to prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Boxes/Login] Sign up and Password Recovery are now text links below the login box and not only icons anymore (for better usability)
 - [PDF] Usage of core fonts from fpdf instead of `ext_inc/pdf_fonts`
 - [Security] Set Cookies HTTP only and protocol aware (https)
+- [Server] Switch Server hardware informatiuon from Megabyte to Gigabyte (for RAM) and from Megaherz to Gigaherz for CPU
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Party] Add information `Gesamt` in the Party box to show how many people can sign up for a party
 - [Birthday] New module to show users birthdays
 - [Hall of fame] New module to present all tournament winners in a Hall of Fame
+- [Server] Added Voice as server type
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Boxes/Login] Sign up and Password Recovery are now text links below the login box and not only icons anymore (for better usability)
 - [PDF] Usage of core fonts from fpdf instead of `ext_inc/pdf_fonts`
 - [Security] Set Cookies HTTP only and protocol aware (https)
-- [Server] Switch Server hardware informatiuon from Megabyte to Gigabyte (for RAM) and from Megaherz to Gigaherz for CPU
+- [Server] Changed CPU and RAM Unit of measure from Mega to Giga in Server hardware information
+- [Server] Limited visibility for non-Admins to active party
 
 ### Deprecated
 

--- a/modules/server/Functions/CheckPort.php
+++ b/modules/server/Functions/CheckPort.php
@@ -5,8 +5,13 @@
  */
 function CheckPort($port): bool|string
 {
-    if ($port < 1 or $port > 65535) {
+    if (!$port) {
+        return false;
+    }
+
+    if ($port < 1 || $port > 65535) {
         return t('Der Port muss zwischen 1 und 65535 liegen');
     }
+
     return false;
 }

--- a/modules/server/Functions/PingServer.php
+++ b/modules/server/Functions/PingServer.php
@@ -7,10 +7,10 @@
  */
 function PingServer($host, $port)
 {
-    global $db, $func, $cfg;
+    global $database, $func, $cfg;
 
     $cfg["server_ping_refresh"] = (int) $cfg["server_ping_refresh"];
-    $server_daten = $db->qry_first("
+    $server_daten = $database->queryWithOnlyFirstRow("
       SELECT
         UNIX_TIMESTAMP(NOW())-UNIX_TIMESTAMP(lastscan) AS idle,
         type,
@@ -18,9 +18,9 @@ function PingServer($host, $port)
         special_info
       FROM %prefix%server
       WHERE
-        (ip = %string%)
-        AND (port = %string%)
-      HAVING (idle > %int%)", $host, $port, $cfg["server_ping_refresh"]);
+        ip = ?
+        AND port = ?
+      HAVING idle > ?", [$host, $port, $cfg["server_ping_refresh"]]);
 
     if (random_int(0, 2) == 0) {
         // Erreichbarkeit testen
@@ -128,6 +128,6 @@ function PingServer($host, $port)
         if ($special_info =="") {
             $special_info=$server_daten["special_info"];
         }
-        $db->qry('UPDATE %prefix%server SET special_info=%string%, available=%string%, scans=scans+1, success=success+%int%, lastscan=NOW() WHERE ((ip = %string%) AND (port=%int%));', $special_info, $available, $success, $host, $port);
+        $database->query('UPDATE %prefix%server SET special_info = ?, available = ?, scans = scans + 1, success = success + ?, lastscan = NOW() WHERE ip = ? AND port = ?', [$special_info, $available, $success, $host, $port]);
     }
 }

--- a/modules/server/Functions/ServerType.php
+++ b/modules/server/Functions/ServerType.php
@@ -10,6 +10,7 @@ function ServerType($type)
         "gameserver" => "Game",
         "ftp" => "FTP",
         "irc" => "IRC",
+        "voice" => "Voice",
         "web" => "Web",
         "proxy" => "Proxy",
         "misc" => "Misc",

--- a/modules/server/add.php
+++ b/modules/server/add.php
@@ -50,6 +50,7 @@ if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     $selections['gameserver'] = t('Gameserver');
     $selections['ftp'] = t('FTP Server');
     $selections['irc'] = t('IRC Server');
+    $selections['voice'] = t('Voice Server');
     $selections['web'] = t('Web Server');
     $selections['proxy'] = t('Proxy Server');
     $selections['misc'] = t('Sonstiger Server');

--- a/modules/server/add.php
+++ b/modules/server/add.php
@@ -2,7 +2,7 @@
 
 $get_paid = ['paid' => 0];
 if ($auth['type'] <= \LS_AUTH_TYPE_USER) {
-    $get_paid = $db->qry_first('SELECT paid FROM %prefix%party_user WHERE user_id = %int% AND party_id = %int%', $auth['userid'], $party->party_id);
+    $get_paid = $database->queryWithOnlyFirstRow('SELECT paid FROM %prefix%party_user WHERE user_id = ? AND party_id = ?', [$auth['userid'], $party->party_id]);
 }
 if ($cfg['server_ip_auto_assign']) {
     $IPBase = substr($cfg['server_ip_auto_assign'], 0, strrpos($cfg['server_ip_auto_assign'], '.'));
@@ -38,11 +38,10 @@ if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     // Party-Liste
     if ($func->isModActive('party')) {
         $party_list = array('' => t('KEINE'));
-        $row = $db->qry("SELECT party_id, name FROM %prefix%partys");
-        while ($res = $db->fetch_array($row)) {
-            $party_list[$res['party_id']] = $res['name'];
+        $rows = $database->queryWithFullResult("SELECT party_id, name FROM %prefix%partys");
+        foreach ($rows as $row) {
+            $party_list[$row['party_id']] = $row['name'];
         }
-        $db->free_result($row);
         $mf->AddField(t('Party'), 'party_id', \LanSuite\MasterForm::IS_SELECTION, $party_list, $party->party_id);
     }
 
@@ -74,7 +73,7 @@ if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     if ($mf->SendForm('index.php?mod=server&action=add', 'server', 'serverid', $serverIdParameter)) {
         // Increase auto IP
         if ($cfg['server_ip_auto_assign']) {
-            $db->qry('UPDATE %prefix%config SET cfg_value = %int% WHERE cfg_key = \'server_ip_next\'', $cfg['server_ip_next'] + 1);
+            $database->query('UPDATE %prefix%config SET cfg_value = ? WHERE cfg_key = \'server_ip_next\'', [$cfg['server_ip_next'] + 1]);
         }
     };
 }

--- a/modules/server/add.php
+++ b/modules/server/add.php
@@ -65,8 +65,8 @@ if ($cfg['server_ip_auto_assign'] and $cfg['server_ip_next'] > $IPEnd) {
     $mf->AddField(t('Port'), 'port', '', '', '', 'CheckPort');
     $mf->AddField(t('MAC-Adresse'), 'mac', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL, 'CheckMAC');
     $mf->AddField(t('Betriebssystem'), 'os', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
-    $mf->AddField(t('CPU (MHz)'), 'cpu', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
-    $mf->AddField(t('RAM (MB)'), 'ram', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
+    $mf->AddField(t('CPU (GHz)'), 'cpu', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
+    $mf->AddField(t('RAM (GB)'), 'ram', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddField(t('HDD (GB)'), 'hdd', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddField(t('Passwort geschützt'), 'pw', '', '', \LanSuite\MasterForm::FIELD_OPTIONAL);
     $mf->AddField(t('Beschreibung'), 'text', '', \LanSuite\MasterForm::LSCODE_ALLOWED, \LanSuite\MasterForm::FIELD_OPTIONAL);

--- a/modules/server/delete.php
+++ b/modules/server/delete.php
@@ -7,7 +7,7 @@ switch ($stepParameter) {
         break;
     
     case 2:
-        $server = $db->qry_first("SELECT caption FROM %prefix%server WHERE serverid = %int%", $_GET["serverid"]);
+        $server = $database->queryWithOnlyFirstRow("SELECT caption FROM %prefix%server WHERE serverid = ?", [$_GET["serverid"]]);
         $servername = $server["caption"];
 
         if ($server) {
@@ -18,19 +18,19 @@ switch ($stepParameter) {
         break;
 
     case 3:
-        $server = $db->qry_first("
+        $server = $database->queryWithOnlyFirstRow("
           SELECT
             caption,
             owner
           FROM %prefix%server
           WHERE
-            serverid = %int%", $_GET["serverid"]);
+            serverid = ?", [$_GET["serverid"]]);
 
         if ($server) {
             if ($server["owner"] != $auth["userid"] and $auth['type'] <= \LS_AUTH_TYPE_USER) {
                 $func->information(t('Nur der Besitzer und Administratoren d&uuml;rfen diese Aktion ausf&uuml;hren'), "index.php?mod=server&action=delete");
             } else {
-                $delete = $db->qry("DELETE FROM %prefix%server WHERE serverid = %int%", $_GET["serverid"]);
+                $delete = $database->query("DELETE FROM %prefix%server WHERE serverid = ?", [$_GET["serverid"]]);
             
                 $servername = $server["caption"];
                 if ($delete) {

--- a/modules/server/plugins/home.php
+++ b/modules/server/plugins/home.php
@@ -1,5 +1,5 @@
 <?php
-$smarty->assign('caption', t('Server für die ') . ' ' . $_SESSION['party_info']['name']);
+$smarty->assign('caption', t('Server für ') . ' ' . $_SESSION['party_info']['name']);
 $content = "";
 
 if (!$cfg['server_sortmethod']) {

--- a/modules/server/plugins/home.php
+++ b/modules/server/plugins/home.php
@@ -5,7 +5,8 @@ $content = "";
 if (!$cfg['server_sortmethod']) {
     $cfg['server_sortmethod'] = 'changedate';
 }
-$query = $db->qry("
+
+$serverRows = $database->queryWithFullResult("
   SELECT
     serverid,
     caption,
@@ -13,22 +14,22 @@ $query = $db->qry("
     UNIX_TIMESTAMP(changedate) AS changedate
   FROM %prefix%server
   WHERE
-    party_id = %int%
-  ORDER BY %string% DESC
-  LIMIT 0, %plain%", $party->party_id, $cfg['server_sortmethod'], $cfg['home_item_cnt_server']);
+    party_id = ?
+  ORDER BY ? DESC
+  LIMIT 0, ?", [$party->party_id, $cfg['server_sortmethod'], $cfg['home_item_cnt_server']]);
 
-if ($db->num_rows($query) > 0) {
-    while ($row = $db->fetch_array($query)) {
-        $smarty->assign('link', "index.php?mod=server&action=show_details&serverid={$row["serverid"]}");
-        $smarty->assign('text', $func->CutString($row["caption"], 40));
-        $smarty->assign('text2', " (".$row["type"].")");
+if (count($serverRows) > 0) {
+  foreach ($serverRows as $row) {
+    $smarty->assign('link', "index.php?mod=server&action=show_details&serverid={$row["serverid"]}");
+    $smarty->assign('text', $func->CutString($row["caption"], 40));
+    $smarty->assign('text2', " (".$row["type"].")");
 
-        if ($func->CheckNewPosts($row['changedate'], 'server', $row['serverid'])) {
-            $content .= $smarty->fetch('modules/home/templates/show_row_new.htm');
-        } else {
-            $content .= $smarty->fetch('modules/home/templates/show_row.htm');
-        }
+    if ($func->CheckNewPosts($row['changedate'], 'server', $row['serverid'])) {
+        $content .= $smarty->fetch('modules/home/templates/show_row_new.htm');
+    } else {
+        $content .= $smarty->fetch('modules/home/templates/show_row.htm');
     }
+  }
 } else {
-    $content = "<i>". t('Keine Server vorhanden') ."</i>";
+  $content = "<i>". t('Keine Server vorhanden') ."</i>";
 }

--- a/modules/server/plugins/home.php
+++ b/modules/server/plugins/home.php
@@ -1,6 +1,5 @@
 <?php
-
-$smarty->assign('caption', t('Neue Server'));
+$smarty->assign('caption', t('Server für die ') . ' ' . $_SESSION['party_info']['name']);
 $content = "";
 
 if (!$cfg['server_sortmethod']) {
@@ -14,11 +13,7 @@ $query = $db->qry("
     UNIX_TIMESTAMP(changedate) AS changedate
   FROM %prefix%server
   WHERE
-    (
-      party_id = %int%
-      OR party_id = 0
-      OR party_id = NULL
-    )
+    party_id = %int%
   ORDER BY %string% DESC
   LIMIT 0, %plain%", $party->party_id, $cfg['server_sortmethod'], $cfg['home_item_cnt_server']);
 

--- a/modules/server/search.inc.php
+++ b/modules/server/search.inc.php
@@ -7,7 +7,7 @@ $ms2->config['EntriesPerPage'] = 30;
 
 $ms2->AddTextSearchField(t('Name'), array('s.caption' => 'like', 's.ip' => 'like'));
 $ms2->AddTextSearchField(t('Besitzer'), array('u.username' => '1337', 'u.name' => 'like', 'u.firstname' => 'like'));
-$ms2->AddTextSearchDropDown(t('Servertyp'), 's.type', array('' => t('Alle'), 'gameserver' => 'Game', 'ftp' => 'FTP', 'irc' => 'IRC', 'web' => 'Web', 'proxy' => 'Proxy', 'misc' => 'Misc'));
+$ms2->AddTextSearchDropDown(t('Servertyp'), 's.type', array('' => t('Alle'), 'gameserver' => 'Game', 'ftp' => 'FTP', 'irc' => 'IRC', 'voice' => 'Voice','web' => 'Web', 'proxy' => 'Proxy', 'misc' => 'Misc'));
 $ms2->AddTextSearchDropDown('PW', 's.pw', array('' => t('Alle'), '0' => t('Nein'), '1' => t('Ja')));
 
 $ms2->AddSelect('u.userid');

--- a/modules/server/search.inc.php
+++ b/modules/server/search.inc.php
@@ -3,8 +3,12 @@ $ms2 = new \LanSuite\Module\MasterSearch2\MasterSearch2();
 
 $ms2->query['from'] = "%prefix%server AS s LEFT JOIN %prefix%user AS u ON s.owner = u.userid";
 
-$ms2->config['EntriesPerPage'] = 30;
+// Show only servers of the current party to non-admins
+if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
+    $ms2->query['where'] = 'party_id = ' . intval($party->party_id);
+}
 
+$ms2->config['EntriesPerPage'] = 30;
 $ms2->AddTextSearchField(t('Name'), array('s.caption' => 'like', 's.ip' => 'like'));
 $ms2->AddTextSearchField(t('Besitzer'), array('u.username' => '1337', 'u.name' => 'like', 'u.firstname' => 'like'));
 $ms2->AddTextSearchDropDown(t('Servertyp'), 's.type', array('' => t('Alle'), 'gameserver' => 'Game', 'ftp' => 'FTP', 'irc' => 'IRC', 'voice' => 'Voice','web' => 'Web', 'proxy' => 'Proxy', 'misc' => 'Misc'));
@@ -15,6 +19,9 @@ $ms2->AddResultField(t('Name'), 's.caption');
 $ms2->AddResultField(t('Servertyp'), 's.type', 'ServerType');
 $ms2->AddResultField(t('IP-Adresse / Domain'), 'INET6_NTOA(s.ip) AS ip');
 $ms2->AddResultField(t('Port'), 's.port');
+if ($auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
+    $ms2->AddResultField(t('Party-ID'), 's.party_id');
+}
 $ms2->AddResultField(t('Besitzer'), 'u.username', 'UserNameAndIcon');
 $ms2->AddResultField('PW', 's.pw', 'PWIcon');
 $ms2->AddResultField(t('Status'), 's.available', 'ServerStatus');

--- a/modules/server/show_details.php
+++ b/modules/server/show_details.php
@@ -39,6 +39,7 @@ if ($server == "") {
         $type_descriptor["gameserver"] = t('Gameserver');
         $type_descriptor["ftp"] = t('FTP-Server');
         $type_descriptor["irc"] = t('IRC-Server');
+        $type_descriptor["voice"] = t('Voice-Server');
         $type_descriptor["web"] = t('Webserver');
         $type_descriptor["proxy"] = t('Proxy / Gateway');
         $type_descriptor["misc"] = t('Sonstiges');

--- a/modules/server/show_details.php
+++ b/modules/server/show_details.php
@@ -1,7 +1,7 @@
 <?php
 $serverid = $_GET["serverid"];
 
-$server = $db->qry_first("
+$server = $database->queryWithOnlyFirstRow("
   SELECT
     a.serverid,
     a.owner,
@@ -21,7 +21,7 @@ $server = $db->qry_first("
   FROM %prefix%server AS a
   LEFT JOIN %prefix%user AS b ON a.owner = b.userid
   WHERE
-    serverid = %int%", $serverid);
+    serverid = ?", [$serverid]);
      
 if ($server == "") {
     $func->error(t('Der von dir aufgerufene Server existiert nicht'), "index.php?mod=server&action=show");
@@ -50,7 +50,7 @@ if ($server == "") {
             PingServer($server["ip"], $server["port"]);
 
             // Gescannte Daten neu auslesen
-            $server_scan = $db->qry_first('
+            $server_scan = $database->queryWithOnlyFirstRow('
               SELECT
                 special_info,
                 available,
@@ -58,7 +58,7 @@ if ($server == "") {
                 scans,
                 UNIX_TIMESTAMP(lastscan) AS lastscan
               FROM %prefix%server
-              WHERE serverid = %int%', $serverid);
+              WHERE serverid = ?', [$serverid]);
 
             ($server_scan["available"] == 1) ?
                 $serverstatus = "<div class=\"tbl_green\">".t('Dienst erreichbar')."</div>" : $serverstatus = "<div class=\"tbl_red\">".t('Dienst nicht ereichbar')."</div>";

--- a/modules/server/show_details.php
+++ b/modules/server/show_details.php
@@ -31,7 +31,7 @@ if ($server == "") {
     // Just show details if the user is not adding, deleting or chaning his comment
     $mcactParameter = $_GET["mcact"] ?? '';
     if ($mcactParameter == "" || $mcactParameter == "show") {
-        $dsp->NewContent(t('Serverdetails'), t('Auf dieser Seite diehst du alle Details zum Server <b>%1</b>. Durch eine Klick auf den Zur&uuml;ck-Button gelangst du zur Übersicht zur&uuml;ck', $server["caption"]));
+        $dsp->NewContent(t('Serverdetails'), t('Auf dieser Seite siehst du alle Details zum Server <b>%1</b>. Durch eine Klick auf den Zur&uuml;ck-Button gelangst du zur Übersicht zur&uuml;ck', $server["caption"]));
 
         $dsp->AddDoubleRow(t('Name'), $server["caption"]);
         $dsp->AddDoubleRow(t('Besitzer'), $dsp->FetchUserIcon($server['userid'], $server["username"]));

--- a/modules/server/show_details.php
+++ b/modules/server/show_details.php
@@ -88,8 +88,8 @@ if ($server == "") {
         }
         $dsp->AddDoubleRow(t('Betriebssystem'), $server["os"]);
 
-        ($server["cpu"] == "0") ? $server["cpu"] = "<i>". t('Keine Angabe') ."</i>" : $server["cpu"] = $server["cpu"]." Megaherz";
-        ($server["ram"] == "0") ? $server["ram"] = "<i>". t('Keine Angabe') ."</i>" : $server["ram"] = $server["ram"]." Megabyte";
+        ($server["cpu"] == "0") ? $server["cpu"] = "<i>". t('Keine Angabe') ."</i>" : $server["cpu"] = $server["cpu"]." Gigaherz";
+        ($server["ram"] == "0") ? $server["ram"] = "<i>". t('Keine Angabe') ."</i>" : $server["ram"] = $server["ram"]." Gigabyte";
         ($server["hdd"] == "0") ? $server["hdd"] = "<i>". t('Keine Angabe') ."</i>" : $server["hdd"] = $server["hdd"]." Gigabyte";
         $dsp->AddDoubleRow("CPU", $server["cpu"]);
         $dsp->AddDoubleRow("RAM", $server["ram"]);

--- a/website/docs/guides/guides-upgrade.md
+++ b/website/docs/guides/guides-upgrade.md
@@ -216,3 +216,20 @@ If you have added your own custom fonts into `ext_inc/pdf_fonts`, you need to co
 2. Choose your custom font file (ttf)
 3. Download the generated *.z and *.php file
 4. Add the `*.ttf`, `*.z` and `*.php` into `ext_inc/pdf_fonts`
+
+### Server module: Change of hardware information from Megabyte to Gigabyte (for RAM) and from Megaherz to Gigaherz for CPU
+
+The meaning of the fields following fields has changed:
+
+Before:
+
+* `CPU (MHz)`
+* `RAM (MB)`
+
+After:
+
+* `CPU (GHz)`
+* `RAM (GB)`
+
+LanSuite is not taking care about the update of your data.
+Please go to the Server module and change the CPU and RAM values for your servers manually.


### PR DESCRIPTION
### What is this PR doing?

* [Server] Switched database class to prepared statements
* [Server] Fix typo
* [Server] Show only servers for the current party (if you are not an admin)
* [Server] Switch Server hardware from Megabyte to Gigabyte (for RAM) and from Megaherz to Gigaherz for CPU
* [Server] Add new server type "Voice"
* [Server] Avoid Port-Check if no port is given

### Breaking change

> * [Server] Switch Server hardware from Megabyte to Gigabyte (for RAM) and from Megaherz to Gigaherz for CPU

It is a breaking change. We use the same field but change the order of magnitude.
Existing values might look wired.
However, I decided not to create a new field but rather mark this in the upgrade guide.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update