### PR TITLE
[Tournament2] Fix "Parse error: syntax error, unexpected double-quotemark, expecting "-" or identifier or variable or number in /modules/tournament2/tree.php on line 56"

### DIFF
--- a/modules/tournament2/tree.php
+++ b/modules/tournament2/tree.php
@@ -52,9 +52,6 @@ if (!$_GET['tournamentid']) {
                 }
                 if (($tournament["mode"] == "groups") && $groupParameter === false) {
                     $teams = $database->queryWithOnlyFirstRow("
-  
-                if (($tournament["mode"] == "groups") && (!$groupParameter)) {
-                    $teams = $database->queryWithOnlyFirstRow("
                       SELECT
                         MAX(group_nr) AS max_group_nr
                       FROM %prefix%t2_games


### PR DESCRIPTION
### What is this PR doing?

[Tournament2] Fix "Parse error: syntax error, unexpected double-quotemark, expecting "-" or identifier or variable or number in /modules/tournament2/tree.php on line 56"

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed