### PR TITLE
Adds an icon to box to update account check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Discord] Introduced a new module to manage Discord Servers
 - [Party] Add information `Gesamt` in the Party box to show how many people can sign up for a party
 - [Party] Added ability to switch party in internet system for admins
+- [Party] Added ability to trigger account check update from display box
 - [Birthday] New module to show users birthdays
 - [Hall of fame] New module to present all tournament winners in a Hall of Fame
 - [Server] Added Voice as server type

--- a/modules/party/boxes/signonstatus.php
+++ b/modules/party/boxes/signonstatus.php
@@ -151,7 +151,11 @@ if ($cfg['sys_internet']) {
 
         $checked = $database->queryWithOnlyFirstRow("SELECT UNIX_TIMESTAMP(checked) AS n FROM %prefix%partys WHERE party_id = ?", [$party->party_id]);
         $box->EmptyRow();
-        $box->ItemRow("data", "<b>". t('Letzter Kontocheck') ."</b>");
+        $updateIcon = '';
+        if ($auth && $auth['type'] >= \LS_AUTH_TYPE_ADMIN) {
+            $updateIcon = $dsp->FetchIcon('change', 'index.php?mod=guestlist&action=checking', t('Aktualisieren'));
+        }
+        $box->ItemRow("data", "<b>". t('Letzter Kontocheck') ."</b>" . $updateIcon);
         $box->EngangedRow($func->unixstamp2date($checked['n'], "datetime"));
     }
 }


### PR DESCRIPTION
### What is this PR doing?

Allows admins to directly update account check date from the box where the date is displayed

### Which issue(s) this PR fixes:

Fixes #none

### Checklist

- [x] `CHANGELOG.md` entry
- [ ] Documentation update