### PR TITLE
Upgrade GitHub Actions runner to Ubuntu 24.04 / latest commit

### DIFF
--- a/.github/workflows/label-pr-conflicts.yml
+++ b/.github/workflows/label-pr-conflicts.yml
@@ -12,10 +12,10 @@ permissions:
 
 jobs:
   conflicts:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@v2.0
+      - uses: mschilde/auto-label-merge-conflicts@3fdaf1c8b3f8e5b0f88753d9cb3c9c779370b3ef
         with:
           CONFLICT_LABEL_NAME: conflicts
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### What is this PR doing?

Upgrade runner to use latest commit for workflow and newer ubuntu-version. Documentation says to use `ubuntu-latest` and `@master`, but I think it is better to have some control about the embedding here

### Which issue(s) this PR fixes:

(hopefully) fixes current runner issues

### Checklist

- [ ] `CHANGELOG.md` entry
- [ ] Documentation update