### PR TITLE
Fix #1093: PHP Warnings in Security and Database class

### DIFF
--- a/inc/Classes/DB.php
+++ b/inc/Classes/DB.php
@@ -110,7 +110,7 @@ class DB
         $pass = $config['database']['passwd'];
         $database = $config['database']['database'];
         $port = $config['database']['dbport'] ?? 3306;
-        $charset = $config['database']['charset'];
+        $charset = $config['database']['charset'] ?? '';
         $sqlmode = '';
         if (array_key_exists('sqlmode', $config['database'])) {
             $sqlmode = $config['database']['sqlmode'];

--- a/inc/Classes/Security.php
+++ b/inc/Classes/Security.php
@@ -23,13 +23,7 @@ class Security
             }
 
             $database->query('DELETE FROM %prefix%ip_hits WHERE (date + ?) < NOW()', [$cfg["reload_time"]]);
-            $db->qry(
-                'INSERT INTO %prefix%ip_hits SET ip = INET6_ATON(%string%)',
-                $_SERVER['REMOTE_ADDR'],
-                $_GET["mod"],
-                $_GET["action"],
-                $_GET["step"]
-            );
+            $database->query('INSERT INTO %prefix%ip_hits SET ip = INET6_ATON(?)', [$_SERVER['REMOTE_ADDR']]);
 
             $ip_hits = $database->queryWithOnlyFirstRow('
               SELECT COUNT(*) AS hits 


### PR DESCRIPTION
### What is this PR doing?

The database table `ip_hits` does not have fields for the module, action or step.
Hence, the parameters never served a value.

### Which issue(s) this PR fixes:

Fixes #1093

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed