### PR TITLE
Fix #1131: Restrict display of PHP warnings to (Super-)Admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Community] Created a discord community
 - [PDF] In-Module Documentation
 - [PDF] New options "align" and "border" to configure for a single PDF document
+- [System] Restrict display of PHP warnings to (Super-)Admins (#1131)
 
 ### Changed
 

--- a/index.php
+++ b/index.php
@@ -356,6 +356,14 @@ if ($config['environment']['configured'] == 0) {
     $olduserid = $authentication->get_olduserid();
 }
 
+// If the current user is not an admin, we suppress PHP warnings
+// We keep them for Admins and Superadmins, because they might be interested in a fully functional system.
+// We assume those errors get reported back to the developers.
+if ($auth['type'] < \LS_AUTH_TYPE_ADMIN) {
+    $errorlevel = error_reporting();
+    error_reporting($errorlevel & ~E_WARNING);
+}
+
 // Initialize party
 // Needed also, when not configured for LanSuite Import
 if ($func->isModActive('party')) {


### PR DESCRIPTION
### What is this PR doing?

Surpresses PHP-Warnings if the user auth level is below Admin.

### Which issue(s) this PR fixes:

Fixes #1131

### Checklist

- [X] `CHANGELOG.md` entry
- [X] Documentation update - Not needed