### PR TITLE
Fix namespacing issue for Smarty

### DIFF
--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -3,6 +3,7 @@
 namespace LanSuite;
 
 use Symfony\Component\HttpFoundation\Request;
+use Smarty\Smarty;
 
 class Framework
 {


### PR DESCRIPTION
### What is this PR doing?

Adds inclusion of `Smarty\Smarty`, as otherwise namespacing is incorrect for type definition on private attribute `$templateEngine` and method `public function setTemplateEngine(\Smarty $engine): void`

### Which issue(s) this PR fixes:

Currently broken master

### Checklist

- [x] ~`CHANGELOG.md` entry~ not needed, bugfix for regression
- [x] ~Documentation update~ not needed, bugfix for regression