### PR TITLE
Fixed issue that no admin user is created in wizzard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ We could not reconstruct _all_ changes, but we tried our best to make the most o
 - [Installation] Fixed dropdown to select the design
 - [Installation] Fixed Database error when going from step 2 to 1 in install wizzard (#871)
 - [Installation] Fixed compatibility with database names containing a hyphen (#1095)
+- [Installation] Fixed regression causing no admin user to be created (#1193)
 - [Home] Set module `home` as default if we don't have a module parameter
 - [Clanmgr] Only prefix clan URL with http:// if an URL was entered
 - [Clanmgr] Only prefix URL field with http:// for display when an URL exists

--- a/index.php
+++ b/index.php
@@ -434,7 +434,7 @@ function initializeDesign()
     }
 
     // Fallback design is 'simple'
-    if (!$auth['design'] || !file_exists('design/' . $auth['design'] . '/templates/main.htm')) {
+    if (!array_key_exists('design', $auth) || !file_exists('design/' . $auth['design'] . '/templates/main.htm')) {
         $auth['design'] = 'simple';
         if (!isset($_GET['design']) || ($_GET['design'] != 'popup' && $_GET['design'] != 'base')) {
             $design = 'simple';


### PR DESCRIPTION
### What is this PR doing?

fixes issue caused by too accurate comparison in `wizzard.php` after implementation of `$database`.

Installer checked if return value from `$database->queryWithOnlyFirstRow` was not type equal to `false`.
But the new class returns an empty array when no entry is found, which does not compare to boolean false.
Thus the installer ran the update case, which did nothing as no entry existed.

This is fixed by just comparing against `$row`, as that covers everything that is not an actual resultset

While I was at it also the related queries have been transferred to use `$database` and also some warning from index.php that popped up as warning.
Also transparent transfer after user creation to next step was implemented.

### Which issue(s) this PR fixes:

Fixes #1136, #1191

### Checklist

- [x] `CHANGELOG.md` entry
- [ ] ~Documentation update~