### PR TITLE
[MasterSearch2] Fix wrong number of rows found

### DIFF
--- a/modules/mastersearch2/Classes/MasterSearch2.php
+++ b/modules/mastersearch2/Classes/MasterSearch2.php
@@ -559,7 +559,7 @@ class MasterSearch2
 
         // Generate Page-Links
         $count_pages = 0;
-        $count_rows = $database->queryWithOnlyFirstRow('SELECT FOUND_ROWS() AS count');
+        $count_rows = $db->qry_first('SELECT FOUND_ROWS() AS count');
         if ($this->config['EntriesPerPage'] > 0) {
             $count_pages = ceil($count_rows['count'] / $this->config['EntriesPerPage']);
         }


### PR DESCRIPTION
### What is this PR doing?

[MasterSearch2] Fix wrong number of rows found

The issue: `FOUND_ROWS` refers to the last SQL statement, which is made with the old DB class. This query can't be easily switched over to the new DB class, due the current usage.

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed