### PR TITLE
docker-compose: Fix docker-compose.yml: `version` is obsolete

### DIFF
--- a/docker-compose.dump.yml
+++ b/docker-compose.dump.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     mysql:
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     web:
         image: nginx:1.25.3-alpine


### PR DESCRIPTION
### What is this PR doing?

docker-compose: Fix docker-compose.yml: `version` is obsolete

See https://github.com/nextcloud/docker/issues/2194

### Which issue(s) this PR fixes:

None

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed