### PR TITLE
Documentation: Add a page about the users of LanSuite

### DIFF
--- a/website/docs/other/_category_.json
+++ b/website/docs/other/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Other",
+  "position": 4,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/website/docs/other/users.md
+++ b/website/docs/other/users.md
@@ -1,0 +1,34 @@
+---
+id: users
+title: Users of LanSuite
+sidebar_position: 1
+---
+
+## Who is using LanSuite?
+
+This is an incomplete list of sites that using the LanSuite system.
+
+If you are using LanSuite and want to appear in this list, head over to our [ticket system and let us know via a new ticket](https://github.com/lansuite/lansuite/issues) or join our [Discord Community](https://discord.gg/3wkDqGmrFZ).
+
+## Users
+
+* Netsession: https://www.netsession.net/
+* Fraghouse: https://fraghouse.at/lanparty/
+* FH Joanneum: https://lansuite.fhlan.info/
+* Haag-networX: https://www.haag-networx.at/
+* Berg-LAN: https://berg-lan.de/
+* GyBraLAN:RE / LunaLAN: https://gybralanre.de/
+* PsychoLANPartys: https://www.psycholanpartys.org/
+* lansin: https://www.lansin.de/lansuite/
+* Synergy Lan: https://synergy-lan.de/
+* C-LAN-SAP: https://lan.clansap.org/
+* MUFA LAN: https://lan.erdbeermilch.de/
+* X-Treme LAN: https://www.xtrlan.net/
+* GameFarm: https://lan.gamefarm.at/
+* Vision LAN: https://vision-lan.de/
+* Elite LAN: http://www.elite-lan.net/
+* LanHub: https://lanhub.nopnerd.net/
+* Beer at LAN: https://www.bal-clan.at/lansuite/
+* Lanwa[h]n: https://www.lanwahn.at/
+* Computer Club Striegistal e.V.: https://cc-striegistal.de/
+* Fun at LAN: https://www.fun-at-lan.de/

--- a/website/docs/other/users.md
+++ b/website/docs/other/users.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 This is an incomplete list of sites that using the LanSuite system.
 
-If you are using LanSuite and want to appear in this list, head over to our [ticket system and let us know via a new ticket](https://github.com/lansuite/lansuite/issues) or join our [Discord Community](https://discord.gg/3wkDqGmrFZ).
+If you are using LanSuite and want to appear in this list, head over to our [ticket system and let us know via a new ticket](https://github.com/lansuite/lansuite/issues) or join our [Discord Community](https://discord.gg/3wkDqGmrFZ) or raise a Pull Request for a change on this file yourself.
 
 ## Users
 


### PR DESCRIPTION


### What is this PR doing?

Showcase the users of LanSuite. See https://github.com/lansuite/lansuite/issues/312

### Which issue(s) this PR fixes:

Fixes #312

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update