### PR TITLE
Fixed type mismatch with index.php

### DIFF
--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -110,7 +110,7 @@ class Framework
     /**
      * Smarty templating engine
      */
-    private \Smarty $templateEngine;
+    private \Smarty\Smarty $templateEngine;
 
     /**
      * Debugging object
@@ -167,7 +167,7 @@ class Framework
     /**
      * Set the template engine
      */
-    public function setTemplateEngine(\Smarty $engine): void
+    public function setTemplateEngine(\Smarty\Smarty $engine): void
     {
         $this->templateEngine = $engine;
     }


### PR DESCRIPTION
And I am a moron and was served a stale page and considered this done

### What is this PR doing?

Fixes prior issue with type mismatch. 
Considered this done, checked index page, then though inclusion through `use \Smarty\Smarty` would be better, modified code and reloaded page.
But modification was not saved and thus I broke it all the same, but different ;)


### Which issue(s) this PR fixes:

Prior issue. Really now.

### Checklist

- [ ] ~`CHANGELOG.md` entry~
- [ ] ~Documentation update~