### PR TITLE
feat: Ersetze FCKeditor durch TinyMCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ ext_inc/pdf_fonts/*.ttf
 ext_inc/pdf_templates/*
 !ext_inc/pdf_templates/background_usercard.jpg
 ext_inc/user_pics/*
+/ext_scripts/FCKeditor/

--- a/inc/Classes/Framework.php
+++ b/inc/Classes/Framework.php
@@ -138,6 +138,14 @@ class Framework
         $this->addJavaScriptFile('ext_scripts/jquery-min.js');
         $this->addJavaScriptFile('ext_scripts/jquery-ui/jquery-ui.min.js');
         $this->addJavaScriptFile('scripts.js');
+        $this->mainHeaderJavaScriptfiles .= '<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/8/tinymce.min.js" referrerpolicy="origin"></script>';
+        $this->addJavaScriptCode(
+            "tinymce.init({
+                selector: 'textarea.tinymce-editor',
+                plugins: 'code table lists',
+                toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright | indent outdent | bullist numlist | code | table'
+            });"
+        );
 
         $this->addCSSFile('ext_scripts/jquery-ui/jquery-ui.min.css');
         $this->addCSSFile('design/style.css');

--- a/inc/Classes/MasterForm.php
+++ b/inc/Classes/MasterForm.php
@@ -540,12 +540,6 @@ class MasterForm
                                         if ($field['name']) {
                                             $err = false;
 
-                                            // Copy WYSIWYG editor variable
-                                            if (array_key_exists($field['name'], $SQLFieldTypes) && ($SQLFieldTypes[$field['name']] == 'text' || $SQLFieldTypes[$field['name']] == 'mediumtext' || $SQLFieldTypes[$field['name']] == 'longtext') && $field['selections'] == self::HTML_WYSIWYG) {
-                                                $this->FCKeditorID++;
-                                                $_POST[$field['name']] = $_POST['FCKeditor'. $this->FCKeditorID];
-                                            }
-
                                             // If not in DependOn-Group, or DependOn-Group is active
                                             if (!$this->DependOnStarted || (array_key_exists($this->DependOnField, $_POST) && $_POST[$this->DependOnField])) {
                                                 // -- Convertions --
@@ -751,18 +745,9 @@ class MasterForm
                                                 } elseif ($field['selections'] == self::HTML_WYSIWYG) {
                                                     $fieldValueParameter = $_POST[$field['name']] ?? '';
 
-                                                    $this->FCKeditorID++;
-                                                    ob_start();
-                                                    include_once("ext_scripts/FCKeditor/fckeditor.php");
-                                                    $oFCKeditor = new \FCKeditor('FCKeditor'. $this->FCKeditorID) ;
-                                                    $oFCKeditor->BasePath = 'ext_scripts/FCKeditor/';
-                                                    $oFCKeditor->Config["CustomConfigurationsPath"] = "../myconfig.js"  ;
-                                                    $oFCKeditor->Value = $func->AllowHTML($fieldValueParameter);
-                                                    $oFCKeditor->Height = 460;
-                                                    $oFCKeditor->Create();
-                                                    $fcke_content = ob_get_contents();
-                                                    ob_end_clean();
-                                                    $dsp->AddSingleRow($fcke_content);
+                                                    $value = $func->AllowHTML($fieldValueParameter);
+                                                    $textarea = "<textarea name=\"{$field['name']}\" id=\"{$field['name']}\" class=\"tinymce-editor\" style=\"height: 460px;\">{$value}</textarea>";
+                                                    $dsp->AddSingleRow($textarea);
 
                                                     $errorMessage = $this->error[$field['name']] ?? '';
                                                     if ($errorMessage) {

--- a/modules/beamer/Classes/Display.php
+++ b/modules/beamer/Classes/Display.php
@@ -210,16 +210,9 @@ class Display
 
         if ($ctype == 'text') {
             $dsp->AddTextFieldRow("ccaption", t("Bezeichnung: "), "", "", '50');
-            ob_start();
-            include_once("ext_scripts/FCKeditor/fckeditor.php");
-            $oFCKeditor = new \FCKeditor('FCKeditor1') ;
-            $oFCKeditor->BasePath    = 'ext_scripts/FCKeditor/';
-            $oFCKeditor->Value = "";
-            $oFCKeditor->Height = 380;
-            $oFCKeditor->Create();
-            $fcke_content = ob_get_contents();
-            ob_end_clean();
-            $dsp->AddSingleRow($fcke_content);
+            $value = "";
+            $textarea = "<textarea name=\"beamer_content\" id=\"beamer_content\" class=\"tinymce-editor\" style=\"height: 380px;\">{$value}</textarea>";
+            $dsp->AddSingleRow($textarea);
         }
         
         if ($ctype == 'wrapper') {
@@ -250,16 +243,9 @@ class Display
 
         if ($content['contentType']=='text') {
             $dsp->AddTextFieldRow("ccaption", "Bezeichnung: ", $content['caption'], "", '50');
-            ob_start();
-            include_once("ext_scripts/FCKeditor/fckeditor.php");
-            $oFCKeditor = new \FCKeditor('FCKeditor1') ;
-            $oFCKeditor->BasePath    = 'ext_scripts/FCKeditor/';
-            $oFCKeditor->Value = $func->AllowHTML($content['contentData']);
-            $oFCKeditor->Height = 380;
-            $oFCKeditor->Create();
-            $fcke_content = ob_get_contents();
-            ob_end_clean();
-            $dsp->AddSingleRow($fcke_content);
+            $value = $func->AllowHTML($content['contentData']);
+            $textarea = "<textarea name=\"beamer_content\" id=\"beamer_content\" class=\"tinymce-editor\" style=\"height: 380px;\">{$value}</textarea>";
+            $dsp->AddSingleRow($textarea);
         }
         if ($content['contentType']=='wrapper') {
             $arr = explode("*", $content['contentData']);

--- a/modules/beamer/beamer_index.php
+++ b/modules/beamer/beamer_index.php
@@ -28,7 +28,6 @@ $action = $_GET['action'] ?? '';
 if (isset($debug)) {
     echo "<br/>Ctype: " . $ctype;
     echo "<br/>bcID: " . $bcid;
-    echo "<br/>FCKeditor1-Data: " . $_POST['FCKeditor1'];
 }
 
 $beamermodul = new LanSuite\Module\Beamer\Beamer();
@@ -53,7 +52,7 @@ switch ($action) {
 
         switch ($ctype) {
             case 'text':
-                $newContent['text'] = $_POST['FCKeditor1'];
+                $newContent['text'] = $_POST['beamer_content'];
                 break;
             case 'wrapper':
                 $newContent['text'] = $_POST['curl'] ."*". $_POST['choehe'] ."*". $_POST['cbreite'];


### PR DESCRIPTION
Ersetzt den veralteten und nicht mehr unterstützten FCKeditor durch den modernen Rich-Text-Editor TinyMCE.

- Fügt die TinyMCE-Bibliothek über ein CDN hinzu und initialisiert sie global.
- Ändert die `MasterForm`-Klasse, um eine `textarea` für TinyMCE anstelle des FCKeditors zu rendern.
- Aktualisiert das `beamer`-Modul, das eine separate FCKeditor-Implementierung hatte, um ebenfalls TinyMCE zu verwenden.
- Passt die serverseitige Logik an, um die Daten vom neuen Editor korrekt zu verarbeiten.

Dies modernisiert die Textbearbeitung in der gesamten Anwendung und verbessert die Benutzerfreundlichkeit und Sicherheit.

### What is this PR doing?

<!--
Please describe what you add, change, or fix in this PR.
This is a useful place to

- bug: add how to reproduce it
- explain your design decisions/thoughts
-->

### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [ ] `CHANGELOG.md` entry
- [ ] Documentation update