### PR TITLE
[Framework] Remove private class variable `framework_messages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Server] Changed CPU and RAM Unit of measure from Mega to Giga in Server hardware information
 - [Server] Limited visibility for non-Admins to active party
 - [Captcha] Replaced ASCII-Captcha with a graphical captcha
+- [Templating] Removed variable `$MainFrameworkmessages`
 
 ### Deprecated
 

--- a/design/beamer/main.htm
+++ b/design/beamer/main.htm
@@ -36,7 +36,6 @@
 
 <div id="BoxesLeft">{$MainLeftBox}</div>
 <div id="{$MainContentStyleID}">
-  {$MainFrameworkmessages}
   {$MainContent}
   <br />
   <div id="Footer">{$Footer}</div>

--- a/design/beamer/templates/main.htm
+++ b/design/beamer/templates/main.htm
@@ -36,7 +36,6 @@
 
 <div id="BoxesLeft">{$MainLeftBox}</div>
 <div id="{$MainContentStyleID}">
-  {$MainFrameworkmessages}
   {$MainContent}
   <br />
   <div id="Footer">{$Footer}</div>

--- a/design/osX/templates/main.htm
+++ b/design/osX/templates/main.htm
@@ -58,7 +58,6 @@
             <td valign="top" width="8" style="background:url(design/osX/images/menu_content_ml.gif) repeat-y"></td>
             <td valign="top" align="left" id="LScontent" bgcolor="#E8E7E7">
     <div id="{$MainContentStyleID}">
-        {$MainFrameworkmessages}
         {$MainContent}
     </div>
       </td>

--- a/design/simple/templates/main.htm
+++ b/design/simple/templates/main.htm
@@ -45,7 +45,6 @@
 {/if}
 
 <div id="{$MainContentStyleID}">
-  {$MainFrameworkmessages}
   {$MainContent}
   <br />
   <div id="Footer">{$Footer}</div>

--- a/design/sunset/templates/main.htm
+++ b/design/sunset/templates/main.htm
@@ -62,7 +62,6 @@
         <tr class="content">
             <td colspan="2" id="LScontent">
         <div id="{$MainContentStyleID}">
-            {$MainFrameworkmessages}
             {$MainContent}
         </div>
       </td>

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -24,11 +24,6 @@ class Framework
     private string $design = '';
 
     /**
-     * All framework messages
-     */
-    private string $framework_messages = '';
-
-    /**
      * Main Content
      */
     private string $mainContent = '';
@@ -386,7 +381,6 @@ ga('send', 'pageview');
         $this->templateEngine->assign('MainRightBox', '');
         $this->templateEngine->assign('Footer', '');
         $this->templateEngine->assign('CloseFullscreen', '');
-        $this->templateEngine->assign('MainFrameworkmessages', $this->framework_messages);
         $this->templateEngine->assign('Design', $this->getDesign());
         $this->templateEngine->assign('MainDebug', '');
         $this->templateEngine->assign('MainContentStyleID', $mainContentStyleID);

--- a/website/docs/guides/guides-upgrade.md
+++ b/website/docs/guides/guides-upgrade.md
@@ -235,3 +235,9 @@ After:
 
 LanSuite is not taking care about the update of your data.
 Please go to the Server module and change the CPU and RAM values for your servers manually.
+
+### Templating: Removed variable `$MainFrameworkmessages`
+
+If you use a custom or modified template, please go to your design (in your `/design/<name/` folder) and remove all occurrences of the variable `$MainFrameworkmessages.`
+
+This variable is no longer provided / replaced by LanSuite.


### PR DESCRIPTION
### What is this PR doing?

[Framework] Remove private class variable `framework_messages`

Mainly, because this was not used.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update