### PR TITLE
[Shoutbox] Fix PHP warnings

### DIFF
--- a/modules/shoutbox/boxes/shoutbox.php
+++ b/modules/shoutbox/boxes/shoutbox.php
@@ -9,6 +9,10 @@ if (!$auth['userid']) {
     $userid = $auth['userid'];
 }
 
+$shoutDelay = $cfg['shout_delay'] ?? 20;
+$shoutEntries = $cfg['shout_entries'] ?? 5;
+$shoutLength = $cfg['shout_length'] ?? 160;
+
 $framework->addJavaScriptCode('var shoutdelay = ' . intval($shoutDelay) . ';
                         var maxcount = ' . intval($shoutEntries) . ';');
 

--- a/modules/shoutbox/docu/de_help.php
+++ b/modules/shoutbox/docu/de_help.php
@@ -7,5 +7,6 @@ $helplet['info'] = 'Ein kleiner Minicat auf Ajax Basis.';
 $helplet['key'][1] = 'Allgemeines';
 $helplet['value'][1] = 'Die Shoutbox aktualisiert sich selbständig im Hintergrund.';
 
+$shoutEntries = $cfg['shout_entries'] ?? 5;
 $helplet['key'][2] = 'Einträge';
-$helplet['value'][2] = 'Es werde derzeit immer die letzten '.$cfg['shout_entries'].' Einträge angezeigt. Der Wert kann in der Konfiguration geändert werden.';
+$helplet['value'][2] = 'Es werde derzeit immer die letzten ' . $shoutEntries . ' Einträge angezeigt. Der Wert kann in der Konfiguration geändert werden.';


### PR DESCRIPTION
### What is this PR doing?

[Shoutbox] Fix PHP warnings

Somehow, those got lost in the codebase while merging + resolving conflicts.
These are the lines previously introduced: https://github.com/lansuite/lansuite/commit/3154cda6b1856a683e9efd534c0b6870e55c4acc#diff-428113b8c26a45711199b45cb58e726707b5682d8b539172c2ab4e32592cea9b

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed