### PR TITLE
Fix #1128: Fix PHP Warnings in News module

### DIFF
--- a/inc/Classes/Func.php
+++ b/inc/Classes/Func.php
@@ -701,7 +701,12 @@ class Func
             echo("Error: Function page_split needs defined: current_page, max_entries_per_page,working_link, page_varname For more information please visit the lansuite programmers docu");
         }
 
-        return [];
+        return [
+            'html' => '',
+            'sql' => '',
+            'a' => 0,
+            'b' => 0,
+        ];
     }
 
     /**


### PR DESCRIPTION
### What is this PR doing?

Fixing two PHP Warnings in the News Archive

### Which issue(s) this PR fixes:

Fixes #1128

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed