### PR TITLE
Fix jquery tabs default selector

### DIFF
--- a/inc/Classes/Display.php
+++ b/inc/Classes/Display.php
@@ -174,7 +174,7 @@ class Display
 
         $sel = '';
         if (array_key_exists('tab', $_GET) && $_GET['tab']) {
-            $sel = '{ selected: '. (int)$_GET['tab'] .' }';
+            $sel = '{ active: '. (int)$_GET['tab'] .' }';
         }
         $framework->addJavaScriptCode('$(function() { $("#tabs").tabs('. $sel .'); });');
 

--- a/modules/install/Classes/Install.php
+++ b/modules/install/Classes/Install.php
@@ -982,7 +982,7 @@ class Install
 
             $find_mod = $database->queryWithOnlyFirstRow("SELECT module FROM %prefix%menu WHERE module = ?", [$row["name"]]);
             if (is_array($find_mod) && $find_mod["module"]) {
-                $menu_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=30&module={$row["name"]}\">". t('Menü') ."</a>";
+                $menu_link = " | <a href=\"index.php?mod=install&action=mod_cfg&step=30&module={$row["name"]}&tab=3\">". t('Menü') ."</a>";
             } else {
                 $menu_link = "";
             }


### PR DESCRIPTION
### What is this PR doing?

The jQuery-UI property to select the default active tab has apparently been renamed from `selected` to `active`, which broke tab selection after the related update.
While fixing and testing that I noted that the direct link from Module config did not have the tab reference

### Which issue(s) this PR fixes:

Fixes #none

### Checklist

- [ ] ~`CHANGELOG.md` entry~ (fix of regression, so no change in perspective of 4.2)
- [ ] ~Documentation update~