### PR TITLE
Extract and provide per-module upgrade capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [System] Introduced symfony/cache to easily provide other cache backends like APCu (next to file caching)
 - [System] Introduced symfony/http-foundation to unify safe access to superglobals
 - [Database] Added the setting to replace the hardcoded database table prefix `lansuite_` with something admin configurable
-- [Database] Introduced options to update single module DB structure (#927)
+- [Database] Introduced options to update single module DB structure (#927), menu entries and permissions (#1187)
 - [Tournament] Added tournament icon for Starcraft II
 - [Tournament] Added tournament icon for Counter-Strike: Global Offensive
 - [Tournament] Added tournament icon for Rocket League
@@ -75,6 +75,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [System] Separated Google API-Keys for Analytics, Maps and Translate into dedicated settings (#887)
 - [System] Don't enforce php-snmp; only suggest it (#148)
 - [System] Added unique id per installation to `config.php` for cache pool separation (#1141)
+- [System] Add separate Class for module configuration
 - [Cron] Show execution state, runtime and error, deactvate after 3 failed executions (#924)
 - [System] Updated jQuery to v3.7.1 and jQuery UI to v1.13.2
 - [Database] Set utf8mb4 as the default charset

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -553,63 +553,14 @@ class Install
             if ($func->isModActive($module)) {
                 $menu_found = $database->queryWithOnlyFirstRow("SELECT 1 AS found FROM %prefix%menu WHERE module = ?", [$module]);
                 if (!$menu_found) {
-                    $file = "modules/$module/mod_settings/menu.xml";
-                    if (file_exists($file)) {
-                        $handle = fopen($file, "r");
-                        $xml_file = fread($handle, filesize($file));
-                        fclose($handle);
-
-                        $menu = $xml->get_tag_content("menu", $xml_file);
-                        $main_pos = $xml->get_tag_content("pos", $menu);
-                        $entrys = $xml->get_tag_content_array("entry", $menu);
-
-                        $i = 0;
-                        foreach ($entrys as $entry) {
-                            $action = $xml->get_tag_content("action", $entry);
-                            $file = $xml->get_tag_content("file", $entry);
-                            $caption = $xml->get_tag_content("caption", $entry);
-                            $hint = $xml->get_tag_content("hint", $entry);
-                            $link = $xml->get_tag_content("link", $entry);
-                            $requirement = $xml->get_tag_content("requirement", $entry);
-                            $level = $xml->get_tag_content("level", $entry);
-                            $needed_config = $xml->get_tag_content("needed_config", $entry);
-
-                            if ($file == "") {
-                                $file = $action;
-                            }
-                            if (!$level) {
-                                $level = 0;
-                            }
-                            if (!$requirement) {
-                                $requirement = 0;
-                            }
-
-                            ($level == 0)? $pos = $main_pos : $pos = $i;
-                            $i++;
-
-                            $database->query(
-                                "INSERT INTO %prefix%menu SET module = ?, action = ?, file = ?, caption = ?, hint = ?, link = ?, requirement = ?, level = ?, pos = ?, needed_config = ?, boxid = ?",
-                                [$module,
-                                $action,
-                                $file,
-                                $caption,
-                                $hint,
-                                $link,
-                                $requirement,
-                                $level,
-                                $pos,
-                                $needed_config,
-                                $menubox['boxid']]
-                            );
-                        }
-                    }
+                    $moduleConfig = new ModuleConfig();
+                    $moduleConfig->writeModuleMenu($module);
                 }
             }
         }
     }
 
-
-    /**
+     /**
      * Check the general env for installation.
      *
      * @return int
@@ -982,7 +933,7 @@ class Install
 
             $find_mod = $database->queryWithOnlyFirstRow("SELECT module FROM %prefix%menu WHERE module = ?", [$row["name"]]);
             if (is_array($find_mod) && $find_mod["module"]) {
-                $menu_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=30&module={$row["name"]}\">". t('Menü') ."</a>";
+                $menu_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=30&module={$row["name"]}&tab=1\">". t('Menü') ."</a>";
             } else {
                 $menu_link = "";
             }

--- a/modules/install/Classes/ModuleConfig.php
+++ b/modules/install/Classes/ModuleConfig.php
@@ -75,9 +75,7 @@ public function disable(string $moduleName) : bool
      */
     public function updateModuleTables(string $moduleName = null) : void
     {
-        $importXml = new \LanSuite\XML();
-        $installImport = new \LanSuite\Module\Install\Import($importXml);
-        $install = new \LanSuite\Module\Install\Install($installImport);
+        $install = new \LanSuite\Module\Install\Install();
         $install->WriteTableFromXMLFile($moduleName, 1);
     }
 

--- a/modules/install/Classes/ModuleConfig.php
+++ b/modules/install/Classes/ModuleConfig.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace LanSuite\Module\Install;
+
+/**
+ * Class to handle module specific functions currently distributed everywhere in the code.
+ * Separate "Module" class may come later to deal with this on a one-object-per-module basis
+ */
+class ModuleConfig
+{
+
+    private \LanSuite\Database $database;
+
+    public function __construct( \LanSuite\Database &$database = null)
+    {
+        if($database) {
+            // Use provided DB adaptor if existing, use LS standard global obj otherwise
+            $this->database = &$database;
+            return;
+        }
+            global $database;
+            $this->database = &$database;
+    }
+
+    /**
+     * Enables/activates a module based on the name
+     *
+     * @param string $moduleName The name of the module to be enabled
+     */
+public function enable(string $moduleName) : bool
+    {
+        $this->database->query("UPDATE %prefix%modules SET active = 1 WHERE name = ?", [$moduleName]);
+    }
+
+    /**
+     * Disables a module based on the name
+     *
+     * @param string $moduleName The name of the module to be disabled
+     */
+public function disable(string $moduleName) : bool
+    {
+        $this->database->query("UPDATE %prefix%modules SET active = 0 WHERE name = ?", [$moduleName]);
+    }
+
+    /**
+     * Returns the activation state of the module given by name
+     *
+     * @param string $moduleName The name of the module to be disabled
+     */
+    public function getStatus(string $moduleName) : bool
+    {
+
+        $moduleStatus= $this->database->queryWithOnlyFirstRow('SELECT active FROM %prefix%modules WHERE name = ?', [$moduleName]);
+        return $moduleStatus['active'];
+    }
+
+    /**
+     * Returns list of modules defined in the database
+     *
+     * @param bool|null $filterState Determines if modules with a given state will be returned or all of them if left empty
+     */
+    public function getModules(bool|null $filterState = null) : array
+    {
+        $where = '';
+        if ($filterState) {
+            $where = ' WHERE active = ' . (int) $filterState;
+        }
+        return $this->database->queryWithFullResult('SELECT `name`, description, active, changeable, `version`, `state`  FROM %prefix%modules'. $where);
+    }
+
+    /**
+     * Triggers DB update for the mdoule
+     *
+     * @param string $moduleName Name of the module to update
+     */
+    public function updateModuleTables(string $moduleName = null) : void
+    {
+        $importXml = new \LanSuite\XML();
+        $installImport = new \LanSuite\Module\Install\Import($importXml);
+        $install = new \LanSuite\Module\Install\Install($installImport);
+        $install->WriteTableFromXMLFile($moduleName, 1);
+    }
+
+    /**
+     * (Over-)Writes Menu entries for a given module
+     *
+     * @param string $moduleName The name of the module to be written
+     *
+     */
+    public function writeModuleMenu($moduleName='')
+    {
+        global $database;
+        $xml = new \LanSuite\XML();
+        $file = "modules/$moduleName/mod_settings/menu.xml";
+        if (file_exists($file)) {
+            $handle = fopen($file, "r");
+            $xml_file = fread($handle, filesize($file));
+            fclose($handle);
+
+            $menu = $xml->get_tag_content("menu", $xml_file);
+            $main_pos = $xml->get_tag_content("pos", $menu);
+            $entrys = $xml->get_tag_content_array("entry", $menu);
+
+            //successfully read out file, clean up existing entries
+            $database->query('DELETE FROM %prefix%menu WHERE module = ?', [$moduleName]);
+            //obtain ID of box that contains the navigation menu
+            $menubox = $database->queryWithOnlyFirstRow('SELECT boxid FROM %prefix%boxes WHERE source = \'menu\' AND active = 1');
+
+            //iterate through all entries and write them
+            $i = 0;
+            foreach ($entrys as $entry) {
+                $action = $xml->get_tag_content("action", $entry);
+                $file = $xml->get_tag_content("file", $entry);
+                $caption = $xml->get_tag_content("caption", $entry);
+                $hint = $xml->get_tag_content("hint", $entry);
+                $link = $xml->get_tag_content("link", $entry);
+                $requirement = $xml->get_tag_content("requirement", $entry);
+                $level = $xml->get_tag_content("level", $entry);
+                $needed_config = $xml->get_tag_content("needed_config", $entry);
+
+                if ($file == "") {
+                    $file = $action;
+                }
+                if (!$level) {
+                    $level = 0;
+                }
+                if (!$requirement) {
+                    $requirement = 0;
+                }
+
+                ($level == 0)? $pos = $main_pos : $pos = $i;
+                $i++;
+
+                $database->query(
+                    "INSERT INTO %prefix%menu SET module = ?, action = ?, file = ?, caption = ?, hint = ?, link = ?, requirement = ?, level = ?, pos = ?, needed_config = ?, boxid = ?",
+                    [$moduleName,
+                    $action,
+                    $file,
+                    $caption,
+                    $hint,
+                    $link,
+                    $requirement,
+                    $level,
+                    $pos,
+                    $needed_config,
+                    $menubox['boxid']]
+                );
+            }
+        } else {
+            echo('module.xml für modul nicht gefunden');
+        }
+    }
+}

--- a/modules/install/Classes/ModuleConfig.php
+++ b/modules/install/Classes/ModuleConfig.php
@@ -2,6 +2,9 @@
 
 namespace LanSuite\Module\Install;
 
+use Error;
+use Exception;
+
 /**
  * Class to handle module specific functions currently distributed everywhere in the code.
  * Separate "Module" class may come later to deal with this on a one-object-per-module basis
@@ -88,6 +91,11 @@ public function disable(string $moduleName) : bool
     public function writeModuleMenu($moduleName='')
     {
         global $database;
+
+        if (!ctype_alnum($moduleName)){
+            throw new Exception(t('Ungültiger Modulname "%1" angegeben'));
+        }
+
         $xml = new \LanSuite\XML();
         $file = "modules/$moduleName/mod_settings/menu.xml";
         if (file_exists($file)) {
@@ -145,7 +153,7 @@ public function disable(string $moduleName) : bool
                 );
             }
         } else {
-            echo('module.xml für modul nicht gefunden');
+            throw new Exception(t('Datei menu.xml wurde für Modul "%1" nicht gefunden', $moduleName));
         }
     }
 }

--- a/modules/install/mod_cfg.php
+++ b/modules/install/mod_cfg.php
@@ -177,6 +177,8 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
                 'id',
                 "module = '". $_GET['module'] ."' AND caption != ''"
             );
+            $dsp->AddDoubleRow('', $dsp->FetchSpanButton(t('Menü neu schreiben'), 'index.php?mod=install&action=modules&step=25&module='. $_GET['module'] .'&tab=3'));
+
             $dsp->EndTab();
 
             $dsp->StartTab(t('Datenbank'), 'database');
@@ -324,6 +326,8 @@ if (!is_dir('modules/'. $_GET['module'] .'/mod_settings')) {
 
             $mf->SendForm('', 'menu', 'id', "module = '". $_GET['module'] ."' AND caption != ''");
             $dsp->AddDoubleRow('', $dsp->FetchSpanButton(t('Link hinzufügen'), 'index.php?mod=install&action=mod_cfg&step=31&module='. $_GET['module'] .'&tab=3'));
+            $dsp->AddDoubleRow('', $dsp->FetchSpanButton(t('Menü neu schreiben'), 'index.php?mod=install&action=modules&step=25&module='. $_GET['module'] .'&tab=3'));
+
             $dsp->EndTab();
 
             $dsp->StartTab(t('Übersetzung'), 'translate');

--- a/modules/install/modules.php
+++ b/modules/install/modules.php
@@ -1,5 +1,7 @@
 <?php
 
+use LanSuite\Module\Install\ModuleConfig;
+
 $install = new \LanSuite\Module\Install\Install();
 
 $stepParameter = $_GET["step"] ?? 0;
@@ -23,7 +25,7 @@ switch ($stepParameter) {
         $database->query("UPDATE %prefix%modules SET active = 1 WHERE name = 'settings'");
         $database->query("UPDATE %prefix%modules SET active = 1 WHERE name = 'banner'");
         $database->query("UPDATE %prefix%modules SET active = 1 WHERE name = 'about'");
-        
+
         $install->CreateNewTables(0);
         $func->confirmation(t('Änderungen erfolgreich gespeichert.'), "index.php?mod=install&action=modules");
         break;
@@ -41,6 +43,7 @@ switch ($stepParameter) {
     // Add Menuentry
     case 22:
         $db->qry("INSERT INTO %prefix%menu SET caption = 'Neuer Eintrag', requirement = '0', hint = '', link = 'index.php?mod=', needed_config = '', module=%string%, level = 1", $_GET["module"]);
+        break;
 
     // Menuentries
     case 20:
@@ -73,18 +76,20 @@ switch ($stepParameter) {
     case 21:
         foreach ($_POST["caption"] as $key => $val) {
             $boxId = $_POST["boxid"][$key] ?? 0;
-            $db->qry(
-                "UPDATE %prefix%menu SET caption = %string%, requirement = %string%, action = %string%, hint = %string%, link = %string%, file = %string%, pos = %string%, boxid = %int%, needed_config = %string% WHERE id = %int%",
-                $_POST["caption"][$key],
-                $_POST["requirement"][$key],
-                $_POST["action"][$key],
-                $_POST["hint"][$key],
-                $_POST["link"][$key],
-                $_POST["file"][$key],
-                $_POST["pos"][$key],
-                $boxId,
-                $_POST["needed_config"][$key],
-                $key
+            $database->query(
+                "UPDATE %prefix%menu SET caption = ?, requirement = ?, action = ?, hint = ?, link = ?, file = ?, pos = ?, boxid = ?, needed_config = ? WHERE id = ?",
+                [
+                    $_POST["caption"][$key],
+                    $_POST["requirement"][$key],
+                    $_POST["action"][$key],
+                    $_POST["hint"][$key],
+                    $_POST["link"][$key],
+                    $_POST["file"][$key],
+                    $_POST["pos"][$key],
+                    $boxId,
+                    $_POST["needed_config"][$key],
+                    $key
+                ]
             );
         }
 
@@ -102,6 +107,15 @@ switch ($stepParameter) {
         }
         break;
 
+    // rewrite module menu for defined module
+    case 25:
+        if (array_key_exists('module', $_GET) && $_GET['module'])
+        {
+            $moduleConfig = new ModuleConfig();
+            $moduleConfig->writeModuleMenu($_GET['module']);
+            $func->confirmation(t('Die Menüeinträge für Modul %1 wurden erfolgreich neu geschrieben', $_GET['module']));
+        }
+        break;
 
     // Show Modulelist
     default:

--- a/website/docs/guides/guides-upgrade.md
+++ b/website/docs/guides/guides-upgrade.md
@@ -94,6 +94,14 @@ Please check the upgrade guide to your specific version below.
 Visit "Admin-Page" -> "Lansuite updaten / reparieren" ->> "Datenbank updaten und verwalten".
 This is also available at `http(s)://<your-domain>/index.php?mod=install&action=db`.
 
+### Execute Rewrite of menu items and permissions
+
+Visit "Admin-Page" -> "Lansuite updaten / reparieren" ->> "Menüeinträge neu schreiben".
+This is also available at `http(s)://<your-domain>/index.php?mod=install&action=dbmenu`.
+This rewrites all menue entries and permissions.
+Keep in mind that this also resets any customizing done to the installation.
+You can also selectively update/reset each module in the related module settings
+
 ### Test your installation
 
 Now is the time to look if everything is as expected.


### PR DESCRIPTION
### What is this PR doing?

Provides new class in Install module named `ModuleConfig` to collect module configuration specific actions in one place
Extracts logic for module menu writing and provides functionality to write config for one menu only.
Adds documentation to run menu rewrite, as this is NOT done by setting configured = 0 and running the wizzard (which was tbd in scope of #893)

### Which issue(s) this PR fixes:

Fixes #893

### Checklist

- [x] `CHANGELOG.md` entry
- [x] Documentation update