### PR TITLE
Update README.md with permanent discord link

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -100,6 +100,9 @@ Um diese API Dokumentation im HTML-Format zu generieren, kann [phpDocumentor](ht
 $ composer install
 $ bin/phpdoc run --progressbar -t ./docs/
 ```
+## Discord Community
+
+Schaut auch gerne in Discord vorbei: [https://discord.gg/3wkDqGmrFZ](https://discord.gg/3wkDqGmrFZ).
 
 ## Ähnliche Projekte
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This way, it is transparent to the community, and all team members and contribut
 
 ## Discord Community
 
-Join the community today: [https://discord.gg/xbZjkjyF](https://discord.gg/xbZjkjyF).
+Join the community today: [https://discord.gg/h6kSFZengh](https://discord.gg/h6kSFZengh).
 
 ## Similar projects
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This way, it is transparent to the community, and all team members and contribut
 
 ## Discord Community
 
-Join the community today: [https://discord.gg/h6kSFZengh](https://discord.gg/h6kSFZengh).
+Join the community today: [https://discord.gg/3wkDqGmrFZ](https://discord.gg/3wkDqGmrFZ).
 
 ## Similar projects
 


### PR DESCRIPTION
### What is this PR doing?
Link in readme.md was time-limited and different from website documentation, now changed to correct perma-link.
Also added a note to german readme

### Which issue(s) this PR fixes:

Fixes #
none

### Checklist

- ~[ ] `CHANGELOG.md` entry~
- [x] Documentation update