### PR TITLE
Fix #1130: Fix PHP Warnings in Wiki module

### DIFF
--- a/modules/wiki/edit.php
+++ b/modules/wiki/edit.php
@@ -1,6 +1,7 @@
 <?php
 
 $_GET['mf_id'] = '1';
+$masterFormStepParameter = $_GET['mf_step'] ?? null;
 
 $nextVersionId = 0;
 $row = $database->queryWithOnlyFirstRow('
@@ -20,7 +21,7 @@ if ($row['found']) {
       WHERE
         postid = ?
         AND versionid = ?', [$_GET['postid'], $row['versionid']]);
-    if ($_GET['mf_step'] != 2) {
+    if ($masterFormStepParameter != 2) {
         $_POST['text'] = $row['text'];
     }
 }
@@ -49,7 +50,7 @@ $mf->AddFix('postid', $_GET['postid']);
 $mf->AddFix('versionid', $nextVersionId);
 
 $mf->SendForm('index.php?mod=wiki&amp;action='. $_GET['action'] .'&postid='. $_GET['postid'], 'wiki_versions');
-if ($_GET['mf_step'] == '2') {
+if ($masterFormStepParameter == '2') {
     $_GET['action'] = 'show';
     include_once('modules/wiki/show.php');
 }

--- a/modules/wiki/show.php
+++ b/modules/wiki/show.php
@@ -1,10 +1,13 @@
 <?php
 
-if ($_GET['name']) {
+$nameParameter = $_GET['name'] ?? '';
+if ($nameParameter) {
     $row = $database->queryWithOnlyFirstRow('SELECT postid FROM %prefix%wiki WHERE name = ?', [$_GET['name']]);
     $_GET['postid'] = $row['postid'];
 }
-if (!$_GET['postid']) {
+
+$postIDParameter = $_GET['postid'] ?? null;
+if (!$postIDParameter) {
     $_GET['postid'] = 1;
 }
 if (!isset($_GET['versionid'])) {


### PR DESCRIPTION
### What is this PR doing?

Fix #1130: Fix PHP Warnings in Wiki module

### Which issue(s) this PR fixes:

Fixes #1130

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed