### PR TITLE
Fix #1138: Fix PHP Warnings in module usrmgr, when deleting a user

### DIFF
--- a/modules/usrmgr/Functions/CheckDeleteUser.php
+++ b/modules/usrmgr/Functions/CheckDeleteUser.php
@@ -22,12 +22,16 @@ function CheckDeleteUser($userid)
 
     if ($auth['type'] == \LS_AUTH_TYPE_ADMIN and $get_data["type"] >= 2) {
         $func->error(t('Du hast nicht die erforderlichen Rechte, um einen Admin zu löschen'), "index.php?mod=usrmgr");
-    } elseif ($get_party_data["found"]) {
+
+    } elseif (is_array($get_party_data) && $get_party_data["found"]) {
         $func->error(t('Dieser Benutzer ist noch zu einer Party angemeldet. Melden sie ihn zuerst ab'), "index.php?mod=usrmgr");
+
     } elseif ($get_data["type"] < 0) {
         $func->error(t('Dieser Benutzer wurde bereits gelöscht'), "index.php?mod=usrmgr");
+
     } elseif ($auth["userid"] == $userid) {
         $func->error(t('Du kannst dich nicht selbst löschen'), "index.php?mod=usrmgr");
+
     } else {
         $database->query("UPDATE %prefix%seat_seats SET status = '1', userid = '0' WHERE userid = ?", [$userid]);
         return true;


### PR DESCRIPTION
### What is this PR doing?

Fix #1138: Fix PHP Warnings in module usrmgr, when deleting a user

### Which issue(s) this PR fixes:

Fixes #1138

### Checklist

- [X] `CHANGELOG.md` entry - Not needed
- [X] Documentation update - Not needed